### PR TITLE
Not Block Sites for selected HammerCloud act. Fixes #4510

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -530,6 +530,13 @@ class DagmanCreator(TaskAction.TaskAction):
             global_whitelist = set(self.config.Sites.available)
         if hasattr(self.config.Sites, 'banned'):
             global_blacklist = set(self.config.Sites.banned)
+        # This is needed for Site Metrics
+        # It should not block any site for Site Metrics and if needed for other activities
+        # self.config.TaskWorker.ActivitiesToRunEverywhere = ['hctest', 'hcdev']
+        if hasattr(self.config.TaskWorker, 'ActivitiesToRunEverywhere') and \
+                   kwargs['task']['tm_activity'] in self.config.TaskWorker.ActivitiesToRunEverywhere:
+            global_whitelist = set()
+            global_blacklist = set()
 
         sitead = classad.ClassAd()
         siteinfo = {'groups': {}}
@@ -574,7 +581,7 @@ class DagmanCreator(TaskAction.TaskAction):
             if whitelist:
                 available &= whitelist
                 if not available:
-                    msg = "The CRAB3 server backend refuses to send jobs to the Grid scheduler. You put (%s) in the site whitelist, but your task %s can only run in "+\
+                    msg = "The CRAB3 server backend refuses to send jobs to the Grid scheduler. You put (%s) in the site whitelist, but your task %s can only run in "\
                           "(%s). Please check in das the locations of your datasets. Hint: the ignoreLocality option might help" % (", ".join(whitelist),\
                           kwargs['task']['tm_taskname'], ", ".join(availablesites))
                     raise TaskWorker.WorkerExceptions.NoAvailableSite(msg)


### PR DESCRIPTION
Requires to set parameter in TaskWorker config file :

```
config.TaskWorker.ActivitiesToRunEverywhere = []
```

If needed it can have several activities which have to be non blocked.
Style fix : remove +

More discussed here : https://github.com/dmwm/CRABServer/pull/4515
