### PR TITLE
Accept totalUnits for LumiBased and FileBased.

### DIFF
--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -62,7 +62,8 @@ class DBSDataDiscovery(DataDiscovery):
         if len(blocks) != len(locationsMap):
             self.logger.warning("The locations of some blocks have not been found: %s" % (set(blocks) - set(locationsMap)))
         filedetails = dbs.listDatasetFileDetails(kwargs['task']['tm_input_dataset'], True)
-        result = self.formatOutput(task=kwargs['task'], requestname=kwargs['task']['tm_taskname'], datasetfiles=filedetails, locations=locationsMap)
+        result = self.formatOutput(task = kwargs['task'], requestname = kwargs['task']['tm_taskname'], datasetfiles = filedetails, locations = locationsMap, \
+                                   splitting = kwargs['task']['tm_split_algo'], total_units = kwargs['task']['tm_totalunits'])
         self.logger.debug("Got result: %s" % result.result)
         return result
 


### PR DESCRIPTION
Allow the user to specify Data.totalUnits for LumiBased and FileBased splitting.
The patch was tested using the /GenericTTbar/HC-CMSSW_5_3_1_START53_V5-v1/GEN-SIM-RECO input dataset, which contains 177 files.
When I specified Data.splitting = 'LumiBased', Data.unitsPerJob = 10, Data.totalUnits = 5, http://glidemon.web.cern.ch/glidemon/jobs.php?taskid=383730, one job was created with 5 lumis. These 5 lumis were 671695, 671721, 671746, 671840, 672623, which are not the first 5 lumis in the dataset.
When I specified Data.splitting = 'LumiBased', Data.unitsPerJob = 10, Data.totalUnits = 10, http://glidemon.web.cern.ch/glidemon/jobs.php?taskid=383729, one job was created with 10 lumis. These 10 lumis were 670969, 671693, 671721, 671789, 671802, 671840, 671867, 671882, 671884, 672610, which are not a superset of the previous 5 lumis.
I ran a third task putting again Data.splitting = 'LumiBased', Data.unitsPerJob = 10, Data.totalUnits = 5, http://glidemon.web.cern.ch/glidemon/jobs.php?taskid=383765, and the 5 lumis were again 671695, 671721, 671746, 671840, 672623.

This is for issue #4367.
