### PR TITLE
Validate the publication dataset name and the primary dataset name.

### DIFF
--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -227,8 +227,9 @@ class DataWorkflow(object):
                             user_vo         = ['cms'],
                             user_role       = [vorole],
                             user_group      = [vogroup],
-                            #a dash in the publishname is there if the user specified the publishname (publishname-isbcheckusm). Otherwise publishname=isbchecksum
-                            #BTW isbchecksum is overwritten later with the psethash for publication
+                            ## The client defines publishname = <Data.publishDataName>-<isbchecksum>
+                            ## if the user defines Data.publishDataName, and publishname = <isbchecksum> otherwise.
+                            ## (The PostJob replaces then the isbchecksum by the psethash.)
                             publish_name    = [(workflow.replace(":", "_") + '-' + publishname) if publishname.find('-')==-1 else publishname],
                             asyncdest       = [asyncdest],
                             dbs_url         = [dbsurl],

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -1,6 +1,11 @@
 import re
 from WMCore.Lexicon import lfnParts, SEARCHDATASET_RE
 
+
+## This regular expression matches anything. It is useful for example for
+## functions that require a regular expression against which they will match a
+## given value, but we don't really want to do that matching.
+RX_ANYTHING = re.compile(r"^.*$")
 # TODO: we should start replacing most of the regex here with what we have in WMCore.Lexicon
 #       (this probably requires to adapt something on Lexicon)
 wfBase = r"^[a-zA-Z0-9\-_:]{1,%s}$"

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -1315,8 +1315,14 @@ class PostJob():
                 if multiple_edm and file_info.get('module_label'):
                     left, right = publishname.rsplit('-', 1)
                     publishname = "%s_%s-%s" % (left, file_info['module_label'], right)
-                outdataset = os.path.join('/' + self.input_dataset.split('/')[1], \
-                                          self.job_ad['CRAB_UserHN'] + '-' + publishname, 'USER')
+                ## Extracting the primary dataset name from the input dataset is ok
+                ## for an analysis job type. But to make sense of this same logic in
+                ## a MC generation job type, the client defines the input dataset as
+                ## '/' + primary dataset name. TODO: Some day maybe we could improve
+                ## this (define a primary dataset parameter in the job ad and in the
+                ## rest interface).
+                primary_dataset_name = self.input_dataset.split('/')[1]
+                outdataset = os.path.join('/' + primary_dataset_name, self.job_ad['CRAB_UserHN'] + '-' + publishname, 'USER')
                 output_datasets.add(outdataset)
             else:
                 outdataset = '/FakeDataset/fakefile-FakePublish-5b6a581e4ddd41b130711a045d5fecb9/USER'


### PR DESCRIPTION
Fixes https://github.com/dmwm/CRABClient/issues/4257

Tests:

For Analysis job type:

1) Incorrect publication dataset name with publication = True

Will use configuration file crabConfig_test.py
WARNING: Incompatible CRABClient version "3.3.12.patch1" 
Server is saying that compatible versions are: ['3.3.8', '3.3.9.rc2', '3.3.9', '3.3.10', '3.3.9.pre2']
WARNING: The following output files will not be published, as they are not EDM files: ['tfileservice.root', 'ggH_Hmass125_hfact4.95_Bmass0_seed001.lhe']
Sending the request to the server
Error contacting the server.
Server answered with: Invalid input parameter
Reason is: Invalid CRAB configuration parameter Data.publishDataName. The parameter should not have more than 157 characters and should match the regular expression ([a-zA-Z0-9\-_])+
Log file is /afs/cern.ch/work/a/atanasi/CRAB3-tutorial/CMSSW_7_0_5/src/crab_check_publish_name_2/crab.log

2) Incorrect publication dataset name with publication = False

Will use configuration file crabConfig_test.py
WARNING: Incompatible CRABClient version "3.3.12.patch1" 
Server is saying that compatible versions are: ['3.3.8', '3.3.9.rc2', '3.3.9', '3.3.10', '3.3.9.pre2']
Sending the request to the server
Error contacting the server.
Server answered with: Invalid input parameter
Reason is: Incorrect 'Data.publishDataName' parameter
Log file is /afs/cern.ch/work/a/atanasi/CRAB3-tutorial/CMSSW_7_0_5/src/crab_check_publish_name_2/crab.log

For PrivateMC job type:

3) Incorrect publication dataset name with publication = True

Will use configuration file crabConfig_test.py
WARNING: Incompatible CRABClient version "3.3.12.patch1" 
Server is saying that compatible versions are: ['3.3.8', '3.3.9.rc2', '3.3.9', '3.3.10', '3.3.9.pre2']
WARNING: The following output files will not be published, as they are not EDM files: ['tfileservice.root', 'ggH_Hmass125_hfact4.95_Bmass0_seed001.lhe']
Sending the request to the server
Error contacting the server.
Server answered with: Invalid input parameter
Reason is: Invalid CRAB configuration parameter Data.publishDataName. The parameter should not have more than 157 characters and should match the regular expression ([a-zA-Z0-9\-_])+
Log file is /afs/cern.ch/work/a/atanasi/CRAB3-tutorial/CMSSW_7_0_5/src/crab_check_publish_name_2/crab.log

4) Incorrect publication dataset name with publication = False

Will use configuration file crabConfig_test.py
WARNING: Incompatible CRABClient version "3.3.12.patch1" 
Server is saying that compatible versions are: ['3.3.8', '3.3.9.rc2', '3.3.9', '3.3.10', '3.3.9.pre2']
Sending the request to the server
Error contacting the server.
Server answered with: Invalid input parameter
Reason is: Incorrect 'Data.publishDataName' parameter
Log file is /afs/cern.ch/work/a/atanasi/CRAB3-tutorial/CMSSW_7_0_5/src/crab_check_publish_name_2/crab.log

5) Incorrect primary dataset name with publication = True

Will use configuration file crabConfig_test.py
WARNING: Incompatible CRABClient version "3.3.12.patch1" 
Server is saying that compatible versions are: ['3.3.8', '3.3.9.rc2', '3.3.9', '3.3.10', '3.3.9.pre2']
WARNING: The following output files will not be published, as they are not EDM files: ['tfileservice.root', 'ggH_Hmass125_hfact4.95_Bmass0_seed001.lhe']
Sending the request to the server
Error contacting the server.
Server answered with: Invalid input parameter
Reason is: Invalid CRAB configuration parameter Data.primaryDataset. The parameter should not have more than 99 characters and should match the regular expression [a-zA-Z][a-zA-Z0-9\-_]*
Log file is /afs/cern.ch/work/a/atanasi/CRAB3-tutorial/CMSSW_7_0_5/src/crab_check_publish_name_2/crab.log

6) Incorrect primary dataset name with publication = False

Will use configuration file crabConfig_test.py
WARNING: Incompatible CRABClient version "3.3.12.patch1" 
Server is saying that compatible versions are: ['3.3.8', '3.3.9.rc2', '3.3.9', '3.3.10', '3.3.9.pre2']
Sending the request to the server
Error contacting the server.
Server answered with: Invalid input parameter
Reason is: Incorrect 'Data.inputDataset or Data.primaryDataset' parameter
Log file is /afs/cern.ch/work/a/atanasi/CRAB3-tutorial/CMSSW_7_0_5/src/crab_check_publish_name_2/crab.log
