### PR TITLE
Save webdirurl in database and fixes #4351

### DIFF
--- a/etc/updateOracle.sql
+++ b/etc/updateOracle.sql
@@ -1,1 +1,1 @@
-alter table tasks add (tm_task_warnings CLOB);
+alter table tasks add (tm_user_webdir VARCHAR(1000));

--- a/scripts/dag_bootstrap_startup.sh
+++ b/scripts/dag_bootstrap_startup.sh
@@ -60,12 +60,6 @@ then
     fi
 fi
 
-# Recalculate the black / whitelist
-if [ -e AdjustSites.py ];
-then
-  python2.6 AdjustSites.py
-fi
-
 # Bootstrap the runtime - we want to do this before DAG is submitted
 # so all the children don't try this at once.
 if [ "X$TASKWORKER_ENV" = "X" -a ! -e CRAB3.zip ]
@@ -116,6 +110,12 @@ then
 	ls -lah
 
         export TASKWORKER_ENV="1"
+fi
+
+# Recalculate the black / whitelist
+if [ -e AdjustSites.py ];
+then
+  python2.6 AdjustSites.py
 fi
 
 export _CONDOR_DAGMAN_LOG=$PWD/$1.dagman.out

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -43,6 +43,7 @@ RX_FILESTATE  = re.compile(r'^TRANSFERRING|FINISHED|FAILED|COOLOFF$')
 RX_LFNPATH   = re.compile(r"^(?=.{0,500}$)%(subdir)s(/%(subdir)s)*/?$" % lfnParts)
 RX_HOURS   = re.compile(r"^\d{0,6}$") #should be able to erase the last 100 years with 6 digits
 RX_ASOURL = RX_DBSURL
+RX_URL = re.compile(r"^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w :\.-]*)*$")
 #TODO!
 RX_OUT_DATASET = re.compile(r"^.*$")
 
@@ -54,7 +55,7 @@ RX_SUBRESTAT = re.compile(r"^errors|report|logs|data$")
 
 #subresources of the ServerInfo (/info) and Task (/task) resources
 RX_SUBRES_SI = re.compile(r"^delegatedn|backendurls|version|bannedoutdest|scheddaddress|ignlocalityblacklist|$")
-RX_SUBRES_TASK = re.compile(r"^allinfo|allusers|summary|search|taskbystatus|addwarning$")
+RX_SUBRES_TASK = re.compile(r"^allinfo|allusers|summary|search|taskbystatus|addwarning|addwebdir$")
 
 #worker workflow
 RX_WORKER_NAME = re.compile(r"^[A-Za-z0-9\-\._]{1,100}$")

--- a/src/python/Databases/TaskDB/MySQL/Create.py
+++ b/src/python/Databases/TaskDB/MySQL/Create.py
@@ -74,6 +74,7 @@ class Create(DBCreator):
         tm_priority BIGINT,
         tm_output_dataset LONGTEXT,
         tm_task_warnings LONGTEXT,
+        tm_user_webdir VARCHAR(1000),
         CONSTRAINT taskname_pk PRIMARY KEY(tm_taskname),
         CONSTRAINT check_tm_publication CHECK (tm_publication IN ('T', 'F')),
         CONSTRAINT check_tm_save_logs CHECK (tm_save_logs IN ('T', 'F'))

--- a/src/python/Databases/TaskDB/MySQL/Task/Task.py
+++ b/src/python/Databases/TaskDB/MySQL/Task/Task.py
@@ -48,7 +48,7 @@ class Task(object):
 
     ID_sql = "SELECT tm_taskname, panda_jobset_id, tm_task_status, tm_user_role, \
              tm_user_group, tm_task_failure, tm_split_args, panda_resubmitted_jobs, \
-             tm_save_logs, tm_username, tm_user_dn, tm_arguments, tm_input_dataset, tm_dbs_url, tm_publication \
+             tm_save_logs, tm_username, tm_user_dn, tm_arguments, tm_input_dataset, tm_dbs_url, tm_publication, tm_user_webdir \
              FROM tasks WHERE tm_taskname=%(taskname)s"
 
     New_sql = "INSERT INTO tasks ( \
@@ -98,3 +98,6 @@ class Task(object):
 
     SetUpdateOutDataset_sql = """UPDATE tasks SET tm_output_dataset = %(tm_output_dataset)s \
                                 WHERE tm_taskname = %(tm_taskname)s"""
+
+    UpdateWebUrl_sql = """UPDATE tasks SET tm_user_webdir = %(webdirurl)s \
+                              WHERE tm_taskname = %(workflow)s"""

--- a/src/python/Databases/TaskDB/Oracle/Create.py
+++ b/src/python/Databases/TaskDB/Oracle/Create.py
@@ -75,6 +75,7 @@ class Create(DBCreator):
         tm_priority NUMBER(38),
         tm_output_dataset CLOB,
         tm_task_warnings CLOB,
+        tm_user_webdir VARCHAR(1000),
         CONSTRAINT taskname_pk PRIMARY KEY(tm_taskname),
         CONSTRAINT check_tm_publication CHECK (tm_publication IN ('T', 'F')),
         CONSTRAINT check_tm_save_logs CHECK (tm_save_logs IN ('T', 'F'))

--- a/src/python/Databases/TaskDB/Oracle/Task/Task.py
+++ b/src/python/Databases/TaskDB/Oracle/Task/Task.py
@@ -9,10 +9,11 @@ class Task(object):
      #ID
     ID_tuple = namedtuple("ID", ["taskname", "panda_jobset_id", "task_status", "user_role", "user_group", \
              "task_failure", "split_args", "panda_resubmitted_jobs", "save_logs", "username", \
-             "user_dn", "arguments", "input_dataset", "dbs_url", "task_warnings", "tm_publication"])
+             "user_dn", "arguments", "input_dataset", "dbs_url", "task_warnings", "tm_publication", "tm_user_webdir"])
     ID_sql = "SELECT tm_taskname, panda_jobset_id, tm_task_status, tm_user_role, tm_user_group, \
              tm_task_failure, tm_split_args, panda_resubmitted_jobs, tm_save_logs, tm_username, \
-             tm_user_dn, tm_arguments, tm_input_dataset, tm_dbs_url, tm_task_warnings, tm_publication FROM tasks WHERE tm_taskname=:taskname"
+             tm_user_dn, tm_arguments, tm_input_dataset, tm_dbs_url, tm_task_warnings, tm_publication, tm_user_webdir \
+             FROM tasks WHERE tm_taskname=:taskname"
 
     IDAll_sql = "SELECT tm_taskname, tm_task_status, tm_user_role, tm_user_group, \
              tm_save_logs, tm_username, \
@@ -138,4 +139,8 @@ class Task(object):
 
     #UpdateWarnings
     SetWarnings_sql = """UPDATE tasks SET tm_task_warnings=:warnings WHERE tm_taskname=:workflow"""
+
+    #TaskUpdateWebDir
+    UpdateWebUrl_sql = """UPDATE tasks SET tm_user_webdir = :webdirurl \
+                              WHERE tm_taskname = :workflow"""
 

--- a/src/python/TaskWorker/Actions/DagmanSubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanSubmitter.py
@@ -289,6 +289,8 @@ class DagmanSubmitter(TaskAction.TaskAction):
         if 'JobPrio' not in dagAd:
             dagAd['JobPrio'] = 10
 
+        dagAd["CRAB_RestTaskUrl"] = self.config.TaskWorker.resturl
+        dagAd["CRAB_RestTaskInstance"] = self.resturl.replace('workflowdb', '')
         # NOTE: Changes here must be synchronized with the job_submit in DagmanCreator.py in CAFTaskWorker
         dagAd["Out"] = str(os.path.join(info['scratch'], "request.out"))
         dagAd["Err"] = str(os.path.join(info['scratch'], "request.err"))


### PR DESCRIPTION
Currently only webdirurl is saved in database, and it is not used anywhere.  Need final decision how we use it and reduce load of `condor_q` command to schedd.

Also Dagman ClassAd has `CRAB_RestTaskUrl` and `CRAB_RestTaskInstance` which can be used for uploading together to ASO couch document to solve DBS publication issue.

```
CRAB_RestTaskUrl = balcas-crab.cern.ch
CRAB_RestTaskInstance = /crabserver/{dev|prod|preprod}/
```

Also fixed this https://github.com/dmwm/CRABServer/issues/4351. Now sandbox can be found in web directory to speed up debugging.

Signed-off-by: Justas Balcas juztas@gmail.com
