### PR TITLE
Remove reschedule as it is not needed anymore

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanSubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanSubmitter.py
@@ -337,7 +337,6 @@ class DagmanSubmitter(TaskAction.TaskAction):
                 if resultAds:
                     id = "%s.%s" % (resultAds[0]['ClusterId'], resultAds[0]['ProcId'])
                     schedd.edit([id], "LeaveJobInQueue", classad.ExprTree("(JobStatus == 4) && (time()-EnteredCurrentStatus < 30*86400)"))
-                    schedd.reschedule()
         results = rpipe.read()
         if results != "OK":
             raise TaskWorkerException("Failure when submitting task to scheduler. Error reason: '%s'" % results)


### PR DESCRIPTION
After discussion with @bbockelm : Turns out, it already calls reschedule() in the 8.3.x series