### PR TITLE
Remove CRAB_SkipASO from dagAd, since it is not used anymore.

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanSubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanSubmitter.py
@@ -285,9 +285,6 @@ class DagmanSubmitter(TaskAction.TaskAction):
         if 'JobPrio' not in dagAd:
             dagAd['JobPrio'] = 10
 
-        if not info['saveoutput']:
-            dagAd['CRAB_SkipASO'] = True
-
         # NOTE: Changes here must be synchronized with the job_submit in DagmanCreator.py in CAFTaskWorker
         dagAd["Out"] = str(os.path.join(info['scratch'], "request.out"))
         dagAd["Err"] = str(os.path.join(info['scratch'], "request.err"))


### PR DESCRIPTION
CRAB_SkipASO was used before in the PostJob, but after this commit https://github.com/dmwm/CRABServer/commit/f5966b0aff0930937355269412c24ecd9487c98b it is not used anymore.
