### PR TITLE
Late binding of schedd. Fixes #4629

### DIFF
--- a/etc/updateOracle.sql
+++ b/etc/updateOracle.sql
@@ -39,3 +39,6 @@ UPDATE filemetadata SET fmd_tmplfn=fmd_lfn WHERE fmd_tmplfn is NULL or fmd_tmplf
 --Changes that will be needed for version 3.4.02
 alter table tasks add (tm_collector VARCHAR(1000));
 ALTER TABLE tasks DROP column tm_transformation;
+
+-----------------------------------------------
+ALTER TABLE tasks ADD (tm_schedd VARCHAR(255));

--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -168,6 +168,7 @@ class DataWorkflow(object):
 
         timestamp = time.strftime('%y%m%d_%H%M%S', time.gmtime())
         requestname = ""
+        schedd_name = ""
         backend_urls = self.centralcfg.centralconfig.get("backend-urls", {})
         if collector:
             backend_urls['htcondorPool'] = collector
@@ -175,7 +176,8 @@ class DataWorkflow(object):
             collector = backend_urls['htcondorPool']
 
         try:
-            requestname = self.updateRequest('%s_%s_%s' % (timestamp, userhn, workflow), scheddname, backend_urls)
+            requestname = '%s:%s_%s' % (timestamp, userhn, workflow)
+            schedd_name = self.chooseScheduler(scheddname, backend_urls).split(":")[0]
         except IOError, err:
             self.logger.debug("Failed to communicate with components %s. Request name %s: " % (str(err), str(requestname)))
             raise ExecutionError("Failed to communicate with crabserver components. If problem persist, please report it.")
@@ -251,7 +253,8 @@ class DataWorkflow(object):
                             scriptargs      = [dbSerializer(scriptargs)],
                             extrajdl        = [dbSerializer(extrajdl)],
                             asourl          = [asourl],
-                            collector       = [collector]
+                            collector       = [collector],
+                            schedd_name     = [schedd_name]
         )
 
         return [{'RequestName': requestname}]

--- a/src/python/CRABInterface/RESTWorkerWorkflow.py
+++ b/src/python/CRABInterface/RESTWorkerWorkflow.py
@@ -235,4 +235,5 @@ class Task(dict):
         self['tm_events_per_lumi'] = task[46]
         self['tm_use_parent'] = task[47]
         self['tm_collector'] = task[48]
+        self['tm_schedd'] = task[49]
 

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -54,7 +54,7 @@ RX_HOURS   = re.compile(r"^\d{0,6}$") #should be able to erase the last 100 year
 RX_ASOURL = RX_DBSURL
 RX_URL = re.compile(r"^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w :\.-])*$")
 RX_SCRIPTARGS = re.compile(r'^[+a-zA-Z0-9\-._:?/"]+=[a-zA-Z0-9\-._:?/"]+$')
-RX_SCHEDD_NAME = re.compile(r"^[A-Za-z0-9._-]+@[A-Za-z0-9._-]+\.[A-Za-z]{2,6}$")
+RX_SCHEDD_NAME = re.compile(r"^[A-Za-z0-9._-]+[@.][A-Za-z0-9._-]+\.[A-Za-z]{2,6}$")
 RX_COLLECTOR = re.compile(r"^(([A-Za-z0-9._-]+\.[A-Za-z]{2,6}),?)+$")
 #TODO!
 RX_OUT_DATASET = re.compile(r"^.*$")

--- a/src/python/Databases/TaskDB/MySQL/Create.py
+++ b/src/python/Databases/TaskDB/MySQL/Create.py
@@ -81,6 +81,7 @@ class Create(DBCreator):
         tm_extrajdl VARCHAR(1000),
         tm_asourl VARCHAR(4000),
         tm_collector VARCHAR(1000),
+        tm_schedd VARCHAR(255),
         CONSTRAINT taskname_pk PRIMARY KEY(tm_taskname),
         CONSTRAINT check_tm_publication CHECK (tm_publication IN ('T', 'F')),
         CONSTRAINT check_tm_save_logs CHECK (tm_save_logs IN ('T', 'F'))

--- a/src/python/Databases/TaskDB/Oracle/Create.py
+++ b/src/python/Databases/TaskDB/Oracle/Create.py
@@ -84,6 +84,7 @@ class Create(DBCreator):
         tm_extrajdl VARCHAR(1000),
         tm_asourl VARCHAR(4000),
         tm_collector VARCHAR(1000),
+        tm_schedd VARCHAR(255),
         CONSTRAINT taskname_pk PRIMARY KEY(tm_taskname),
         CONSTRAINT check_tm_publication CHECK (tm_publication IN ('T', 'F')),
         CONSTRAINT check_tm_save_logs CHECK (tm_save_logs IN ('T', 'F'))

--- a/src/python/Databases/TaskDB/Oracle/Task/Task.py
+++ b/src/python/Databases/TaskDB/Oracle/Task/Task.py
@@ -9,10 +9,10 @@ class Task(object):
      #ID
     ID_tuple = namedtuple("ID", ["taskname", "panda_jobset_id", "task_status", "user_role", "user_group", \
              "task_failure", "split_args", "panda_resubmitted_jobs", "save_logs", "username", \
-             "user_dn", "arguments", "input_dataset", "dbs_url", "task_warnings", "publication", "user_webdir", "asourl", "output_dataset", "collector"])
+             "user_dn", "arguments", "input_dataset", "dbs_url", "task_warnings", "publication", "user_webdir", "asourl", "output_dataset", "collector", "schedd"])
     ID_sql = "SELECT tm_taskname, panda_jobset_id, tm_task_status, tm_user_role, tm_user_group, \
              tm_task_failure, tm_split_args, panda_resubmitted_jobs, tm_save_logs, tm_username, \
-             tm_user_dn, tm_arguments, tm_input_dataset, tm_dbs_url, tm_task_warnings, tm_publication, tm_user_webdir, tm_asourl, tm_output_dataset, tm_collector \
+             tm_user_dn, tm_arguments, tm_input_dataset, tm_dbs_url, tm_task_warnings, tm_publication, tm_user_webdir, tm_asourl, tm_output_dataset, tm_collector, tm_schedd \
              FROM tasks WHERE tm_taskname=:taskname"
 
     IDAll_sql = "SELECT tm_taskname, tm_task_status, tm_user_role, tm_user_group, \
@@ -36,13 +36,14 @@ class Task(object):
               tm_user_vo, tm_user_role, tm_user_group, tm_publish_name, tm_asyncdest, tm_dbs_url, tm_publish_dbs_url, \
               tm_publication, tm_outfiles, tm_tfile_outfiles, tm_edm_outfiles, tm_job_type, tm_generator, tm_arguments,\
               panda_resubmitted_jobs, tm_save_logs, tm_user_infiles, tm_maxjobruntime, tm_numcores, tm_maxmemory, tm_priority,\
-              tm_scriptexe, tm_scriptargs, tm_extrajdl, tm_asourl, tm_events_per_lumi, tm_collector) \
+              tm_scriptexe, tm_scriptargs, tm_extrajdl, tm_asourl, tm_events_per_lumi, tm_collector, tm_schedd) \
               VALUES (:task_name, :task_activity, :jobset_id, upper(:task_status), SYS_EXTRACT_UTC(SYSTIMESTAMP), :task_failure, :job_sw, \
               :job_arch, :input_dataset, :use_parent, :site_whitelist, :site_blacklist, :split_algo, :split_args, \
               :total_units, :user_sandbox, :cache_url, :username, :user_dn, \
               :user_vo, :user_role, :user_group, :publish_name, :asyncdest, :dbs_url, :publish_dbs_url, \
               :publication, :outfiles, :tfile_outfiles, :edm_outfiles, :job_type, :generator, :arguments,\
-              :resubmitted_jobs, :save_logs, :user_infiles, :maxjobruntime, :numcores, :maxmemory, :priority, :scriptexe, :scriptargs, :extrajdl, :asourl, :events_per_lumi, :collector)"
+              :resubmitted_jobs, :save_logs, :user_infiles, :maxjobruntime, :numcores, :maxmemory, :priority,\
+              :scriptexe, :scriptargs, :extrajdl, :asourl, :events_per_lumi, :collector, :schedd_name)"
 
     #GetFailedTasks
     GetFailedTasks_sql = "SELECT tm_taskname, tm_task_status FROM tasks WHERE tm_task_status = 'FAILED'"
@@ -58,7 +59,7 @@ class Task(object):
                        tm_totalunits, tm_user_sandbox, tm_cache_url, tm_username, tm_user_dn, tm_user_vo, \
                        tm_user_role, tm_user_group, tm_publish_name, tm_asyncdest, tm_dbs_url, \
                        tm_publish_dbs_url, tm_publication, tm_outfiles, tm_tfile_outfiles, tm_edm_outfiles, \
-                       tm_job_type, tm_arguments, panda_resubmitted_jobs, tm_save_logs, tm_user_infiles, tm_asourl, tm_collector \
+                       tm_job_type, tm_arguments, panda_resubmitted_jobs, tm_save_logs, tm_user_infiles, tm_asourl, tm_collector, tm_schedd \
                        FROM tasks WHERE tm_task_status = 'KILL' """
    
     #GetNewResubmit
@@ -70,7 +71,7 @@ class Task(object):
                        tm_user_role, tm_user_group, tm_publish_name, tm_asyncdest, tm_dbs_url, \
                        tm_publish_dbs_url, tm_publication, tm_outfiles, tm_tfile_outfiles, tm_edm_outfiles, \
                        tm_job_type, tm_arguments, panda_resubmitted_jobs, tm_save_logs, \
-                       tm_user_infiles, tw_name, tm_asourl, tm_collector \
+                       tm_user_infiles, tw_name, tm_asourl, tm_collector, tm_schedd \
                        FROM tasks WHERE tm_task_status = 'NEW' OR tm_task_status = 'RESUBMIT' """
    
     #GetReadyTasks
@@ -84,7 +85,7 @@ class Task(object):
                        tm_job_type, tm_arguments, panda_resubmitted_jobs, tm_save_logs, \
                        tm_user_infiles, tw_name, tm_maxjobruntime, tm_numcores, tm_maxmemory, tm_priority, tm_activity, \
                        tm_scriptexe, tm_scriptargs, tm_extrajdl, tm_generator, tm_asourl, tm_events_per_lumi, \
-                       tm_use_parent, tm_collector \
+                       tm_use_parent, tm_collector, tm_schedd \
                        FROM tasks WHERE tm_task_status = :get_status AND ROWNUM <= :limit AND tw_name = :tw_name"""
    
     #GetUserFromID

--- a/src/python/HTCondorLocator.py
+++ b/src/python/HTCondorLocator.py
@@ -51,6 +51,7 @@ class HTCondorLocator(object):
         """
         Return a tuple (schedd, address) containing an object representing the
         remote schedd and its corresponding address.
+        Still required for OLD tasks. Remove it later TODO
         """
         info = name.split("_")
         if len(info) > 3:
@@ -75,6 +76,21 @@ class HTCondorLocator(object):
             address = self.scheddAd['MyAddress']
             schedd = htcondor.Schedd(self.scheddAd)
         return schedd, address
+
+    def getScheddObjNew(self,schedd):
+        """
+        Return a tuple (schedd, address) containing an object representing the
+        remote schedd and its corresponding address.
+        """
+        htcondor.param['COLLECTOR_HOST'] = self.getCollector()
+        coll = htcondor.Collector()
+        schedds = coll.query(htcondor.AdTypes.Schedd, 'regexp(%s, Name)' % HTCondorUtils.quote(schedd))
+        if not schedds:
+            raise Exception("Unable to locate schedd %s" % schedd)
+        self.scheddAd = schedds[0]
+        address = self.scheddAd['MyAddress']
+        scheddObj = htcondor.Schedd(self.scheddAd)
+        return scheddObj, address
 
     def getCollector(self, name="localhost"):
         """

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -165,7 +165,7 @@ SPLIT_ARG_MAP = { "LumiBased" : "lumis_per_job",
 
 
 def getCreateTimestamp(taskname):
-    return "_".join(taskname.split("_")[:2])
+    return "_".join(taskname.split(":")[:1])
 
 
 def makeLFNPrefixes(task):

--- a/src/python/TaskWorker/Actions/DagmanKiller.py
+++ b/src/python/TaskWorker/Actions/DagmanKiller.py
@@ -56,7 +56,14 @@ class DagmanKiller(TaskAction):
         if self.task['tm_collector']:
             self.backendurls['htcondorPool'] = self.task['tm_collector']
         loc = HTCondorLocator.HTCondorLocator(self.backendurls)
-        self.schedd, address = loc.getScheddObj(self.workflow) #TODO wrap this with a try/except. Copy from HTCondorDataWf
+
+        # If tm_schedd exist, this means task is submitted with new crabserver version
+        # TODO remove it later when no old tasks will be left
+        address = ""
+        if self.task['tm_schedd']:
+            self.schedd, address = loc.getScheddObjNew(self.task['tm_schedd'])
+        else:
+            self.schedd, address = loc.getScheddObj(self.workflow) #TODO wrap this with a try/except. Copy from HTCondorDataWf
 
         ad = classad.ClassAd()
         ad['foo'] = self.task['kill_ids']

--- a/src/python/TaskWorker/Actions/DagmanResubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanResubmitter.py
@@ -39,7 +39,15 @@ class DagmanResubmitter(TaskAction.TaskAction):
         if task['tm_collector']:
             self.backendurls['htcondorPool'] = task['tm_collector']
         loc = HTCondorLocator.HTCondorLocator(self.backendurls)
-        schedd, address = loc.getScheddObj(workflow) #TODO wrap
+
+        # If tm_schedd exist, this means task is submitted with new crabserver version
+        # TODO remove it later when no old tasks will be left
+        schedd = ""
+        address = ""
+        if task['tm_schedd']:
+            schedd, address = loc.getScheddObjNew(task['tm_schedd'])
+        else:
+            schedd, address = loc.getScheddObj(workflow) #TODO wrap
 
         # Release the DAG
         rootConst = "TaskType =?= \"ROOT\" && CRAB_ReqName =?= %s" % HTCondorUtils.quote(workflow)

--- a/src/python/TaskWorker/Actions/DagmanSubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanSubmitter.py
@@ -183,7 +183,15 @@ class DagmanSubmitter(TaskAction.TaskAction):
         if task['tm_collector']:
             self.backendurls['htcondorPool'] = task['tm_collector']
         loc = HTCondorLocator.HTCondorLocator(self.backendurls)
-        schedd, address = loc.getScheddObj(workflow)
+
+        # If tm_schedd exist, this means task is submitted with new crabserver version
+        # TODO remove it later when no old tasks will be left
+        address = ""
+        schedd = ""
+        if task['tm_schedd']:
+            schedd, address = loc.getScheddObjNew(task['tm_schedd'])
+        else:
+            schedd, address = loc.getScheddObj(self.workflow) #TODO wrap this with a try/except. Copy from HTCondorDataWf
 
         rootConst = 'TaskType =?= "ROOT" && CRAB_ReqName =?= %s && (isUndefined(CRAB_Attempt) || CRAB_Attempt == 0)' % HTCondorUtils.quote(workflow)
 
@@ -249,7 +257,14 @@ class DagmanSubmitter(TaskAction.TaskAction):
             if task['tm_collector']:
                 self.backendurls['htcondorPool'] = task['tm_collector']
             loc = HTCondorLocator.HTCondorLocator(self.backendurls)
-            schedd, address = loc.getScheddObj(task['tm_taskname'])
+            # If tm_schedd exist, this means task is submitted with new crabserver version
+            # TODO remove it later when no old tasks will be left
+            address = ""
+            schedd = ""
+            if task['tm_schedd']:
+                schedd, address = loc.getScheddObjNew(task['tm_schedd'])
+            else:
+                schedd, address = loc.getScheddObj(self.workflow) #TODO wrap this with a try/except. Copy from HTCondorDataWf
 
             #try to gsissh in order to create the home directory (and check if we can connect to the schedd)
             try:


### PR DESCRIPTION
This pull request also have backward compatability for tasks submitted before. After some time(2months) need to clean up. Schedd choose is done in CRABServer and will create a new issue for TaskWorker to allow change scheduler and update it in CRABServer database.
Also this pull request allows to name crab3 shedds `vocms095.cern.ch` and it is not required anymore to have `crab3test-1`.
If we will change schedd names from `crab3test-2@vocms095.cern.ch` to `vocms095.cern.ch`, we have to update all column in database which points to old name.

P.S. This pull request is not for February release.