### PR TITLE
Move schedd.reschedule to be used with user_proxy

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanSubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanSubmitter.py
@@ -337,11 +337,10 @@ class DagmanSubmitter(TaskAction.TaskAction):
                 if resultAds:
                     id = "%s.%s" % (resultAds[0]['ClusterId'], resultAds[0]['ProcId'])
                     schedd.edit([id], "LeaveJobInQueue", classad.ExprTree("(JobStatus == 4) && (time()-EnteredCurrentStatus < 30*86400)"))
+                    schedd.reschedule()
         results = rpipe.read()
         if results != "OK":
             raise TaskWorkerException("Failure when submitting task to scheduler. Error reason: '%s'" % results)
-
-        schedd.reschedule()
 
 
     def sendDashboardJobs(self, params, info):


### PR DESCRIPTION
reschedule requires authentication, so moving this after schedd.edit and to be used with HTCondorUtils.AuthenticatedSubprocess. reschedule is just an optimization - otherwise if we don`t have this, it may take up to 5 minutes about new jobs