### PR TITLE
Put lfn field in existng ASO docs back to source lfn.

### DIFF
--- a/scripts/cmscp.py
+++ b/scripts/cmscp.py
@@ -648,6 +648,7 @@ def inject_to_aso(file_transfer_info):
     doc_new_info = {'state'           : 'new',
                     'source'          : source_site,
                     'destination'     : G_JOB_AD['CRAB_AsyncDest'],
+                    'lfn'             : file_transfer_info['source']['lfn'],
                     'checksums'       : checksums,
                     'size'            : size,
                     # The following four times - and how they're calculated - makes no sense to me. BB


### PR DESCRIPTION
Needed because ASO removes the "/temp" part of the LFN when the transfer is marked as 'done'.