### PR TITLE
Allow to use schedd which is not in the rest configuration list

### DIFF
--- a/src/python/CRABInterface/DataUserWorkflow.py
+++ b/src/python/CRABInterface/DataUserWorkflow.py
@@ -116,6 +116,7 @@ class DataUserWorkflow(object):
            :arg int faillimit: the maximum number of failed jobs allowed before workflow is aborted
            :arg int ignorelocality: ignore data locality.
            :arg str list userfiles: The files to process instead of a DBS-based dataset.
+           :arg str scheddname: Schedd name used for debugging.
            :returns: a dict which contaians details of the request"""
 
         return self.workflow.submit(*args, **kwargs)

--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -115,7 +115,7 @@ class DataWorkflow(object):
     def submit(self, workflow, activity, jobtype, jobsw, jobarch, inputdata, siteblacklist, sitewhitelist, splitalgo, algoargs, cachefilename, cacheurl, addoutputfiles,
                userhn, userdn, savelogsflag, publication, publishname, asyncdest, dbsurl, publishdbsurl, vorole, vogroup, tfileoutfiles, edmoutfiles,
                runs, lumis, totalunits, adduserfiles, oneEventMode=False, maxjobruntime=None, numcores=None, maxmemory=None, priority=None, lfnprefix=None, lfn=None,
-               ignorelocality=None, saveoutput=None, faillimit=10, userfiles=None, userproxy=None, asourl=None):
+               ignorelocality=None, saveoutput=None, faillimit=10, userfiles=None, userproxy=None, asourl=None, scheddname=None):
         """Perform the workflow injection
 
            :arg str workflow: workflow name requested by the user;
@@ -156,12 +156,13 @@ class DataWorkflow(object):
            :arg str lfn: lfn used to store output files.
            :arg str userfiles: The files to process instead of a DBS-based dataset.
            :arg str asourl: Specify which ASO to use for transfers and publishing.
+           :arg str scheddname: Schedd Name used for debugging.
            :returns: a dict which contaians details of the request"""
 
         timestamp = time.strftime('%y%m%d_%H%M%S', time.gmtime())
         requestname = ""
         try:
-            requestname = self.updateRequest('%s_%s_%s' % (timestamp, userhn, workflow))
+            requestname = self.updateRequest('%s_%s_%s' % (timestamp, userhn, workflow), scheddname)
         except IOError, err:
             self.logger.debug("Failed to communicate with components %s. Request name : " % (str(err), str(requestname)))
             raise ExecutionError("Failed to communicate with crabserver components. If problem persist, please report it.")

--- a/src/python/CRABInterface/HTCondorDataWorkflow.py
+++ b/src/python/CRABInterface/HTCondorDataWorkflow.py
@@ -64,13 +64,16 @@ class HTCondorDataWorkflow(DataWorkflow):
     failedList = ['held', 'failed', 'cooloff']
 
     @conn_handler(services=['centralconfig'])
-    def updateRequest(self, workflow):
+    def updateRequest(self, workflow, schedd_name):
         info = workflow.split("_", 3)
         if len(info) < 4:
             return workflow
         hn_name = info[2]
-        locator = HTCondorLocator.HTCondorLocator(self.centralcfg.centralconfig["backend-urls"])
-        name = locator.getSchedd().split("@")[0].split(".")[0]
+        if not schedd_name:
+            locator = HTCondorLocator.HTCondorLocator(self.centralcfg.centralconfig["backend-urls"])
+            name = locator.getSchedd().split("@")[0].split(".")[0]
+        else:
+            name = schedd_name.split("@")[0].split(".")[0]
         info[2] = "%s:%s" % (name, hn_name)
         return "_".join(info)
 

--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -175,6 +175,7 @@ class RESTUserWorkflow(RESTEntity):
                 raise InvalidParameter("The number of runs and the number of lumis lists are different")
             validate_strlist("adduserfiles", param, safe, RX_ADDFILE)
             validate_str("asourl", param, safe, RX_ASOURL, optional=True)
+            validate_str("scheddname", param, safe, RX_SCHEDD_NAME, optional=True)
 
         elif method in ['POST']:
             validate_str("workflow", param, safe, RX_UNIQUEWF, optional=False)
@@ -223,7 +224,7 @@ class RESTUserWorkflow(RESTEntity):
     def put(self, workflow, activity, jobtype, jobsw, jobarch, inputdata, siteblacklist, sitewhitelist, splitalgo, algoargs, cachefilename, cacheurl, addoutputfiles,\
                 savelogsflag, publication, publishname, asyncdest, dbsurl, publishdbsurl, vorole, vogroup, tfileoutfiles, edmoutfiles, runs, lumis,\
                 totalunits, adduserfiles, oneEventMode, maxjobruntime, numcores, maxmemory, priority, blacklistT1, nonprodsw, lfnprefix, lfn, saveoutput,
-                faillimit, ignorelocality, userfiles, asourl):
+                faillimit, ignorelocality, userfiles, asourl, scheddname):
         """Perform the workflow injection
 
            :arg str workflow: workflow name requested by the user;
@@ -265,6 +266,7 @@ class RESTUserWorkflow(RESTEntity):
            :arg int faillimit: the maximum number of failed jobs which triggers a workflow abort.
            :arg int ignorelocality: whether to ignore file locality in favor of the whitelist.
            :arg str userfiles: The files to process instead of a DBS-based dataset.
+           :arg str scheddname: Schedd Name used for debugging.
            :returns: a dict which contaians details of the request"""
 
         #print 'cherrypy headers: %s' % cherrypy.request.headers['Ssl-Client-Cert']
@@ -277,7 +279,7 @@ class RESTUserWorkflow(RESTEntity):
                                        dbsurl=dbsurl, publishdbsurl=publishdbsurl, tfileoutfiles=tfileoutfiles,
                                        edmoutfiles=edmoutfiles, runs=runs, lumis=lumis, totalunits=totalunits, adduserfiles=adduserfiles, oneEventMode=oneEventMode,
                                        maxjobruntime=maxjobruntime, numcores=numcores, maxmemory=maxmemory, priority=priority, lfnprefix=lfnprefix, lfn=lfn,
-                                       ignorelocality=ignorelocality, saveoutput=saveoutput, faillimit=faillimit, userfiles=userfiles, asourl=asourl)
+                                       ignorelocality=ignorelocality, saveoutput=saveoutput, faillimit=faillimit, userfiles=userfiles, asourl=asourl, scheddname=scheddname)
 
     @restcall
     def post(self, workflow, siteblacklist, sitewhitelist, jobids, maxjobruntime, numcores, maxmemory, priority):

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -45,6 +45,7 @@ RX_LFNPATH   = re.compile(r"^(?=.{0,500}$)%(subdir)s(/%(subdir)s)*/?$" % lfnPart
 RX_HOURS   = re.compile(r"^\d{0,6}$") #should be able to erase the last 100 years with 6 digits
 RX_ASOURL = RX_DBSURL
 RX_URL = re.compile(r"^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w :\.-])*$")
+RX_SCHEDD_NAME = re.compile(r"^[A-Za-z0-9._-]+@[A-Za-z0-9._-]+\.[A-Za-z]{2,6}$")
 #TODO!
 RX_OUT_DATASET = re.compile(r"^.*$")
 


### PR DESCRIPTION
This will allow us to test schedd or changed puppet configuration using main interface. Like now :

On global pool waiting 2 schedds : vocms095 and vocms096. To check them need to have full CrabServer installation or change rest configuration for preprod or dev. To change pool, schedds on rest configuration is not good, we saw a lot of issues with this change https://github.com/dmwm/CRABServer/issues/4336

Friday(09.19) ~5PM vocms0109 went down because puppet configuration started running and messed up whole schedd (ELOG filled). It was take out from rest configuration and condor was stopped. Whenever it will be fixed, it will require testing before going to prod rest configuration.

We talked several times to leave Hammercloud running with submission of minimal jobs and test schedd changes, if we want to change to newer version, or do modifications on schedd. This fix/feature will allow to specify schedd name on which change was made and to make sure that it did not break anything.

Addon in Client : https://github.com/juztas/CRABClient/commit/42d602e35f452c8067f94f193229823c3659804c

@jamesletts @mmascher @bbockelm
