### PR TITLE
Propagate transferOutput, saveLogs and publication flags from client to ASO.

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanSubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanSubmitter.py
@@ -35,10 +35,12 @@ CRAB_META_HEADERS = \
 +CRAB_SplitAlgo = %(splitalgo)s
 +CRAB_AlgoArgs = %(algoargs)s
 +CRAB_ConfigDoc = %(configdoc)s
-+CRAB_PublishName = %(publishname)s
 +CRAB_DBSUrl = %(dbsurl)s
-+CRAB_PublishDBSUrl = %(publishdbsurl)s
 +CRAB_LumiMask = %(lumimask)s
++CRAB_TransferOutputs = %(saveoutput)s
++CRAB_Publish = %(publication)s
++CRAB_PublishName = %(publishname)s
++CRAB_PublishDBSUrl = %(publishdbsurl)s
 """
 
 # NOTE: Changes here must be synchronized with the submitDirect function below
@@ -85,14 +87,16 @@ SUBMIT_INFO = [ \
             ('CRAB_EDMOutputFiles', 'edmoutfiles'),
             ('CRAB_TFileOutputFiles', 'tfileoutfiles'),
             ('CRAB_SaveLogsFlag', 'savelogsflag'),
+            ('CRAB_TransferOutputs', 'saveoutput'),
             ('CRAB_UserDN', 'userdn'),
             ('CRAB_UserHN', 'userhn'),
             ('CRAB_AsyncDest', 'asyncdest'),
             ('CRAB_BlacklistT1', 'blacklistT1'),
             ('CRAB_SplitAlgo', 'splitalgo'),
             ('CRAB_AlgoArgs', 'algoargs'),
-            ('CRAB_PublishName', 'publishname'),
             ('CRAB_DBSUrl', 'dbsurl'),
+            ('CRAB_Publish', 'publication'),
+            ('CRAB_PublishName', 'publishname'),
             ('CRAB_PublishDBSUrl', 'publishdbsurl'),
             ('CRAB_LumiMask', 'lumimask'),
             ('CRAB_JobCount', 'jobcount'),


### PR DESCRIPTION
With this patch, now one can set the publication, the transfer of the tar log and the transfer of outputs to True or False, and all work as I would expect. Publication is turned off for log files. I have tested the patch using my private REST and TW, for all possible combinations (True, False or default value) of these three flags, and I can see that the fixes for transfer from WN work as I would expect. I also tested the PostJob by intentionally failing the injection to ASO from the WN so that the PostJob is the one who injects to ASO, and it also works as I would expect.
If you want to see the tasks I submitted for these tests, see http://glidemon.web.cern.ch/glidemon/user.php?userid=1280&range=14days&type=crab3 and look for tasks named "atanasi_crab_test_mS_pub<T,F,D>_trfOut<T,F,D>_savLog<T,F,D>_1" (injection to ASO from WN) and "atanasi_crab_test_mS_pub<T,F,D>_trfOut<T,F,D>_savLog<T,F,D>_2" (injection to ASO from PostJob).
The default value for Data.publication is False, the default value for General.transferOutput is True, and the default value for General.saveLogs is False. These are set in the client.
This patch solves issue #4317 which refers to the saveoutput flag. (There is no issue opened requesting propagation of publication and savelogs flags, but of course we want this.)

I also included in this patch a few lines of code intended to not publish output files that are not EDM, but I haven't tested it. I want to wait until we fix the issue with TFiles not being added to the JR. Then I will be able to easily test if TFiles are indeed not being published. But IMHO this is not a show stopper to merge this pull request.
