### PR TITLE
Don't do local stageout nor file metadata upload if transfer flag is False.

### DIFF
--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -57,7 +57,7 @@ class RESTUserWorkflow(RESTEntity):
            If lfn is not there, default to '/store/user/username/'.
            Handle old clients lfnprefix parameter.
         """
-        ## Is this the username registered in SiteDB?
+        ## This is the username registered in SiteDB.
         username = cherrypy.request.user['login']
         if kwargs['lfnprefix']:
             kwargs['lfn'] = '/store/user/%s/%s' % (username, kwargs["lfnprefix"])


### PR DESCRIPTION
I still do the input files metadata upload even if the transfer output flag is False, because I think this is still useful so that the user can get the lumiSummary.json and the number of processed files and events in the crab report.