### PR TITLE
Generate Fake FJR for Fatal errors and kill job if DiskUsage exceeds 100GB

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -148,11 +148,12 @@ periodic_release = (HoldReasonCode == 28) || (HoldReasonCode == 30) || (HoldReas
 periodic_remove = ((JobStatus =?= 5) && (time() - EnteredCurrentStatus > 7*60)) || \
                   ((JobStatus =?= 2) && ( \
                      (MemoryUsage > RequestMemory) || \
-                     (MaxWallTimeMins*60 < time() - EnteredCurrentStatus) \
+                     (MaxWallTimeMins*60 < time() - EnteredCurrentStatus) || \
+                     (DiskUsage > RequestDisk) \
                   ))
 +PeriodicRemoveReason = ifThenElse(MemoryUsage > RequestMemory, "Removed due to memory use", \
                           ifThenElse(MaxWallTimeMins*60 < time() - EnteredCurrentStatus, "Removed due to wall clock limit", \
-                            "Removed due to job being held"))
+                            ifThenElse(DiskUsage > RequestDisk, "Removed due to disk usage", "Removed due to job being held")))
 %(extra_jdl)s
 queue
 """


### PR DESCRIPTION
If job will exceed 100GB usage, job will be killed and it will be FatalError. 100GB limit is set on Scheduler.
Generated fake FJR will allow to print users real message why job failed and not that FJR does not exist.
Fixes #4534 #4532
