### PR TITLE
cleaning up runtime scripts

### DIFF
--- a/bin/dagman_make_runtime.sh
+++ b/bin/dagman_make_runtime.sh
@@ -16,16 +16,8 @@ WMCOREDIR=$STARTDIR/WMCore
 WMCOREVER=0.9.70-dagman2
 WMCOREREPO=bbockelm
 
-TASKWORKERDIR=$STARTDIR/TaskWorker
-TASKWORKERVER=0.0.1pre3-dagman5
-TASKWORKERREPO=bbockelm
-
-CAFUTILITIESDIR=$STARTDIR/CAFUtilities
-CAFUTILITIESVER=0.0.1pre4-dagman
-CAFUTILITIESREPO=bbockelm
-
 DBSDIR=$STARTDIR/DBS
-DBSVER=DBS_2_1_9-dagman2
+DBSVER=DBS_2_1_9-dagman3
 DBSREPO=bbockelm
 
 DLSDIR=$STARTDIR/DLS
@@ -45,7 +37,6 @@ cp $BASEDIR/gWMS-CMSRunAnalysis.sh $STARTDIR || exit 3
 
 
 rm -rf $WMCOREDIR && mkdir -p $WMCOREDIR
-rm -rf $TASKWORKERDIR && mkdir -p $TASKWORKERDIR
 rm -rf $DBSDIR && mkdir -p $DBSDIR
 rm -rf $DLSDIR && mkdir -p $DLSDIR
 rm -rf $CRABSERVERDIR && mkdir -p $CRABSERVERDIR
@@ -68,14 +59,6 @@ if [[ ! -e external+py2-pyopenssl+0.11-1-1.slc5_amd64_gcc462.rpm ]]; then
 fi
 rpm2cpio external+py2-pyopenssl+0.11-1-1.slc5_amd64_gcc462.rpm | cpio -uimd || exit 2
 
-if [[ -d "$REPLACEMENT_ABSOLUTE/CAFUtilities" ]]; then
-    echo "Using replacement CAFUtlities source at $REPLACEMENT_ABSOLUTE/CAFUtlities"
-    CAFUTILITIES_PATH="$REPLACEMENT_ABSOLUTE/CAFUtilities"
-else
-    curl -L https://github.com/$CAFUTILITIESREPO/CAFUtilities/archive/$CAFUTILITIESVER.tar.gz | tar zx || exit 2
-    CAFUTILITIES_PATH="CAFUtilities-$CAFUTILITIESVER"
-fi
-
 if [[ -d "$REPLACEMENT_ABSOLUTE/WMCore" ]]; then
     echo "Using replacement WMCore source at $REPLACEMENT_ABSOLUTE/WMCore"
     WMCORE_PATH="$REPLACEMENT_ABSOLUTE/WMCore"
@@ -85,14 +68,6 @@ else
     fi
     tar zxf $WMCOREVER.tar.gz || exit 2
     WMCORE_PATH="WMCore-$WMCOREVER"
-fi
-
-if [[ -d "$REPLACEMENT_ABSOLUTE/CAFTaskWorker" ]]; then
-    echo "Using replacement CAFTaskWorker source at $REPLACEMENT_ABSOLUTE/CAFTaskWorker"
-    TASKWORKER_PATH="$REPLACEMENT_ABSOLUTE/CAFTaskWorker"
-else
-    curl -L https://github.com/$TASKWORKERREPO/CAFTaskWorker/archive/$TASKWORKERVER.tar.gz | tar zx || exit 2
-    TASKWORKER_PATH="CAFTaskWorker-$TASKWORKERVER"
 fi
 
 if [ ! -e $DBSVER.tar.gz ]; then
@@ -189,14 +164,6 @@ pushd $WMCORE_PATH/src/python
 zip -rq $STARTDIR/CRAB3.zip WMCore WMQuality PSetTweaks -x \*.pyc -x \*.swp || exit 3
 popd
 
-pushd $TASKWORKER_PATH/src/python
-zip -rq $STARTDIR/CRAB3.zip TaskWorker  -x \*.pyc -x \*.swp || exit 3
-popd
-
-pushd $CAFUTILITIES_PATH/src/python
-zip -rq $STARTDIR/CRAB3.zip transform Databases PandaServerInterface.py  -x \*.pyc || exit 3
-popd
-
 cat > setup.sh << EOF
 export CRAB3_VERSION=$CRAB3_VERSION
 export CRAB3_BASEPATH=\`dirname \${BASH_SOURCE[0]}\`
@@ -214,9 +181,9 @@ touch lib/fake_condor_config
 
 mkdir -p bin
 cp $CRABSERVER_PATH/bin/* bin/
-cp $CAFUTILITIES_PATH/src/python/transformation/CMSRunAnalysis/CMSRunAnalysis.sh bin/
-cp $CAFUTILITIES_PATH/src/python/transformation/CMSRunAnalysis/CMSRunAnalysis.py .
-cp $CAFUTILITIES_PATH/src/python/transformation/TweakPSet.py .
+cp $CRABSERVER_PATH/src/python/transformation/CMSRunAnalysis/CMSRunAnalysis.sh bin/
+cp $CRABSERVER_PATH/src/python/transformation/CMSRunAnalysis/CMSRunAnalysis.py .
+cp $CRABSERVER_PATH/src/python/transformation/TweakPSet.py .
 
 echo "Making TaskManagerRun tarball"
 tar zcf $ORIGDIR/TaskManagerRun-$CRAB3_VERSION.tar.gz CRAB3.zip setup.sh crab3 crab gWMS-CMSRunAnalysis.sh CMSRunAnalysis.py bin TweakPSet.py || exit 4


### PR DESCRIPTION
- don't pull CAF\* repos
- update to new DBS client tag
- re-add making external-only repo

@bbockelm there's an htcondor_make_runtime and a dagman_make_runtime scripts. Are we going to the former everywhere? If so, I want to remove dagman_make_runtime
