### PR TITLE
Scram project time identification

### DIFF
--- a/scripts/CMSRunAnalysis.py
+++ b/scripts/CMSRunAnalysis.py
@@ -825,6 +825,8 @@ if __name__ == "__main__":
             directory = os.getcwd(),
             architecture = opts.scramArch,
             )
+            
+        print "==== SCRAM Obj CREATED at %s ====" % time.asctime(time.gmtime())
         if scram.project() or scram.runtime(): #if any of the two commands fail...
             msg = scram.diagnostic()
             handleException("FAILED", EC_CMSMissingSoftware, 'Error setting CMSSW environment: %s' % msg)
@@ -834,9 +836,11 @@ if __name__ == "__main__":
         try:
             jobExitCode = None
             if opts.scriptExe=='None':
+                print "==== CMSSW JOB Execution started at %s ====" % time.asctime(time.gmtime())
                 cmssw = executeCMSSWStack(opts, scram)
                 jobExitCode = cmssw.step.execution.exitStatus
             else:
+                print "==== ScriptEXE Execution started at %s ====" % time.asctime(time.gmtime())
                 jobExitCode = executeScriptExe(opts, scram)
         except:
             print "==== CMSSW Stack Execution FAILED at %s ====" % time.asctime(time.gmtime())


### PR DESCRIPTION
Print 3 more lines, which will allow identify where sometimes same jobs are running ~20h and while they should run only ~1h. I already Identified that problem is somewhere here, but want to double check with diff archs from some users and HC tests. I will not need to run any jobs and I can grep this all information from users log files.