### PR TITLE
Do not rely on the ASO status being on the server at all times.

### DIFF
--- a/src/python/CRABInterface/HTCondorDataWorkflow.py
+++ b/src/python/CRABInterface/HTCondorDataWorkflow.py
@@ -55,9 +55,6 @@ def temp_to_lfn(lfn, username):
 class MissingNodeStatus(ExecutionError):
     pass
 
-class MissingAsoStatus(ExecutionError):
-    pass
-
 class HTCondorDataWorkflow(DataWorkflow):
     """ HTCondor implementation of the status command.
     """
@@ -570,7 +567,7 @@ class HTCondorDataWorkflow(DataWorkflow):
             self.parseASOState(fp, nodes)
             self.logger.debug("Finished parsing of aso state")
         else:
-            raise MissingAsoStatus("Cannot get aso state log. Retry later.")
+            self.logger.debug("No aso state file available")
 
         return nodes, pool_info
 


### PR DESCRIPTION
My previous update broke `crab status`, i.e., when jobs were only queued.  I think that a missing aso status can be ignored.
