### PR TITLE
Mark jobs transferred when the ASO is done.

### DIFF
--- a/src/python/CRABInterface/HTCondorDataWorkflow.py
+++ b/src/python/CRABInterface/HTCondorDataWorkflow.py
@@ -55,6 +55,8 @@ def temp_to_lfn(lfn, username):
 class MissingNodeStatus(ExecutionError):
     pass
 
+class MissingAsoStatus(ExecutionError):
+    pass
 
 class HTCondorDataWorkflow(DataWorkflow):
     """ HTCondor implementation of the status command.
@@ -555,6 +557,21 @@ class HTCondorDataWorkflow(DataWorkflow):
         else:
             raise MissingNodeStatus("Cannot get node state log. Retry in a minute if you just submitted the task")
 
+        aso_url = url + "/aso_status.json"
+        curl.setopt(pycurl.URL, aso_url)
+        fp.seek(0)
+        self.logger.debug("Starting download of aso state")
+        curl.perform()
+        self.logger.debug("Finished download of aso state")
+        header = ResponseHeader(hbuf.getvalue())
+        if header.status == 200:
+            fp.seek(0)
+            self.logger.debug("Starting parsing of aso state")
+            self.parseASOState(fp, nodes)
+            self.logger.debug("Finished parsing of aso state")
+        else:
+            raise MissingAsoStatus("Cannot get aso state log. Retry later.")
+
         return nodes, pool_info
 
     def _getOutDatasets(self, workflow):
@@ -722,6 +739,16 @@ class HTCondorDataWorkflow(DataWorkflow):
                 info['WallDurations'].append(now - last_start)
             while len(info['WallDurations']) > len(info['SiteHistory']):
                 info['SiteHistory'].append("Unknown")
+
+
+    def parseASOState(self, fp, nodes):
+        fp.seek(0)
+        data = json.load(fp)
+        for _, result in data['results'].items():
+            state = result['value']['state']
+            jobid = str(result['value']['jobid'])
+            if nodes[jobid]['State'] == 'transferring' and state == 'done':
+                nodes[jobid]['State'] = 'transferred'
 
 
     job_re = re.compile(r"JOB Job(\d+)\s+([A-Z_]+)\s+\((.*)\)")

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -403,7 +403,7 @@ class ASOServerJob(object):
             query = {'reduce': False, 'key': self.reqname, 'stale': 'update_after'}
             logger.debug("Querying task view.")
             try:
-                states = self.couch_database.loadView('AsyncTransfer', 'JobsStatesByWorkflow', query)['rows']
+                states = self.couch_database.loadView('AsyncTransfer', 'JobsIdsStatesByWorkflow', query)['rows']
                 states_dict = {}
                 for state in states:
                     states_dict[state['id']] = state
@@ -421,7 +421,7 @@ class ASOServerJob(object):
         for doc_id in self.doc_ids:
             if doc_id not in aso_info.get("results", {}):
                 return self.statusFallback()
-            statuses.append(aso_info['results'][doc_id]['value'])
+            statuses.append(aso_info['results'][doc_id]['value']['state'])
         return statuses
 
 


### PR DESCRIPTION
Fixes #4285: Fetches the ASO status file on the server and marks jobs transferred when ASO is done and the postjob has not yet processed them.
