### PR TITLE
Hook up WMCores event aware lumi splitting.

### DIFF
--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -31,7 +31,8 @@ class DataWorkflow(object):
 
         self.splitArgMap = { "LumiBased" : "lumis_per_job",
                         "FileBased" : "files_per_job",
-                        "EventBased" : "events_per_job",}
+                        "EventBased" : "events_per_job",
+                        "EventAwareLumiBased": "events_per_job"}
 
 	self.Task = getDBinstance(config, 'TaskDB', 'Task')
 	self.JobGroup = getDBinstance(config, 'TaskDB', 'JobGroup')

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -26,7 +26,7 @@ RX_CMSSW     = re.compile(r"^(?=.{0,255}$)CMSSW[a-zA-Z0-9-_]*$") #using a lookah
 RX_ARCH      = re.compile(r"^(?=.{0,255}$)slc[0-9]{1}_[a-z0-9]+_gcc[a-z0-9]+(_[a-z0-9]+)?$")
 RX_DATASET   = re.compile(SEARCHDATASET_RE)
 RX_BLOCK     = re.compile(r"^(/[a-zA-Z0-9\.\-_]{1,100}){3}#[a-zA-Z0-9\.\-_]{1,100}$")
-RX_SPLIT     = re.compile(r"^FileBased|EventBased|LumiBased$")
+RX_SPLIT     = re.compile(r"^FileBased|EventBased|LumiBased|EventAwareLumiBased$")
 RX_CACHEURL  = re.compile(r"^https?://([-\w\.]*)\.cern\.ch+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?$")
 RX_ADDFILE   = re.compile(r"^(?=.{0,255}$)([a-zA-Z0-9\-\._]+)$")
 # Can be a LFN or PFN (anything CMSSW accepts is fine here)

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -160,7 +160,8 @@ queue
 
 SPLIT_ARG_MAP = { "LumiBased" : "lumis_per_job",
                   "EventBased" : "events_per_job",
-                  "FileBased" : "files_per_job",}
+                  "FileBased" : "files_per_job",
+                  "EventAwareLumiBased" : "events_per_job",}
 
 
 def getCreateTimestamp(taskname):


### PR DESCRIPTION
Creates jobs by consuming lumis from the dataset until a user specified
number of events is reached.  This gives more evenly sized jobs for
datasets with more variation in lumi size.

Fixes #4199.  Additional changes not needed.  The database connection in
WMCore is optional, and if not present, the lumi size is estimated from the
number of events in a file.
