### PR TITLE
Pass CMSRunAnalysis exit code as argument to cmscp. Use it as the exit c...

### DIFF
--- a/scripts/cmscp.py
+++ b/scripts/cmscp.py
@@ -53,6 +53,7 @@ numberOfRetries = 2
 retryPauseTime = 60
 g_now = None
 g_now_epoch = None
+g_cmsRun_exit_code = 0
 g_job_exit_code = 0
 g_job_report_name = None
 g_job_id = None
@@ -439,7 +440,7 @@ def injectToASO(source_lfn, se_name, is_log):
     publish = int(task_publish and file_type == 'output' and isEDM)
     if task_publish and file_type == 'output' and not isEDM:
         print "Disabling publication of output file %s, because it is not of EDM type." % file_name
-    publish = int(publish and not g_job_exit_code)
+    publish = int(publish and not g_cmsRun_exit_code)
     publish_dbs_url = str(ad['CRAB_PublishDBSURL'])
     if publish_dbs_url.lower() == 'undefined':
         publish_dbs_url = "https://cmsweb.cern.ch/dbs/prod/phys03/DBSWriter/"
@@ -684,19 +685,17 @@ def main():
     counter = "%04d" % (g_job_id / 1000)
     dest_temp_dir = os.path.join(dest_temp_dir, counter)
 
-    # Try to determine whether the payload actually succeeded.
-    # If it did not, we place it in a different directory. This prevents
-    # us from putting failed ROOT files in the same directory as successful
-    # files; we worry that users may simply 'ls' the directory and run on
-    # all files.
-    global g_job_exit_code
-    g_job_exit_code = 0
-    try: 
-        g_job_exit_code = job_report['jobExitCode']
+    ## Try to determine whether the payload actually succeeded.
+    ## If the payload didn't succeed, we put it in a different directory. This prevents us from
+    ## putting failed output files in the same directory as successful output files; we worry 
+    ## that users may simply 'ls' the directory and run on all listed files.
+    global g_cmsRun_exit_code
+    try:
+        g_cmsRun_exit_code = job_report['jobExitCode']
     except Exception, ex:
         print "== WARNING: Unable to retrieve cmsRun exit code from job report."
         traceback.print_exc()
-    if g_job_exit_code:
+    if g_cmsRun_exit_code:
         dest_temp_dir = os.path.join(dest_temp_dir, "failed")
 
     ## Transfer of log tarball.
@@ -765,6 +764,13 @@ def main():
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
+    try:
+        for arg in sys.argv:
+            if 'JOB_EXIT_CODE=' in arg and len(arg.split("=")) == 2:
+                global g_job_exit_code
+                g_job_exit_code = int(arg.split("=")[1])
+    except:
+        pass
     try:
         retval = main()
     except:

--- a/scripts/gWMS-CMSRunAnalysis.sh
+++ b/scripts/gWMS-CMSRunAnalysis.sh
@@ -133,7 +133,7 @@ condor_chirp phase output
 echo "======== Stageout at $(TZ=GMT date) STARTING ========"
 rm -f wmcore_initialized
 # Note we prevent buffering of stdout/err -- this is due to observed issues in mixing of out/err for stageout plugins
-PYTHONUNBUFFERED=1 ./cmscp.py
+PYTHONUNBUFFERED=1 ./cmscp.py "JOB_EXIT_CODE=$EXIT_STATUS"
 STAGEOUT_EXIT_STATUS=$?
 
 if [ ! -e wmcore_initialized ];


### PR DESCRIPTION
...ode in cmscp if not 0.

Today a user ran a task
http://glidemon.web.cern.ch/glidemon/jobs.php?taskid=834290&showResubmits=1
on preprod (I asked him to do it, because he could test the "additional outputs" patch) and some jobs failed with a cmsRun error (he knew this could happen). The cmsRun exit code was 134, correctly reported by GlideMon, but in dashboard I saw 134 until cmscp.py finished, then it became 80000 (which is a new error code meaning "Internal error in Crab job wrapper"). The 80000 was reported to dashboard by cmscp.py. The reason of the 80000 error is that the job report didn't have the section 'steps' in it (basically an invalid job report). cmscp.py didn't have the CMSRunAnalysis available from the job report, so it couldn't report it. In this patch what I do is to pass the CMSRunAnalysis exit code to cmscp.py as argument so that it has it available as soon as it starts and it doesn't rely on the job report, and cmscp.py can report it to dashboard instead of reporting 80000. All the point here is that we agreed (I think) that cmscp.py should prioritize the cmsRun exit code (actually I think it is the CMSRunAnalysis exit code) over any stageout exit code.
