### PR TITLE
several fixes with status and ASO

### DIFF
--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -115,7 +115,7 @@ class DataWorkflow(object):
     def submit(self, workflow, jobtype, jobsw, jobarch, inputdata, siteblacklist, sitewhitelist, splitalgo, algoargs, cachefilename, cacheurl, addoutputfiles,
                userhn, userdn, savelogsflag, publication, publishname, asyncdest, dbsurl, publishdbsurl, vorole, vogroup, tfileoutfiles, edmoutfiles,
                runs, lumis, totalunits, adduserfiles, oneEventMode=False, maxjobruntime=None, numcores=None, maxmemory=None, priority=None, lfnprefix=None, lfn=None,
-               ignorelocality=None, saveoutput=None, faillimit=10, userfiles=None, userproxy=None):
+               ignorelocality=None, saveoutput=None, faillimit=10, userfiles=None, userproxy=None, ASOURL=None):
         """Perform the workflow injection
 
            :arg str workflow: workflow name requested by the user;
@@ -154,6 +154,7 @@ class DataWorkflow(object):
            :arg str lfnprefix: prefix for output directory in /store/user. Deprecated in favour of the parameter below (lfn)
            :arg str lfn: lfn used to store output files.
            :arg str userfiles: The files to process instead of a DBS-based dataset.
+           :arg str ASOURL: Specify which ASO to use for transfers and publishing.
            :returns: a dict which contaians details of the request"""
 
         timestamp = time.strftime('%y%m%d_%H%M%S', time.gmtime())
@@ -172,13 +173,16 @@ class DataWorkflow(object):
         if maxmemory == None: maxmemory = 2000
         if priority == None: priority = 10
 
+        if not ASOURL:
+            ASOURL = self.centralcfg.centralconfig.get("backend-urls", {}).get("ASOURL", "")
+
         arguments = { \
             'oneEventMode' : 'T' if oneEventMode else 'F',
             'lfn' : '/store/user/%s/%s' % (username, lfnprefix) if lfnprefix else lfn,
             'saveoutput' : 'T' if saveoutput else 'F',
             'faillimit' : faillimit,
             'ignorelocality' : 'T' if ignorelocality else 'F',
-            'ASOURL' : self.centralcfg.centralconfig.get("backend-urls", {}).get("ASOURL", ""),
+            'ASOURL' : ASOURL,
             'userfiles' : userfiles,
         }
 
@@ -255,7 +259,7 @@ class DataWorkflow(object):
             #if not resubmitList:
             #    raise ExecutionError("There are no jobs to resubmit. Only jobs in %s states are resubmitted" % self.failedList)
             self.logger.info("Jobs to resubmit: %s" % resubmitList)
-            args = {"siteBlackList":siteblacklist, "siteWhiteList":sitewhitelist, "resubmitList":resubmitList}
+            args = {"siteBlackList":siteblacklist, "siteWhiteList":sitewhitelist, "resubmitList":resubmitList, 'ASOURL' : statusRes.get("ASOURL", "")}
             if maxjobruntime != None:
                 args['maxjobruntime'] = maxjobruntime
             if numcores != None:
@@ -310,7 +314,7 @@ class DataWorkflow(object):
         self.logger.info("About to kill workflow: %s. Getting status first." % workflow)
         statusRes = self.status(workflow, userdn, userproxy)[0]
 
-        args = {'ASOURL' : self.centralcfg.centralconfig.get("backend-urls", {}).get("ASOURL", "")}
+        args = {'ASOURL' : statusRes.get("ASOURL", "")}
         # Hm...
         dbSerializer = str
 

--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -173,6 +173,7 @@ class RESTUserWorkflow(RESTEntity):
             if len(safe.kwargs["runs"]) != len(safe.kwargs["lumis"]):
                 raise InvalidParameter("The number of runs and the number of lumis lists are different")
             validate_strlist("adduserfiles", param, safe, RX_ADDFILE)
+            validate_str("ASOURL", param, safe, RX_ASOURL, optional=True)
 
         elif method in ['POST']:
             validate_str("workflow", param, safe, RX_UNIQUEWF, optional=False)
@@ -221,7 +222,7 @@ class RESTUserWorkflow(RESTEntity):
     def put(self, workflow, jobtype, jobsw, jobarch, inputdata, siteblacklist, sitewhitelist, splitalgo, algoargs, cachefilename, cacheurl, addoutputfiles,\
                 savelogsflag, publication, publishname, asyncdest, dbsurl, publishdbsurl, vorole, vogroup, tfileoutfiles, edmoutfiles, runs, lumis,\
                 totalunits, adduserfiles, oneEventMode, maxjobruntime, numcores, maxmemory, priority, blacklistT1, nonprodsw, lfnprefix, lfn, saveoutput,
-                faillimit, ignorelocality, userfiles):
+                faillimit, ignorelocality, userfiles, ASOURL):
         """Perform the workflow injection
 
            :arg str workflow: workflow name requested by the user;
@@ -262,6 +263,7 @@ class RESTUserWorkflow(RESTEntity):
            :arg int faillimit: the maximum number of failed jobs which triggers a workflow abort.
            :arg int ignorelocality: whether to ignore file locality in favor of the whitelist.
            :arg str userfiles: The files to process instead of a DBS-based dataset.
+           :arg str ASOURL: ASO url for transfers and pulishing.
            :returns: a dict which contaians details of the request"""
 
         #print 'cherrypy headers: %s' % cherrypy.request.headers['Ssl-Client-Cert']
@@ -274,7 +276,7 @@ class RESTUserWorkflow(RESTEntity):
                                        dbsurl=dbsurl, publishdbsurl=publishdbsurl, tfileoutfiles=tfileoutfiles,
                                        edmoutfiles=edmoutfiles, runs=runs, lumis=lumis, totalunits=totalunits, adduserfiles=adduserfiles, oneEventMode=oneEventMode,
                                        maxjobruntime=maxjobruntime, numcores=numcores, maxmemory=maxmemory, priority=priority, lfnprefix=lfnprefix, lfn=lfn,
-                                       ignorelocality=ignorelocality, saveoutput=saveoutput, faillimit=faillimit, userfiles=userfiles)
+                                       ignorelocality=ignorelocality, saveoutput=saveoutput, faillimit=faillimit, userfiles=userfiles, ASOURL=ASOURL)
 
     @restcall
     def post(self, workflow, siteblacklist, sitewhitelist, jobids, maxjobruntime, numcores, maxmemory, priority):

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -42,6 +42,7 @@ RX_CHECKSUM  = re.compile(r'^[A-Za-z0-9\-]+$')
 RX_FILESTATE  = re.compile(r'^TRANSFERRING|FINISHED|FAILED|COOLOFF$')
 RX_LFNPATH   = re.compile(r"^(?=.{0,500}$)%(subdir)s(/%(subdir)s)*/?$" % lfnParts)
 RX_HOURS   = re.compile(r"^\d{0,6}$") #should be able to erase the last 100 years with 6 digits
+RX_ASOURL = RX_DBSURL
 #TODO!
 RX_OUT_DATASET = re.compile(r"^.*$")
 

--- a/src/python/Databases/TaskDB/MySQL/Task/Task.py
+++ b/src/python/Databases/TaskDB/MySQL/Task/Task.py
@@ -48,7 +48,7 @@ class Task(object):
 
     ID_sql = "SELECT tm_taskname, panda_jobset_id, tm_task_status, tm_user_role, \
              tm_user_group, tm_task_failure, tm_split_args, panda_resubmitted_jobs, \
-             tm_save_logs, tm_username, tm_user_dn, tm_arguments, tm_input_dataset, tm_dbs_url  \
+             tm_save_logs, tm_username, tm_user_dn, tm_arguments, tm_input_dataset, tm_dbs_url, tm_publication  \
              FROM tasks WHERE tm_taskname=%(taskname)s"
 
     New_sql = "INSERT INTO tasks ( \

--- a/src/python/Databases/TaskDB/Oracle/Task/Task.py
+++ b/src/python/Databases/TaskDB/Oracle/Task/Task.py
@@ -8,7 +8,7 @@ class Task(object):
      #ID
     ID_sql = "SELECT tm_taskname, panda_jobset_id, tm_task_status, tm_user_role, tm_user_group, \
              tm_task_failure, tm_split_args, panda_resubmitted_jobs, tm_save_logs, tm_username, \
-             tm_user_dn, tm_arguments, tm_input_dataset, tm_dbs_url FROM tasks WHERE tm_taskname=:taskname"
+             tm_user_dn, tm_arguments, tm_input_dataset, tm_dbs_url, tm_publication FROM tasks WHERE tm_taskname=:taskname"
    
     IDAll_sql = "SELECT tm_taskname, tm_task_status, tm_user_role, tm_user_group, \
              tm_save_logs, tm_username, \

--- a/src/python/TaskWorker/Actions/DagmanKiller.py
+++ b/src/python/TaskWorker/Actions/DagmanKiller.py
@@ -171,7 +171,7 @@ class DagmanKiller(TaskAction.TaskAction):
 
         # Search for and hold the DAG
         rootConst = "TaskType =?= \"ROOT\" && CRAB_ReqName =?= %s" % HTCondorUtils.quote(self.workflow)
-
+        self.logger.info("About to put on Hold task: %s" % self.workflow)
         with HTCondorUtils.AuthenticatedSubprocess(self.proxy) as (parent, rpipe):
             if not parent:
                self.schedd.act(htcondor.JobAction.Hold, rootConst)

--- a/src/python/TaskWorker/Actions/PreJob.py
+++ b/src/python/TaskWorker/Actions/PreJob.py
@@ -159,11 +159,6 @@ class PreJob:
 
         new_submit_text = self.redo_sites(new_submit_text, id, blacklist)
 
-        asoauth = self.get_asoauth() #get the aso URL from the auth aso file if any
-        if asoauth:
-            #substitute the URL (matches everything preceeded bye 'CRAB_ASOURL = "' and followed by '"')
-            new_submit_text = re.sub(r'(?<=CRAB_ASOURL = ")(.*)(?=")', asoauth, new_submit_text)
-
         with open("Job.%d.submit" % id, "w") as fd:
             fd.write(new_submit_text)
 
@@ -217,19 +212,6 @@ class PreJob:
                 return time.time() - os.stat(os.path.join(logpath, "postjob.%s.%s.txt" % (id, int(retry_num)-1))).st_mtime
         except:
             pass
-
-    def get_asoauth(self):
-        """ If the auth ASO file exist on the schedd return the asourl found there. Otherwise return None
-        """
-        aso_auth_file = os.path.expanduser("~/auth_aso_plugin.config")
-        if os.path.isfile(aso_auth_file):
-            f = open(aso_auth_file)
-            authParams = json.loads(f.read())
-            f.close()
-            return authParams['ASO_DB_URL']
-
-        return ''
-
 
     def execute(self, *args):
         retry_num = int(args[0])


### PR DESCRIPTION
a) Allow posibility to add Debug.ASOURL = 'ASOURL'. (Only for developers). In CrabClient need to merge this : https://github.com/dmwm/CRABClient/pull/4269
b) ASO url for each task is taken from oracle database and not anymore from rest configuration. New submission takes from rest configuration if no Debug.ASOURL is specified.
c) crab status with options (--long, --summary, --idle, --json) was giving differrent information about finished, killed, idle jobs. Because of verbosity 0, 1, 2. crab client decides what to show. In any case, only verbosity level 2 gives more information. 2 is used for --idle. verbose level 1 is removed, to give same information always.
d) Be smarter when calling the publication view for crab status. publication status is called only then minimum one file is transferred and publication flag is true.

This pull request fixes :
1) auth.json file on schedd will not change anything. https://github.com/dmwm/CRABServer/issues/4385 It can be closed. 
2) https://github.com/dmwm/CRABServer/issues/4357 -> (d)
3) https://github.com/dmwm/CRABServer/issues/4285 -> Not needed anymore. Can be closed.

Discussion 
4) https://github.com/dmwm/CRABServer/issues/4407 ASO is hardcoding url where to look for filemetadata. if ASO would know, or crab3 uploads together with document to couch url of filemetadata which is used, publisher would work as expected (Discussion.)
5) https://github.com/dmwm/CRABServer/issues/4332 (Kind of. First need to solve 4. If ASO would know where to look for filemetadata, regarding on task, then we can change rest configuration to be a list ["couch1", "couch2", "couch3"])

@HassenRiahi -> 4 and 5 ?
@mmascher 

Edited :
https://github.com/dmwm/CRABServer/issues/4225 is also solved with this pull request (c)
