### PR TITLE
Ad parameter CRAB_DBSUrl is not there anymore, now it is CRAB_DBSURL.

### DIFF
--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -527,7 +527,7 @@ class ASOServerJob(object):
                            'user'                    : str(self.job_ad['CRAB_UserHN']),
                            'group'                   : group,
                            'role'                    : role,
-                           'dbs_url'                 : str(self.job_ad['CRAB_DBSUrl']),
+                           'dbs_url'                 : str(self.job_ad['CRAB_DBSURL']),
                            'workflow'                : self.reqname,
                            'jobid'                   : self.count,
                            'publication_state'       : 'not_published',
@@ -1500,7 +1500,7 @@ class PostJob():
         """
         required_job_ad_attrs = ['CRAB_ASOURL',
                                  'CRAB_AsyncDest',
-                                 'CRAB_DBSUrl',
+                                 'CRAB_DBSURL',
                                  'CRAB_InputData',
                                  'CRAB_JobSW',
                                  'CRAB_Publish',

--- a/src/python/TaskWorker/TaskManagerBootstrap.py
+++ b/src/python/TaskWorker/TaskManagerBootstrap.py
@@ -49,7 +49,7 @@ def bootstrap():
     
     ad['tm_taskname'] = ad.eval("CRAB_Workflow")
     ad['tm_split_algo'] = ad.eval("CRAB_SplitAlgo")
-    ad['tm_dbs_url'] = ad.eval("CRAB_DBSUrl")
+    ad['tm_dbs_url'] = ad.eval("CRAB_DBSURL")
     ad['tm_input_dataset'] = ad.eval("CRAB_InputData")
     ad['tm_outfiles'] = HTCondorUtils.unquote(ad.eval("CRAB_AdditionalOutputFiles"))
     ad['tm_tfile_outfiles'] = HTCondorUtils.unquote(ad.eval("CRAB_TFileOutputFiles"))


### PR DESCRIPTION
I removed CRAB_DBSUrl in this commit https://github.com/AndresTanasijczuk/CRABServer/commit/2be175de3ae0088f628d6e481ba8c46fdda73854 because we already have CRAB_DBSURL, and missed to update it in a few places.