### PR TITLE
Ignore row on duplicate key in filemetadata

### DIFF
--- a/src/python/Databases/FileMetaDataDB/Oracle/FileMetaData/FileMetaData.py
+++ b/src/python/Databases/FileMetaDataDB/Oracle/FileMetaData/FileMetaData.py
@@ -38,7 +38,7 @@ class FileMetaData(object):
                     ORDER BY fmd_creation_time DESC
              """
 
-    New_sql = "INSERT INTO filemetadata ( \
+    New_sql = "INSERT /*+ IGNORE_ROW_ON_DUPKEY_INDEX(filemetadata, PK_TASKLFN) */ INTO filemetadata ( \
                tm_taskname, panda_job_id, fmd_outdataset, fmd_acq_era, fmd_sw_ver, fmd_in_events, fmd_global_tag,\
                fmd_publish_name, fmd_location, fmd_tmp_location, fmd_runlumi, fmd_adler32, fmd_cksum, fmd_md5, fmd_lfn, fmd_size,\
                fmd_type, fmd_parent, fmd_creation_time, fmd_filestate, fmd_direct_stageout) \


### PR DESCRIPTION
Currently we are getting a lot of errors:
`[21/Jul/2014:02:02:31]    IntegrityError: ORA-00001: unique constraint (CMS_ANALYSIS_REQMGR.PK_TASKLFN) violated` 
With this `IGNORE_ROW_ON_DUPKEY_INDEX(filemetadata, PK_TASKLFN)` if primary key already matches no rows will be inserted and no more big number of errors in the log files.

```
From 20140714 to 20140721
grep 'IntegrityError: ORA-00001: unique constraint (CMS_ANALYSIS_REQMGR.PK_TASKLFN) violated' vocms136/crabserver/crabserver-201407*.log | wc -l
6381
```
