### PR TITLE
Not Block activities for HammerCloud. Fixes #4510

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -581,7 +581,7 @@ class DagmanCreator(TaskAction.TaskAction):
             if whitelist:
                 available &= whitelist
                 if not available:
-                    msg = "The CRAB3 server backend refuses to send jobs to the Grid scheduler. You put (%s) in the site whitelist, but your task %s can only run in "+\
+                    msg = "The CRAB3 server backend refuses to send jobs to the Grid scheduler. You put (%s) in the site whitelist, but your task %s can only run in "\
                           "(%s). Please check in das the locations of your datasets. Hint: the ignoreLocality option might help" % (", ".join(whitelist),\
                           kwargs['task']['tm_taskname'], ", ".join(availablesites))
                     raise TaskWorker.WorkerExceptions.NoAvailableSite(msg)


### PR DESCRIPTION
Requires to set parameter in TaskWorker config file :

```
config.TaskWorker.NonBlockActivities = []
```

If needed it can have several activities which have to be non blocked.

Also one bug is fixed in making string if site is not allowed. '+' is not needed.
