### PR TITLE
Append condor_rm stdout/err to RunJobs.dagman.out

### DIFF
--- a/scripts/dag_bootstrap_startup.sh
+++ b/scripts/dag_bootstrap_startup.sh
@@ -140,6 +140,14 @@ fi
 # This can be removed after all schedds are upgraded to 8.3.2
 cat > condor_rm_fix << EOF
 #!/bin/sh
+# Keep a copy of the original file descriptors open, in case
+# if HTCondor is confused when the pipe closes before the 
+# executable finishes
+exec 3<&1-
+exec 4<&2-
+# Log the "real output" separately.
+exec &>>RunJobs.dag.dagman.out
+
 set -x
 condor_qedit "\$@" JobStatusOnRelease 3
 exec condor_rm "\$@"


### PR DESCRIPTION
Currently, any error message from condor_rm is dropped onto the floor.
Let's put this into the main DAGMan logfile so its possible that
operators can understand these.