### PR TITLE
Allow the generator to be set to pythia, and make it non-optional.

### DIFF
--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -203,6 +203,7 @@ class RESTUserWorkflow(RESTEntity):
         if method in ['PUT']:
             validate_str("activity", param, safe, RX_ACTIVITY, optional=True)
             validate_str("jobtype", param, safe, RX_JOBTYPE, optional=False)
+            # TODO this should be changed to be non-optional
             validate_str("generator", param, safe, RX_GENERATOR, optional=True)
             validate_str("eventsperlumi", param, safe, RX_LUMIEVENTS, optional=True)
             validate_str("jobsw", param, safe, RX_CMSSW, optional=False)

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -25,7 +25,7 @@ RX_PARENTLFN = re.compile(r'^(/[a-zA-Z0-9\-_\.]+/?)+$')
 RX_OUTDSLFN  = re.compile(r'^(?=.{0,500}$)/%(primDS)s/%(hnName)s-%(publishname)s-%(psethash)s/USER$' % lfnParts)
 RX_CAMPAIGN  = RX_UNIQUEWF
 RX_JOBTYPE   = re.compile(r"^(?=.{0,255}$)[A-Za-z]*$")
-RX_GENERATOR = re.compile(r'^lhe$')
+RX_GENERATOR = re.compile(r'^(lhe|pythia)$')
 RX_LUMIEVENTS = re.compile(r'^\d+$')
 RX_CMSSW     = re.compile(r"^(?=.{0,255}$)CMSSW[a-zA-Z0-9-_]*$") #using a lookahead (?=.{0,255}$) to check maximum size of the regex
 RX_ARCH      = re.compile(r"^(?=.{0,255}$)slc[0-9]{1}_[a-z0-9]+_gcc[a-z0-9]+(_[a-z0-9]+)?$")


### PR DESCRIPTION
No other code changes needed, as the currently only other generator type,
lhe, is explicitly checked for.