### PR TITLE
fix getFiles as it requires DirectStageout. Fixes #4571

### DIFF
--- a/src/python/Databases/FileMetaDataDB/Oracle/FileMetaData/FileMetaData.py
+++ b/src/python/Databases/FileMetaDataDB/Oracle/FileMetaData/FileMetaData.py
@@ -6,7 +6,7 @@ class GetFromTaskAndType():
     """ Used for indexing columns retrieved by the GetFromTaskAndType_sql query
     """
     PANDAID, OUTDS, ACQERA, SWVER, INEVENTS, GLOBALTAG, PUBLISHNAME, LOCATION, TMPLOCATION, RUNLUMI, ADLER32, CKSUM, MD5, LFN, SIZE, PARENTS, STATE,\
-    TMPLFN, CREATIONTIME, TYPE = range(20)
+    TMPLFN, CREATIONTIME, DIRECTSTAGEOUT, TYPE = range(21)
 
 class FileMetaData(object):
     """
@@ -34,7 +34,8 @@ class FileMetaData(object):
                            fmd_filestate AS state, \
                            fmd_creation_time AS created, \
                            fmd_tmplfn AS tmplfn, \
-                           fmd_type AS type \
+                           fmd_type AS type, \
+                           fmd_direct_stageout AS directstageout
                     FROM filemetadata \
                     WHERE tm_taskname = :taskname \
                     AND fmd_type IN (SELECT REGEXP_SUBSTR(:filetype, '[^,]+', 1, LEVEL) FROM DUAL CONNECT BY LEVEL <= REGEXP_COUNT(:filetype, ',') + 1) \


### PR DESCRIPTION
@AndresTanasijczuk implemented this to get output from temp directory and new if which is called from getFiles function, requires to have DIRECTSTAGEOUT parameter. Here is implementation to have this parameter. Tested it on my private machine and it returns all information to client. But also found this issue on Client https://github.com/dmwm/CRABClient/issues/4338 . With old client\* (current production) it works

@mmascher 
*

```
[jbalcas@lxplus0002 src]$ crab getlog -t balcas/crab_Test/
Retrieving 9 files']
Placing file 'cmsRun_6.log.tar.gz' in retrieval queue 
Placing file 'cmsRun_3.log.tar.gz' in retrieval queue 
Placing file 'cmsRun_5.log.tar.gz' in retrieval queue 
Placing file 'cmsRun_8.log.tar.gz' in retrieval queue 
Placing file 'cmsRun_10.log.tar.gz' in retrieval queue 
Placing file 'cmsRun_4.log.tar.gz' in retrieval queue 
Placing file 'cmsRun_9.log.tar.gz' in retrieval queue 
Placing file 'cmsRun_2.log.tar.gz' in retrieval queue 
Placing file 'cmsRun_1.log.tar.gz' in retrieval queue 
Please wait
Retrieving cmsRun_6.log.tar.gz 
Retrieving cmsRun_3.log.tar.gz 
Retrieving cmsRun_5.log.tar.gz 
Retrieving cmsRun_8.log.tar.gz 
Retrieving cmsRun_10.log.tar.gz 
Retrieving cmsRun_4.log.tar.gz 
Retrieving cmsRun_9.log.tar.gz 
Retrieving cmsRun_2.log.tar.gz 
Retrieving cmsRun_1.log.tar.gz 
Success: Success in retrieving cmsRun_1.log.tar.gz 
Success: Success in retrieving cmsRun_6.log.tar.gz 
Success: Success in retrieving cmsRun_5.log.tar.gz 
Success: Success in retrieving cmsRun_8.log.tar.gz 
Success: Success in retrieving cmsRun_2.log.tar.gz 
Success: Success in retrieving cmsRun_3.log.tar.gz 
Success: Success in retrieving cmsRun_4.log.tar.gz 
Success: Success in retrieving cmsRun_10.log.tar.gz 
Success: Success in retrieving cmsRun_9.log.tar.gz 
Success: All files successfully retrieve 
```
