### PR TITLE
Try to remove files from the destination for resubmitted jobs

### DIFF
--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -129,7 +129,7 @@ def getUserFromLFN(lfn):
         if lfn.split('/')[2] == 'temp':
             # /store/temp/user/$USER.$HASH/foo
             user = lfn.split('/')[4].rsplit(".", 1)[0]
-        else: 
+        else:
             # /store/user/$USER/foo
             user = lfn.split('/')[3]
     else:
@@ -240,8 +240,7 @@ class ASOServerJob(object):
                             "start_time": now,
                             "end_time": '',
                             "job_end_time": time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(time.time())),
-                            "retry_count": [],
-                            "failure_reason": [],
+                            "failure_reason": []
                           }
             try:
                 doc = self.couchDatabase.document( doc_id )
@@ -259,6 +258,7 @@ class ASOServerJob(object):
                         "user": user,
                         "role": role,
                         "dbSource_url": "gWMS",
+                        "retry_count": [],
                         "publish_dbs_url": publish_dbs_url,
                         "dbs_url": dbs_url,
                         "workflow": self.reqname,


### PR DESCRIPTION
Actually the transfer of a resubmitted job is failing with "output already exists" if the transfer of the first job has succeeded. This patch makes the ASO considering it as a resubmitted transfer and so try before starting the transfer to remove the output from the destination.   
