### PR TITLE
touch jobReport.json.$CRAB_Id

### DIFF
--- a/scripts/gWMS-CMSRunAnalysis.sh
+++ b/scripts/gWMS-CMSRunAnalysis.sh
@@ -53,6 +53,8 @@ then
    echo "======== HTCONDOR JOB SUMMARY at $(TZ=GMT date) FINISH ========"
 fi
 
+touch jobReport.json.$CRAB_Id
+
 echo "======== PROXY INFORMATION START at $(TZ=GMT date) ========"
 voms-proxy-info -all
 echo "======== PROXY INFORMATION FINISH at $(TZ=GMT date) ========"


### PR DESCRIPTION
This is needed for possibility to return log files if periodic remove is called (Removed due to memory).

If this file is not touched, error message:
```
Hold reason: Error from glidein_21858@wn39.cism.ucl.ac.be: STARTER at 10.1.3.39 failed to send file(s) to <128.142.242.250:4080>: error reading from /scratch/condor/execu
te/dir_21754/CREAM692385075/glide_cDFQ4w/execute/dir_29290/jobReport.json.194: (errno 2) No such file or directory; SHADOW failed to receive file(s) from <130.104.133.233:43601>
```