### PR TITLE
Renew remote proxies with clean environment

### DIFF
--- a/src/python/TaskWorker/Actions/Recurring/RenewRemoteProxies.py
+++ b/src/python/TaskWorker/Actions/Recurring/RenewRemoteProxies.py
@@ -80,7 +80,8 @@ class CRAB3ProxyRenewer(object):
                     'server_cert': self.config.MyProxy.serverhostcert,
                     'serverDN': self.config.MyProxy.serverdn,
                     'uisource': getattr(self.config.MyProxy, 'uisource', ''),
-                    'credServerPath': self.config.MyProxy.credpath,}
+                    'credServerPath': self.config.MyProxy.credpath,
+                    'cleanEnvironment' : getattr(self.config.MyProxy, 'cleanEnvironment', False)}
         proxy = Proxy(proxycfg)
         userproxy = proxy.getProxyFilename(serverRenewer=True)
         proxy.logonRenewMyProxy()


### PR DESCRIPTION
```
 error: myproxy-logon: /data/srv/TaskManager/3.3.13.rc3/slc6_amd64_gcc481/external/condor/8.3.1-comp/lib/condor/libglobus_common.so.0: no version information available (required by myproxy-logon)
myproxy-logon: /data/srv/TaskManager/3.3.13.rc3/slc6_amd64_gcc481/external/condor/8.3.1-comp/lib/condor/libglobus_common.so.0: no version information available (required by /usr/lib64/libmyproxy.so.6)

```