### PR TITLE
Failed to contact PhEDEx (getoutput, getlog)

### DIFF
--- a/src/python/CRABInterface/HTCondorDataWorkflow.py
+++ b/src/python/CRABInterface/HTCondorDataWorkflow.py
@@ -145,7 +145,6 @@ class HTCondorDataWorkflow(DataWorkflow):
         if howmany != -1:
             rows = rows[:howmany]
         #jobids=','.join(map(str,jobids)), limit=str(howmany) if howmany!=-1 else str(len(jobids)*100))
-
         for row in rows:
             try:
                 jobid = row[GetFromTaskAndType.PANDAID]
@@ -153,21 +152,25 @@ class HTCondorDataWorkflow(DataWorkflow):
                     if row[GetFromTaskAndType.DIRECTSTAGEOUT]:
                         lfn  = row[GetFromTaskAndType.LFN]
                         site = row[GetFromTaskAndType.LOCATION]
+                        self.logger.debug("LFN: %s and site %s" % (lfn, site))
                         pfn  = self.phedex.getPFN(site, lfn)[(site, lfn)]
                     else:
                         if jobid in finishedIds:
                             lfn  = row[GetFromTaskAndType.LFN]
                             site = row[GetFromTaskAndType.LOCATION]
+                            self.logger.debug("LFN: %s and site %s" % (lfn, site))
                             pfn  = self.phedex.getPFN(site, lfn)[(site, lfn)]
                         elif jobid in transferingIds:
                             lfn  = row[GetFromTaskAndType.TMPLFN]
                             site = row[GetFromTaskAndType.TMPLOCATION]
+                            self.logger.debug("LFN: %s and site %s" % (lfn, site))
                             pfn  = self.phedex.getPFN(site, lfn)[(site, lfn)]
                         else:
                             continue
                 else:
                     lfn  = row[GetFromTaskAndType.TMPLFN]
                     site = row[GetFromTaskAndType.TMPLOCATION]
+                    self.logger.debug("LFN: %s and site %s" % (lfn, site))
                     pfn  = self.phedex.getPFN(site, lfn)[(site, lfn)]
             except Exception, err:
                 self.logger.exception(err)

--- a/src/python/CRABInterface/RESTFileMetadata.py
+++ b/src/python/CRABInterface/RESTFileMetadata.py
@@ -78,6 +78,10 @@ class RESTFileMetadata(RESTEntity):
     def put(self, taskname, outfilelumis, inparentlfns, globalTag, outfileruns, pandajobid, outsize, publishdataname, appver, outtype, checksummd5,\
             checksumcksum, checksumadler32, outlocation, outtmplocation, outdatasetname, acquisitionera, outlfn, events, filestate, directstageout, outtmplfn):
         """Insert a new job metadata information"""
+        # Don`t want to have None in outtmplfn. This needs to be removed in 2015 February release
+        # For old tasks submitted to old crabserver and which are not passing outtmplfn make it same as outlfn
+        if not outtmplfn:
+            outtmplfn = outlfn
         return self.jobmetadata.inject(taskname=taskname, outfilelumis=outfilelumis, inparentlfns=inparentlfns, globalTag=globalTag, outfileruns=outfileruns,\
                            pandajobid=pandajobid, outsize=outsize, publishdataname=publishdataname, appver=appver, outtype=outtype, checksummd5=checksummd5,\
                            checksumcksum=checksumcksum, checksumadler32=checksumadler32, outlocation=outlocation, outtmplocation=outtmplocation,\

--- a/src/python/Databases/FileMetaDataDB/Oracle/FileMetaData/FileMetaData.py
+++ b/src/python/Databases/FileMetaDataDB/Oracle/FileMetaData/FileMetaData.py
@@ -4,9 +4,10 @@ import logging
 
 class GetFromTaskAndType():
     """ Used for indexing columns retrieved by the GetFromTaskAndType_sql query
+        Order of parameters must be the same as it is in query GetFromTaskAndType_sql
     """
     PANDAID, OUTDS, ACQERA, SWVER, INEVENTS, GLOBALTAG, PUBLISHNAME, LOCATION, TMPLOCATION, RUNLUMI, ADLER32, CKSUM, MD5, LFN, SIZE, PARENTS, STATE,\
-    TMPLFN, CREATIONTIME, DIRECTSTAGEOUT, TYPE = range(21)
+    CREATIONTIME, TMPLFN, TYPE, DIRECTSTAGEOUT = range(21)
 
 class FileMetaData(object):
     """


### PR DESCRIPTION
Sorry for this, but in previuos pull request was everything fine. But as a last test I was doing every time getoutput and getlog with all possible options of transfer.
After jobs started finishing, in one time I got that output cannot be encoded from PhEDEx in another everything succeeds. (T vs F in output parameter)
This pull request fixes:
a) For old tasks use the same outtmplfn as outlfn
b) Order correction in Filemetadata and added comment for future
c) More debugging information.

@mmascher @AndresTanasijczuk I have tested this on my private VM with Logs=False, Output=True and it works. Can someone of you test it with Logs=True/False and Output=True/False and give green light?

Also everything about CrabServer and interections with it from Client/TW/WN looks ok, except this getoutput and getlog. Will update validation twiki later. Almost ready for production ;)
