### PR TITLE
Adapting rest to new DAO\'s - CAF-302

### DIFF
--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -1,5 +1,4 @@
 import time
-import datetime
 import threading
 import logging
 import cherrypy #cherrypy import is needed here because we need the 'start_thread' subscription
@@ -151,7 +150,6 @@ class DataWorkflow(object):
                             task_name       = [requestname],\
                             jobset_id       = [None],
                             task_status     = ['NEW'],\
-                            start_time      = [datetime.datetime.now()],\
                             task_failure    = [''],\
                             job_sw          = [jobsw],\
                             job_arch        = [jobarch],\


### PR DESCRIPTION
Improved 5 DAO's to make a single query when updating a timestamp column in the DB.
They changed from doing:

```
a = "select SYS_EXTRACT_UTC(SYSTIMESTAMP) from dual"
sql = "UPDATE tasks SET tm_end_injection = :a"
```

to:

```
sql = "UPDATE tasks SET tm_end_injection = SYS_EXTRACT_UTC(SYSTIMESTAMP)"
```
