### PR TITLE
The 60307 and 60311 errors are both generic local stageout errors.

### DIFF
--- a/src/python/TaskWorker/Actions/RetryJob.py
+++ b/src/python/TaskWorker/Actions/RetryJob.py
@@ -290,6 +290,9 @@ class RetryJob(object):
         if exitCode == 60307 or exitCode == 147:
             raise RecoverableError("Error during attempted file stageout.")
 
+        if exitCode == 60311 or exitCode == 151:
+            raise RecoverableError("Error during attempted file stageout.")
+
         if exitCode:
             raise FatalError("Job wrapper finished with exit code %d.\nExit message:\n  %s" % (exitCode, exitMsg.replace('\n', '\n  ')))
 


### PR DESCRIPTION
Currently, one is a fatal failure and the other is a recoverable failure.
Since they're theoretically the same thing, we should make them both
recoverable.