### PR TITLE
 Create cronjob for cleaning tmp directory. Fixes #4504

### DIFF
--- a/src/python/TaskWorker/Actions/Recurring/RemovetmpDir.py
+++ b/src/python/TaskWorker/Actions/Recurring/RemovetmpDir.py
@@ -1,0 +1,31 @@
+import os
+import time
+import shutil
+
+from datetime import date
+
+from TaskWorker.Actions.Recurring.BaseRecurringAction import BaseRecurringAction
+
+days = 86400*30
+now = time.time()
+
+class RemovetmpDir(BaseRecurringAction):
+    pollingTime = 60*24 #minutes
+
+    def _execute(self, resthost, resturi, config, task):
+        self.logger.info('Checking for directory older than 30 days..')
+        for dirpath, dirnames, filenames in os.walk('/data/srv/tmp'):
+            for dir in dirnames:
+                timestamp = os.path.getmtime(os.path.join(dirpath,dir))
+                if now-days > timestamp:
+                    try: 
+                        self.logger.info('Removing:')
+                        self.logger.info(os.path.join(dirpath,dir))
+                        shutil.rmtree(os.path.join(dirpath,dir))
+                    except Exception,e:
+                        print e
+                        pass
+                    else: 
+                        self.logger.info('Directory removed.')
+            
+        


### PR DESCRIPTION
Directory in /data/srv/tmp that is older than 30 days is remove every 24 hours.
Add also this line:
config.TaskWorker.recurringActions = ['RemovetmpDir']
in TaskWorkerConfig.py under the TaskWorker section.