### PR TITLE
New pull REQ. Allow to use schedd which is not in the rest configuration...

### DIFF
--- a/src/python/CRABInterface/DataUserWorkflow.py
+++ b/src/python/CRABInterface/DataUserWorkflow.py
@@ -116,6 +116,7 @@ class DataUserWorkflow(object):
            :arg int faillimit: the maximum number of failed jobs allowed before workflow is aborted
            :arg int ignorelocality: ignore data locality.
            :arg str list userfiles: The files to process instead of a DBS-based dataset.
+           :arg str scheddname: Schedd name used for debugging.
            :returns: a dict which contaians details of the request"""
 
         return self.workflow.submit(*args, **kwargs)

--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -115,7 +115,7 @@ class DataWorkflow(object):
     def submit(self, workflow, activity, jobtype, jobsw, jobarch, inputdata, siteblacklist, sitewhitelist, splitalgo, algoargs, cachefilename, cacheurl, addoutputfiles,
                userhn, userdn, savelogsflag, publication, publishname, asyncdest, dbsurl, publishdbsurl, vorole, vogroup, tfileoutfiles, edmoutfiles,
                runs, lumis, totalunits, adduserfiles, oneEventMode=False, maxjobruntime=None, numcores=None, maxmemory=None, priority=None, lfnprefix=None, lfn=None,
-               ignorelocality=None, saveoutput=None, faillimit=10, userfiles=None, userproxy=None, asourl=None, scriptexe=None, scriptargs=None):
+               ignorelocality=None, saveoutput=None, faillimit=10, userfiles=None, userproxy=None, asourl=None, scriptexe=None, scriptargs=None, scheddname=None):
         """Perform the workflow injection
 
            :arg str workflow: workflow name requested by the user;
@@ -156,12 +156,13 @@ class DataWorkflow(object):
            :arg str lfn: lfn used to store output files.
            :arg str userfiles: The files to process instead of a DBS-based dataset.
            :arg str asourl: Specify which ASO to use for transfers and publishing.
+           :arg str scheddname: Schedd Name used for debugging.
            :returns: a dict which contaians details of the request"""
 
         timestamp = time.strftime('%y%m%d_%H%M%S', time.gmtime())
         requestname = ""
         try:
-            requestname = self.updateRequest('%s_%s_%s' % (timestamp, userhn, workflow))
+            requestname = self.updateRequest('%s_%s_%s' % (timestamp, userhn, workflow), scheddname)
         except IOError, err:
             self.logger.debug("Failed to communicate with components %s. Request name : " % (str(err), str(requestname)))
             raise ExecutionError("Failed to communicate with crabserver components. If problem persist, please report it.")

--- a/src/python/CRABInterface/HTCondorDataWorkflow.py
+++ b/src/python/CRABInterface/HTCondorDataWorkflow.py
@@ -64,13 +64,16 @@ class HTCondorDataWorkflow(DataWorkflow):
     failedList = ['held', 'failed', 'cooloff']
 
     @conn_handler(services=['centralconfig'])
-    def updateRequest(self, workflow):
+    def updateRequest(self, workflow, scheddname=None):
         info = workflow.split("_", 3)
         if len(info) < 4:
             return workflow
         hn_name = info[2]
-        locator = HTCondorLocator.HTCondorLocator(self.centralcfg.centralconfig["backend-urls"])
-        name = locator.getSchedd().split("@")[0].split(".")[0]
+        if not scheddname:
+            locator = HTCondorLocator.HTCondorLocator(self.centralcfg.centralconfig["backend-urls"])
+            name = locator.getSchedd().split("@")[0].split(".")[0]
+        else:
+            name = scheddname.split("@")[0].split(".")[0]
         info[2] = "%s:%s" % (name, hn_name)
         return "_".join(info)
 

--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -177,6 +177,7 @@ class RESTUserWorkflow(RESTEntity):
             validate_str("asourl", param, safe, RX_ASOURL, optional=True)
             validate_str("scriptexe", param, safe, RX_ADDFILE, optional=True)
             validate_strlist("scriptargs", param, safe, RX_SCRIPTARGS)
+            validate_str("scheddname", param, safe, RX_SCHEDD_NAME, optional=True)
 
         elif method in ['POST']:
             validate_str("workflow", param, safe, RX_UNIQUEWF, optional=False)
@@ -225,7 +226,7 @@ class RESTUserWorkflow(RESTEntity):
     def put(self, workflow, activity, jobtype, jobsw, jobarch, inputdata, siteblacklist, sitewhitelist, splitalgo, algoargs, cachefilename, cacheurl, addoutputfiles,\
                 savelogsflag, publication, publishname, asyncdest, dbsurl, publishdbsurl, vorole, vogroup, tfileoutfiles, edmoutfiles, runs, lumis,\
                 totalunits, adduserfiles, oneEventMode, maxjobruntime, numcores, maxmemory, priority, blacklistT1, nonprodsw, lfnprefix, lfn, saveoutput,
-                faillimit, ignorelocality, userfiles, asourl, scriptexe, scriptargs):
+                faillimit, ignorelocality, userfiles, asourl, scriptexe, scriptargs, scheddname):
         """Perform the workflow injection
 
            :arg str workflow: workflow name requested by the user;
@@ -270,6 +271,7 @@ class RESTUserWorkflow(RESTEntity):
            :arg str asourl: ASO url to be used in place of the one in the ext configuration.
            :arg str scriptexe: script to execute in place of cmsrun.
            :arg str scriptargs: arguments to be passed to the scriptexe script.
+           :arg str scheddname: Schedd Name used for debugging.
            :returns: a dict which contaians details of the request"""
 
         #print 'cherrypy headers: %s' % cherrypy.request.headers['Ssl-Client-Cert']
@@ -283,7 +285,7 @@ class RESTUserWorkflow(RESTEntity):
                                        edmoutfiles=edmoutfiles, runs=runs, lumis=lumis, totalunits=totalunits, adduserfiles=adduserfiles, oneEventMode=oneEventMode,
                                        maxjobruntime=maxjobruntime, numcores=numcores, maxmemory=maxmemory, priority=priority, lfnprefix=lfnprefix, lfn=lfn,
                                        ignorelocality=ignorelocality, saveoutput=saveoutput, faillimit=faillimit, userfiles=userfiles, asourl=asourl,
-                                       scriptexe=scriptexe, scriptargs=scriptargs)
+                                       scriptexe=scriptexe, scriptargs=scriptargs, scheddname=scheddname)
 
     @restcall
     def post(self, workflow, siteblacklist, sitewhitelist, jobids, maxjobruntime, numcores, maxmemory, priority):

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -46,6 +46,7 @@ RX_HOURS   = re.compile(r"^\d{0,6}$") #should be able to erase the last 100 year
 RX_ASOURL = RX_DBSURL
 RX_URL = re.compile(r"^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w :\.-])*$")
 RX_SCRIPTARGS = re.compile(r"^[a-zA-Z0-9\-._:?/]+=[a-zA-Z0-9\-._:?/]+$")
+RX_SCHEDD_NAME = re.compile(r"^[A-Za-z0-9._-]+@[A-Za-z0-9._-]+\.[A-Za-z]{2,6}$")
 #TODO!
 RX_OUT_DATASET = re.compile(r"^.*$")
 


### PR DESCRIPTION
... list.

Sorry for new pull request. it was faster ;) Below are previuos comment. Tested with 3schedds after reinstallation in global pool which are not in rest configuration.

---

This will allow us to test schedd or changed puppet configuration using main interface. Like now :

On global pool waiting 2 schedds : vocms095 and vocms096. To check them need to have full CrabServer installation or change rest configuration for preprod or dev. To change pool, schedds on rest configuration is not good, we saw a lot of issues with this change #4336

Friday(09.19) ~5PM vocms0109 went down because puppet configuration started running and messed up whole schedd (ELOG filled). It was take out from rest configuration and condor was stopped. Whenever it will be fixed, it will require testing before going to prod rest configuration.

We talked several times to leave Hammercloud running with submission of minimal jobs and test schedd changes, if we want to change to newer version, or do modifications on schedd. This fix/feature will allow to specify schedd name on which change was made and to make sure that it did not break anything.

Addon in Client : juztas/CRABClient@42d602e
