### PR TITLE
Adjust regular expressions for Filemetadata resource. CAF-203

### DIFF
--- a/src/python/CRABInterface/RESTFileMetadata.py
+++ b/src/python/CRABInterface/RESTFileMetadata.py
@@ -31,7 +31,7 @@ class RESTFileMetadata(RESTEntity):
             validate_numlist("outfileruns", param, safe)
             if len(safe.kwargs["outfileruns"]) != len(safe.kwargs["outfilelumis"]):
                 raise InvalidParameter("The number of runs and the number of lumis lists are different")
-            validate_strlist("inparentlfns", param, safe, RX_LFN)
+            validate_strlist("inparentlfns", param, safe, RX_PARENTLFN)
             validate_str("globalTag", param, safe, RX_GLOBALTAG, optional=True)
             validate_num("pandajobid", param, safe, optional=False)
             validate_num("outsize", param, safe, optional=False)
@@ -44,7 +44,7 @@ class RESTFileMetadata(RESTEntity):
             validate_str("outlocation", param, safe, RX_CMSSITE, optional=False)
             validate_str("outtmplocation", param, safe, RX_CMSSITE, optional=False)
             validate_str("acquisitionera", param, safe, RX_WORKFLOW, optional=False)#TODO Do we really need this?
-            validate_str("outdatasetname", param, safe, RX_LFN, optional=False)#TODO temporary, need to come up with a regex
+            validate_str("outdatasetname", param, safe, RX_OUTDSLFN, optional=False)#TODO temporary, need to come up with a regex
             validate_str("outlfn", param, safe, RX_LFN, optional=False)
             validate_num("events", param, safe, optional=False)
         elif method in ['POST']:

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -1,10 +1,21 @@
 import re
+from WMCore.Lexicon import lfnParts
 
 # TODO: we should start replacing most of the regex here with what we have in WMCore.Lexicon
 #       (this probably requires to adapt something on Lexicon)
 wfBase = r"^[a-zA-Z0-9\.\-_]{1,%s}$"
+pNameRE      = r"(?=.{0,1000}$)[a-zA-Z0-9\-_]+"
+lfnParts.update( {'publishname' : pNameRE,
+                  'psethash'    : '[a-f0-9]+',
+                  'filename'    : '[a-zA-Z0-9\-_\.]'}
+)
 RX_WORKFLOW  = re.compile( wfBase % 232) #232 = column length in the db (255) - username (8) - timestamp (12) - unserscores (3)
 RX_UNIQUEWF  = re.compile( wfBase % 255)
+RX_PUBLISH   = re.compile(pNameRE)
+RX_LFN       = re.compile(r'^/store/(temp/)?(user|group)/%(hnName)s/%(primDS)s/%(publishname)s/%(psethash)s/%(counter)s/(log/)?%(filename)s+(.root|.tgz)$' % lfnParts)
+RX_PARENTLFN = re.compile(r'^(/[a-zA-Z0-9\-_\.]+/?)+$')
+RX_OUTDSLFN  = re.compile(r'^/%(primDS)s/%(hnName)s-%(publishname)s-%(psethash)s/USER$' % lfnParts)
+RX_CACHENAME = RX_WORKFLOW
 RX_CAMPAIGN  = RX_UNIQUEWF
 RX_JOBTYPE   = re.compile(r"^[A-Za-z]*$")
 RX_CMSSW     = re.compile(r"^(?=.{0,255}$)CMSSW(_\d+){3}(_[a-zA-Z0-9_]+)?$") #using a lookahead (?=.{0,255}$) to check maximum size of the regex
@@ -15,20 +26,17 @@ RX_SPLIT     = re.compile(r"^FileBased|EventBased|LumiBased$")
 #RX_CACHEURL  = re.compile(r"^(?=.{1,255}$)[0-9A-Za-z](?:(?:[0-9A-Za-z]|\b-){0,61}[0-9A-Za-z])?(?:\.[0-9A-Za-z](?:(?:[0-9A-Za-z]|\b-){0,61}[0-9A-Za-z])?)*\.?$")
 RX_CACHEURL  = re.compile(r"^https?://([-\w\.]*)\.cern\.ch+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?$")
 RX_ADDFILE   = re.compile(r"^(?=.{0,255}$)([a-zA-Z0-9\-\._]+)$")
-RX_PUBLISH   = re.compile(r"(?=.{0,1000}$)[a-zA-Z0-9\-_]+")
 RX_CMSSITE   = re.compile(r"^(?=.{0,255}$)T[0-3%]((_[A-Z]{2}(_[A-Za-z0-9]+)*)?)$")
 RX_DBSURL    = re.compile(r"^(?=.{0,255}$)https?://cmsweb([-\w\.]*)\.cern\.ch+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?$")
 RX_PUBDBSURL = re.compile(r"^(?=.{0,255}$)https?://([-\w\.]*)\.cern\.ch+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?$")
 RX_VOPARAMS  = re.compile(r"^(?=.{0,255}$)[A-Za-z0-9]*$")
-RX_CACHENAME = RX_WORKFLOW
 RX_OUTFILES  = re.compile(r"^(?=.{0,255}$)[A-Za-z0-9\.\-_]*\.root$")
 RX_RUNS      = re.compile(r"^\d+$")
-RX_LUMIRANGE  = re.compile(r"^\d+,\d+(,\d+,\d+)*$")
+RX_LUMIRANGE = re.compile(r"^\d+,\d+(,\d+,\d+)*$")
 RX_LUMILIST  = re.compile(r"^\d+(,\d+)*$")
 RX_GLOBALTAG = re.compile(r'^[a-zA-Z0-9\s\.\-_:]{1,100}$')
 RX_OUTTYPES  = re.compile(r'^EDM|LOG|TFILE$')
-RX_LFN       = re.compile(r'.*')#TODO find out the right regular expression. Maybe in relation with previous WMCore Lexicon merge(see TODO at the beginning). BTW, Lexicon has 5 regexp for lfn
-RX_CHECKSUM  = re.compile(r'^[A-Za-z0-9\-]+$')#TODO check the format of checksum
+RX_CHECKSUM  = re.compile(r'^[A-Za-z0-9\-]+$')
 
 #basic certificate check -- used for proxies retrieved from myproxy
 RX_CERT = re.compile(r'^[-]{5}BEGIN CERTIFICATE[-]{5}[\w\W]+[-]{5}END CERTIFICATE[-]{5}\n$')


### PR DESCRIPTION
Can somebody check if the regular expressions I am using are ok? In particular RX_OUTDSLFN (used for fmd_outdataset, should match something like '/GenericTTbar/riahi-AsoTestPublicationv4-4ab251c3a1d9f6622d24e040a40a47ab/USER') and RX_LFN (used for fmd_lfn, should match something like '/store/temp/user/spiga/GenericTTbar/TFileServiceTest/5b6a581e4ddd41b130711a045d5fecb9/1000/log/job.log_25_UO7K6A.tgz')

With the parent lfn I was more loose and the regex should be ok.
