### PR TITLE
Improve message about refused to resubmit jobs.

### DIFF
--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -270,7 +270,9 @@ class DataWorkflow(object):
                 resubmitList = list(set(resubmitList) & set(jobids))
                 #check if all the requested jobids can be resubmitted
                 if len(resubmitList) != len(jobids):
-                    retmsg = "Cannot request resubmission for %s" % str(list(set(jobids) - set(resubmitList)))
+                    requestedResub = list(set(jobids) - set(resubmitList))
+                    retmsg = "CRAB3 server refused to resubmit these jobs: %s." \
+                             "You cannot resubmit these jobs if they are running" % str(requestedResub)
                     return [{"result":retmsg}]
             #if not resubmitList:
             #    raise ExecutionError("There are no jobs to resubmit. Only jobs in %s states are resubmitted" % self.failedList)


### PR DESCRIPTION
Previous message :

```
[jbalcas@lxplus0042 src]$ crab resubmit test_retry/crab_test-retry1/ --jobids=2
Resubmit request successfully sent
Cannot request resubmission for [2]
```

New message

```
[jbalcas@lxplus0042 src]$ crab resubmit test_retry/crab_test-retry1/ --jobids=2
Resubmit request successfully sent
CRAB3 server refused to resubmit these jobs: [2]. You cannot resubmit these jobs if they are running
```
