### PR TITLE
Move htcondorSchedds and htcondorPool parameters to the external configuration file on the REST

### DIFF
--- a/src/python/CRABInterface/HTCondorDataWorkflow.py
+++ b/src/python/CRABInterface/HTCondorDataWorkflow.py
@@ -30,16 +30,18 @@ class HTCondorDataWorkflow(DataWorkflow):
     successList = ['finished']
     failedList = ['held', 'failed', 'cooloff']
 
+    @conn_handler(services=['centralconfig'])
     def updateRequest(self, workflow):
         info = workflow.split("_", 3)
         if len(info) < 4:
             return workflow
         hn_name = info[2]
-        locator = HTCondorLocator.HTCondorLocator(self.config)
+        locator = HTCondorLocator.HTCondorLocator(self.centralcfg.centralconfig["backend-urls"])
         name = locator.getSchedd().split("@")[0].split(".")[0]
         info[2] = "%s:%s" % (name, hn_name)
         return "_".join(info)
 
+    @conn_handler(services=['centralconfig'])
     def status(self, workflow, userdn, userproxy=None, verbose=False):
         """Retrieve the status of the workflow.
 
@@ -74,7 +76,7 @@ class HTCondorDataWorkflow(DataWorkflow):
         name = workflow.split("_")[0]
         cherrypy.log("Getting status for workflow %s, looking for schedd %s" %\
                                 (workflow, name))
-        locator = HTCondorLocator.HTCondorLocator(self.config)
+        locator = HTCondorLocator.HTCondorLocator(self.centralcfg.centralconfig["backend-urls"])
         cherrypy.log("Will talk to %s." % locator.getCollector())
         schedd, address = locator.getScheddObj(workflow)
 
@@ -282,6 +284,7 @@ class HTCondorDataWorkflow(DataWorkflow):
 
         yield res
 
+    @conn_handler(services=['centralconfig'])
     def alt_status(self, workflow, userdn, userproxy=None, verbose=False):
         """Retrieve the status of the workflow.
 
@@ -309,7 +312,7 @@ class HTCondorDataWorkflow(DataWorkflow):
         name = workflow.split("_")[2].split(":")[0]
         cherrypy.log("Getting status for workflow %s, looking for schedd %s" %\
                                 (workflow, name))
-        locator = HTCondorLocator.HTCondorLocator(self.config)
+        locator = HTCondorLocator.HTCondorLocator(self.centralcfg.centralconfig["backend-urls"])
         cherrypy.log("Will talk to %s." % locator.getCollector())
         name = locator.getSchedd()
         cherrypy.log("Schedd name %s." % name)

--- a/src/python/CRABInterface/HTCondorLocator.py
+++ b/src/python/CRABInterface/HTCondorLocator.py
@@ -17,9 +17,9 @@ class HTCondorLocator(object):
         """
         collector = self.getCollector()
         schedd = "localhost"
-        if self.config and hasattr(self.config, 'TaskWorker') and hasattr(self.config.TaskWorker, 'htcondorSchedds'):
-            random.shuffle(self.config.TaskWorker.htcondorSchedds)
-            schedd = self.config.TaskWorker.htcondorSchedds[0]
+        if self.config and "htcondorSchedds" in self.config:
+            random.shuffle(self.config["htcondorSchedds"])
+            schedd = self.config["htcondorSchedds"][0]
         if collector:
             return "%s:%s" % (schedd, collector)
         return schedd
@@ -53,7 +53,7 @@ class HTCondorLocator(object):
         """
         Return an object representing the collector given the pool name.
         """
-        if self.config and hasattr(self.config, 'TaskWorker') and hasattr(self.config.TaskWorker, 'htcondorPool'):
-            return self.config.TaskWorker.htcondorPool
+        if self.config and "htcondorPool" in self.config:
+            return self.config["htcondorPool"]
         return name
 

--- a/src/python/TaskWorker/Actions/DagmanKiller.py
+++ b/src/python/TaskWorker/Actions/DagmanKiller.py
@@ -39,7 +39,7 @@ class DagmanKiller(TaskAction.TaskAction):
         if not WORKFLOW_RE.match(self.workflow):
             raise Exception("Invalid workflow name.")
 
-        loc = HTCondorLocator.HTCondorLocator(self.config)
+        loc = HTCondorLocator.HTCondorLocator(self.backendurls)
         self.schedd, address = loc.getScheddObj(self.workflow)
 
         if self.task['kill_all']:

--- a/src/python/TaskWorker/Actions/DagmanResubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanResubmitter.py
@@ -36,7 +36,7 @@ class DagmanResubmitter(TaskAction.TaskAction):
         self.logger.info("About to resubmit workflow: %s." % workflow)
         self.logger.info("Task info: %s" % str(task))
 
-        loc = HTCondorLocator.HTCondorLocator(self.config)
+        loc = HTCondorLocator.HTCondorLocator(self.backendurls)
         schedd, address = loc.getScheddObj(workflow)
 
         # Release the DAG

--- a/src/python/TaskWorker/Actions/DagmanSubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanSubmitter.py
@@ -147,7 +147,7 @@ class DagmanSubmitter(TaskAction.TaskAction):
 
         try:
             info['remote_condor_setup'] = ''
-            loc = HTCondorLocator.HTCondorLocator(self.config)
+            loc = HTCondorLocator.HTCondorLocator(self.backendurls)
             schedd, address = loc.getScheddObj(task['tm_taskname'])
             if address:
                 self.submitDirect(schedd, 'dag_bootstrap_startup.sh', arg, info)

--- a/src/python/TaskWorker/Actions/PanDAAction.py
+++ b/src/python/TaskWorker/Actions/PanDAAction.py
@@ -3,14 +3,12 @@ from TaskWorker.DataObjects.Result import Result
 
 class PanDAAction(TaskAction):
     """Generic PanDAAction. Probably not needed at the current stage
-       but it since this should not cause a big overhead it would be 
+       but it since this should not cause a big overhead it would be
        better to leave this here in order to eventually be ready to
        support specific PanDA interaction needs."""
 
     def __init__(self, pandaconfig, server, resturl):
         TaskAction.__init__(self, pandaconfig, server, resturl)
-        #each PanDAAction needs to know the PandaServer URLs to use
-        self.pandaurls = self.server.get(self.resturl.replace('workflowdb', 'info'), data={'subresource':'backendurls'})[0]['result'][0]
 
     def translateSiteName(self, sites):
         return ['ANALY_'+ s for s in sites]

--- a/src/python/TaskWorker/Actions/PanDABrokerage.py
+++ b/src/python/TaskWorker/Actions/PanDABrokerage.py
@@ -32,8 +32,8 @@ class PanDABrokerage(PanDAAction):
                 self.logger.error(msg)
                 results.append(Result(task=kwargs['task'], result=(jgroup, None, []), err=msg))
                 continue
-            self.logger.info("Asking best site to PanDA between %s. Using %s as pandaserver." % (str(availablesites), self.pandaurls['baseURLSSL']))
-            selectedsite = runBrokerage(self.pandaurls['baseURLSSL'], proxy=kwargs['task']['user_proxy'],
+            self.logger.info("Asking best site to PanDA between %s. Using %s as pandaserver." % (str(availablesites), self.backendurls['baseURLSSL']))
+            selectedsite = runBrokerage(self.backendurls['baseURLSSL'], proxy=kwargs['task']['user_proxy'],
                                         sites=self.translateSiteName(availablesites))[-1]
             self.logger.info("Choosed site after brokering " +str(selectedsite))
             if not selectedsite:

--- a/src/python/TaskWorker/Actions/PanDAInjection.py
+++ b/src/python/TaskWorker/Actions/PanDAInjection.py
@@ -32,7 +32,7 @@ class PanDAInjection(PanDAAction):
            :arg list taskbuffer.JobSpecs pandajobspecs: the list of specs to inject
            :return: dictionary containining the injection resulting id's."""
         #pandajobspecs = pandajobspecs[0:2]
-        status, injout = submitJobs(self.pandaurls['baseURLSSL'], jobs=pandajobspecs, proxy=task['user_proxy'], verbose=True)
+        status, injout = submitJobs(self.backendurls['baseURLSSL'], jobs=pandajobspecs, proxy=task['user_proxy'], verbose=True)
         self.logger.info('PanDA submission exit code: %s' % status)
         jobsetdef = {}
         for jobid, defid, setid in injout:
@@ -58,7 +58,7 @@ class PanDAInjection(PanDAAction):
         :arg str lfnhanger: random string to append at the file lfn
         :arg list str allsites: all possible sites where the job can potentially run
         :return: the list of job sepcs objects."""
-        refreshSpecs(self.pandaurls['baseURL'], proxy=task['user_proxy'])
+        refreshSpecs(self.backendurls['baseURL'], proxy=task['user_proxy'])
         oldids = []
         pandajobspec = []
         i = startjobid

--- a/src/python/TaskWorker/Actions/PanDAKill.py
+++ b/src/python/TaskWorker/Actions/PanDAKill.py
@@ -16,7 +16,7 @@ class PanDAKill(PanDAAction):
         self.logger.debug("Killing injected jobs ")
         killed = []
         try:
-            status, killed = killJobs(self.pandaurls['baseURLSSL'], ids=kwargs['task']['kill_ids'],
+            status, killed = killJobs(self.backendurls['baseURLSSL'], ids=kwargs['task']['kill_ids'],
                                       proxy=kwargs['task']['user_proxy'])
             notkilled = len([res for res in killed if not res])
             if notkilled > 0:

--- a/src/python/TaskWorker/Actions/PanDAgetSpecs.py
+++ b/src/python/TaskWorker/Actions/PanDAgetSpecs.py
@@ -10,6 +10,6 @@ class PanDAgetSpecs(PanDAAction):
 
     def execute(self, *args, **kwargs):
         self.logger.info("Getting already existing specs ")
-        status, pandaspecs = getFullJobStatus(self.pandaurls['baseURLSSL'], ids=kwargs['task']['resubmit_ids'],
+        status, pandaspecs = getFullJobStatus(self.backendurls['baseURLSSL'], ids=kwargs['task']['resubmit_ids'],
                                               proxy=kwargs['task']['user_proxy'])
         return Result(task=kwargs['task'], result=pandaspecs)

--- a/src/python/TaskWorker/Actions/TaskAction.py
+++ b/src/python/TaskWorker/Actions/TaskAction.py
@@ -12,6 +12,7 @@ class TaskAction(object):
                                "Generic" : "Generic",}
         self.server = server
         self.resturl = resturl
+        self.backendurls = self.server.get(self.resturl.replace('workflowdb', 'info'), data={'subresource':'backendurls'})[0]['result'][0]
 
     def execute(self):
         raise NotImplementedError


### PR DESCRIPTION
That's an example of how the external configuration looks like now:

https://gist.github.com/mmascher/5712701

The two parameters are now ignored in both the REST and the TaskWorker components.
