### PR TITLE
Fix transfer of TFiles. Add "directstageout" to file metadata.

### DIFF
--- a/scripts/cmscp.py
+++ b/scripts/cmscp.py
@@ -161,14 +161,8 @@ def set_se_name(dest_file, se_name, direct=False):
     found_output = False
     for outputModule in output.values():
         for outputFile in outputModule:
-
-            if outputFile.get(u"output_module_class") != u'PoolOutputModule' and \
-                    outputFile.get(u"ouput_module_class") != u'PoolOutputModule':
+            if os.path.split(str(outputFile.get(u"pfn")))[-1] != filename:
                 continue
-
-            if str(outputFile.get(u"pfn")) != filename:
-                continue
-
             outputFile['SEName'] = se_name
             outputFile['direct_stageout'] = direct
             found_output = True
@@ -283,7 +277,7 @@ def injectToASO(dest_lfn, se_name):
         found_output = False
         for outputModule in output.values():
             for outputFile in outputModule:
-                if str(outputFile.get(u"pfn")) != local_fname:
+                if os.path.split(str(outputFile.get(u"pfn")))[-1] != local_fname:
                     continue
                 checksums = outputFile.get(u"checksums", {"cksum": "0", "adler32": "0"})
                 size = outputFile.get(u"size", 0)
@@ -319,7 +313,7 @@ def injectToASO(dest_lfn, se_name):
     task_publish = int(ad['CRAB_Publish'])
     publish = int(task_publish and file_type == 'output' and isEDM)
     if task_publish and file_type == 'output' and not isEDM:
-        print "Disabling the publication of the output file since it is not of EDM type."
+        print "Disabling publication of output file %s, because it is not of EDM type." % fname
     publish = int(publish and not g_cmsRunFailed)
     publish_dbs_url = str(ad['CRAB_PublishDBSURL'])
     if publish_dbs_url.lower() == 'undefined':
@@ -450,7 +444,7 @@ def performDirectTransferImpl(source, direct_pfn, direct_se):
         signal.alarm(0)
 
     if not result:
-        set_se_name(os.path.split(direct_pfn)[-1], direct_se, direct=True)
+        set_se_name(os.path.split(direct_pfn)[-1], direct_se, direct = True)
 
     return result
 


### PR DESCRIPTION
In this patch:
1) In cmscp.py, inject a transfer request document to ASO-couchDB not only for EDM files but also for TFiles. 
2) In PostJob, do not assume output files (EDMs and TFiles) appear listed in the same order in the FJR and in the filenames argument.
3) In PostJob, add "directstageout" to the file metadata (as an integer, 0 or 1) for all kind of files (i.e for logs, EDM outputs and TFile outputs). This info is taken from the FJR. If info can not be retrieved, set to 0.

I tested this patch in my private TW and REST, using a pset that generates both an EDM (dumper.root) and a TFile (histo.root). I ran two tasks, one where injection to ASO from WN worked fine (http://glidemon.web.cern.ch/glidemon/jobs.php?taskid=370614), and one where injection from WN was skipped so that to test injection from PostJob (http://glidemon.web.cern.ch/glidemon/jobs.php?taskid=370650). All seems to be fine for me. Btw, I keep the upload of the filemetadata for all files because this is needed by the getlog and getoutput.
