### PR TITLE
Use WMCore's REST API

### DIFF
--- a/src/python/RESTInteractions.py
+++ b/src/python/RESTInteractions.py
@@ -34,3 +34,18 @@ class HTTPRequests(JSONRequests):
                                          contentType)
 
         return data, responseStatus, responseReason
+
+    @staticmethod
+    def getCACertPath():
+        """ Get the CA certificate path. It looks for it in the X509_CERT_DIR variable if present
+            or return /etc/grid-security/certificates/ instead (if it exists)
+            If a CA certificate path cannot be found throws a EnvironmentException exception
+        """
+        caDefault = '/etc/grid-security/certificates/'
+        if os.environ.has_key("X509_CERT_DIR"):
+            return os.environ["X509_CERT_DIR"]
+        elif os.path.isdir(caDefault):
+            return caDefault
+        else:
+            raise EnvironmentException("The X509_CERT_DIR variable is not set and the %s directory cannot be found.\n" % caDefault +
+                                        "Cannot find the CA certificate path to ahuthenticate the server.")


### PR DESCRIPTION
The old RESTInteractions, while nice, missed some pretty major
functionality, the least of which is the ability to cache requests.
Because of the number of round-trips to cmsweb (times transcontinental
latency), each CRABClient command takes much longer than it needs to
because it doesn't cache even simple requests like:

{'result': [{'services': ['/DC=ch/DC=cern/OU=computers/CN=vocms(24[345]|3[136]|21).cern.ch']}]} 200 OK False
{'result': [['3.3.7', '3.3.7.patch1', '3.3.7.patch2', '3.3.8', '3.3.8.rc10']]} 200 OK False

This wraps the WMCore api with a simple bit of argument-smashing to get
it to look like what the old API looked like and enables caching.
