### PR TITLE
Don't unconditionally process only one event

### DIFF
--- a/scripts/TweakPSet.py
+++ b/scripts/TweakPSet.py
@@ -77,7 +77,7 @@ class SetupCMSSWPsetCore(SetupCMSSWPset):
         self.step.data.application.section_("configuration")
         self.step.data.application.section_("command")
         self.step.data.application.command.configuration = "PSet.py"
-        self.step.data.application.command.oneEventMode = oneEventMode
+        self.step.data.application.command.oneEventMode = oneEventMode in ["1","True",True]
 #        self.step.data.application.configuration.pickledarguments.globalTag/globalTagTransaction
         self.step.data.section_("input")
         self.job = jobDict(lheInputFiles, seeding)


### PR DESCRIPTION
The previous version suffered from the issue where bool(str("0")) == True
