### PR TITLE
Move Task DB parameters in tm_arguments to separate columns. Fixes #4591.

### DIFF
--- a/etc/updateOracle.sql
+++ b/etc/updateOracle.sql
@@ -45,3 +45,11 @@ ALTER TABLE tasks ADD (tm_schedd VARCHAR(255));
 
 --Changes that will be needed for version 3.4.15
 alter table tasks add (tm_dry_run VARCHAR(1)); --for issue ##4462
+
+
+alter table tasks add (tm_user_files CLOB DEFAULT '[]');
+alter table tasks add (tm_transfer_outputs VARCHAR(1));
+alter table tasks add (tm_output_lfn VARCHAR(1000));
+alter table tasks add (tm_ignore_locality VARCHAR(1));
+alter table tasks add (tm_fail_limit NUMBER(38));
+alter table tasks add (tm_one_event_mode VARCHAR(1));

--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -185,25 +185,25 @@ class DataWorkflow(object):
         username = cherrypy.request.user['login']
         dbSerializer = str
 
-        if numcores == None: numcores = 1
-        if maxjobruntime == None: maxjobruntime = 1315
-        if maxmemory == None: maxmemory = 2000
-        if priority == None: priority = 10
+        ## If these parameters were not set in the submission request, give them
+        ## predefined default values.
+        if maxjobruntime is None:
+            maxjobruntime = 1315
+        if maxmemory is None:
+            maxmemory = 2000
+        if numcores is None:
+            numcores = 1
+        if priority is None:
+            priority = 10
 
         if not asourl:
             asourl = self.centralcfg.centralconfig.get("backend-urls", {}).get("ASOURL", "")
             if type(asourl)==list:
                 asourl = random.choice(asourl)
 
-        arguments = { \
-            'oneEventMode' : 'T' if oneEventMode else 'F',
-            'lfn' : lfn,
-            'saveoutput' : 'T' if saveoutput else 'F',
-            'faillimit' : faillimit,
-            'ignorelocality' : 'T' if ignorelocality else 'F',
-            'userfiles' : userfiles,
-        }
+        arguments = {}
 
+        ## Insert this new task into the Tasks DB.
         self.api.modify(self.Task.New_sql,
                             task_name       = [requestname],
                             task_activity   = [activity],
@@ -255,7 +255,13 @@ class DataWorkflow(object):
                             asourl          = [asourl],
                             collector       = [collector],
                             schedd_name     = [schedd_name],
-                            dry_run         = ['T' if dryrun else 'F']
+                            dry_run         = ['T' if dryrun else 'F'],
+                            user_files       = [dbSerializer(userfiles)],
+                            transfer_outputs = ['T' if saveoutput else 'F'],
+                            output_lfn       = [lfn],
+                            ignore_locality  = ['T' if ignorelocality else 'F'],
+                            fail_limit       = [faillimit],
+                            one_event_mode   = ['T' if oneEventMode else 'F']
         )
 
         return [{'RequestName': requestname}]

--- a/src/python/CRABInterface/RESTWorkerWorkflow.py
+++ b/src/python/CRABInterface/RESTWorkerWorkflow.py
@@ -238,3 +238,9 @@ class Task(dict):
         self['tm_collector'] = task[48]
         self['tm_schedd'] = task[49]
         self['tm_dry_run'] = task[50]
+        self['tm_user_files'] = literal_eval(task[51] if ( task[51] is None or isinstance(task[51],str) ) else task[51].read())
+        self['tm_transfer_outputs'] = task[52]
+        self['tm_output_lfn'] = task[53]
+        self['tm_ignore_locality'] = task[54]
+        self['tm_fail_limit'] = task[55]
+        self['tm_one_event_mode'] = task[56]

--- a/src/python/Databases/TaskDB/MySQL/Create.py
+++ b/src/python/Databases/TaskDB/MySQL/Create.py
@@ -83,10 +83,19 @@ class Create(DBCreator):
         tm_collector VARCHAR(1000),
         tm_schedd VARCHAR(255),
         tm_dry_run VARCHAR(1),
+        tm_user_files LONGTEXT DEFAULT '[]',
+        tm_transfer_outputs VARCHAR(1),
+        tm_output_lfn VARCHAR(1000),
+        tm_ignore_locality VARCHAR(1),
+        tm_fail_limit BIGINT,
+        tm_one_event_mode VARCHAR(1),
         CONSTRAINT taskname_pk PRIMARY KEY(tm_taskname),
         CONSTRAINT check_tm_publication CHECK (tm_publication IN ('T', 'F')),
         CONSTRAINT check_tm_dry_run CHECK (tm_dry_run IN ('T', 'F')),
-        CONSTRAINT check_tm_save_logs CHECK (tm_save_logs IN ('T', 'F'))
+        CONSTRAINT check_tm_save_logs CHECK (tm_save_logs IN ('T', 'F')),
+        CONSTRAINT check_tm_transfer_outputs CHECK (tm_transfer_outputs IN ('T', 'F')),
+        CONSTRAINT check_tm_ignore_locality CHECK (tm_ignore_locality IN ('T', 'F')),
+        CONSTRAINT check_tm_one_event_mode CHECK (tm_one_event_mode IN ('T', 'F'))
         ) ENGINE=InnoDB 
         """
         self.create['c_jobgroups'] = """

--- a/src/python/Databases/TaskDB/MySQL/Task/Task.py
+++ b/src/python/Databases/TaskDB/MySQL/Task/Task.py
@@ -10,15 +10,17 @@ class Task(object):
     GetInjectedTasks_sql = "SELECT tm_taskname, tm_task_status FROM tasks WHERE \
     		        tm_task_status = 'INJECTED'"
 
-    GetKillTasks_sql = """SELECT tm_taskname, panda_jobset_id, tm_task_status, tm_start_time, \
-                   tm_start_injection, tm_end_injection, tm_task_failure, tm_job_sw, \
-   		   tm_job_arch, tm_input_dataset, tm_site_whitelist, tm_site_blacklist, \
-   		   tm_split_algo, tm_split_args, tm_totalunits, tm_user_sandbox, tm_cache_url, \
-   		   tm_username, tm_user_dn, tm_user_vo, tm_user_role, tm_user_group, \
-   		   tm_publish_name, tm_asyncdest, tm_dbs_url, tm_publish_dbs_url, \
-   		   tm_publication, tm_outfiles, tm_tfile_outfiles, tm_edm_outfiles, \
-                   tm_job_type, tm_arguments, panda_resubmitted_jobs, \
-   		   tm_save_logs, tm_user_infiles FROM tasks WHERE tm_task_status = 'KILL' """
+    GetKillTasks_sql = """SELECT tm_taskname, panda_jobset_id, tm_task_status, \
+                   tm_start_time, tm_start_injection, tm_end_injection, \
+                   tm_task_failure, tm_job_sw, tm_job_arch, tm_input_dataset, \
+                   tm_site_whitelist, tm_site_blacklist, tm_split_algo, tm_split_args, \
+                   tm_totalunits, tm_user_sandbox, tm_cache_url, tm_username, tm_user_dn, tm_user_vo, \
+                   tm_user_role, tm_user_group, tm_publish_name, tm_asyncdest, tm_dbs_url, \
+                   tm_publish_dbs_url, tm_publication, tm_outfiles, tm_tfile_outfiles, tm_edm_outfiles, \
+                   tm_job_type, tm_arguments, panda_resubmitted_jobs, tm_save_logs, \
+                   tm_user_infiles, tw_name, tm_dry_run, \
+                   tm_user_files, tm_transfer_outputs, tm_output_lfn, tm_ignore_locality, tm_fail_limit, tm_one_event_mode \
+                   FROM tasks WHERE tm_task_status = 'KILL' """
 
     GetNewResubmit_sql = """SELECT tm_taskname, panda_jobset_id, tm_task_status, \
                    tm_start_time, tm_start_injection, tm_end_injection, \
@@ -28,7 +30,8 @@ class Task(object):
                    tm_user_role, tm_user_group, tm_publish_name, tm_asyncdest, tm_dbs_url, \
                    tm_publish_dbs_url, tm_publication, tm_outfiles, tm_tfile_outfiles, tm_edm_outfiles, \
                    tm_job_type, tm_arguments, panda_resubmitted_jobs, tm_save_logs, \
-                   tm_user_infiles, tw_name \
+                   tm_user_infiles, tw_name, tm_dry_run, \
+                   tm_user_files, tm_transfer_outputs, tm_output_lfn, tm_ignore_locality, tm_fail_limit, tm_one_event_mode \
                    FROM tasks WHERE tm_task_status = 'NEW' OR tm_task_status = 'RESUBMIT' """
 
     GetReadyTasks_sql = """SELECT tm_taskname, panda_jobset_id, tm_task_status, \
@@ -39,10 +42,9 @@ class Task(object):
                    tm_user_role, tm_user_group, tm_publish_name, tm_asyncdest, tm_dbs_url, \
                    tm_publish_dbs_url, tm_publication, tm_outfiles, tm_tfile_outfiles, tm_edm_outfiles, \
                    tm_job_type, tm_arguments, panda_resubmitted_jobs, tm_save_logs, \
-                   tm_user_infiles, tw_name, tm_dry_run \
-                   FROM tasks \
-                   WHERE tm_task_status = %(get_status)s \
-                   AND tw_name = %(tw_name)s limit %(limit)s """
+                   tm_user_infiles, tw_name, tm_dry_run, \
+                   tm_user_files, tm_transfer_outputs, tm_output_lfn, tm_ignore_locality, tm_fail_limit, tm_one_event_mode \
+                   FROM tasks WHERE tm_task_status = %(get_status)s AND tw_name = %(tw_name)s limit %(limit)s """
 
     GetUserFromID_sql = "SELECT tm_username FROM tasks WHERE tm_taskname=%(taskname)s"
 
@@ -59,7 +61,9 @@ class Task(object):
    	       tm_username, tm_user_dn, tm_user_vo, tm_user_role, tm_user_group, tm_publish_name, \
    	       tm_asyncdest, tm_dbs_url, tm_publish_dbs_url, tm_publication, tm_outfiles, \
    	       tm_tfile_outfiles, tm_edm_outfiles, tm_job_type, tm_arguments,\
-               panda_resubmitted_jobs, tm_save_logs, tm_user_infiles, tm_maxjobruntime, tm_numcores, tm_maxmemory, tm_priority, tm_dry_run) \
+               panda_resubmitted_jobs, tm_save_logs, tm_user_infiles, tm_maxjobruntime, \
+               tm_numcores, tm_maxmemory, tm_priority, tm_dry_run, \
+               tm_user_files, tm_transfer_outputs, tm_output_lfn, tm_ignore_locality, tm_fail_limit, tm_one_event_mode) \
                VALUES (%(task_name)s, %(jobset_id)s, upper(%(task_status)s), UTC_TIMESTAMP(), \
    	       %(task_failure)s, %(job_sw)s, %(job_arch)s, %(input_dataset)s, %(site_whitelist)s, \
    	       %(site_blacklist)s, %(split_algo)s, %(split_args)s, %(total_units)s, \
@@ -67,7 +71,8 @@ class Task(object):
    	       %(user_group)s, %(publish_name)s, %(asyncdest)s, %(dbs_url)s, %(publish_dbs_url)s, \
                %(publication)s, %(outfiles)s, %(tfile_outfiles)s, %(edm_outfiles)s, \
    	       %(job_type)s, %(arguments)s, %(resubmitted_jobs)s, %(save_logs)s, %(user_infiles)s, %(maxjobruntime)s, \
-           %(numcores)s, %(maxmemory)s, %(priority)s, %(dry_run)s)"
+               %(numcores)s, %(maxmemory)s, %(priority)s, %(dry_run)s, \
+               %(user_files)s, %(transfer_outputs)s, %(output_lfn)s, %(ignore_locality)s, %(fail_limit)s, %(one_event_mode)s)"
 
     SetArgumentsTask_sql = "UPDATE tasks SET tm_arguments = %(arguments)s WHERE tm_taskname = %(taskname)s"
 

--- a/src/python/Databases/TaskDB/Oracle/Create.py
+++ b/src/python/Databases/TaskDB/Oracle/Create.py
@@ -86,10 +86,19 @@ class Create(DBCreator):
         tm_collector VARCHAR(1000),
         tm_schedd VARCHAR(255),
         tm_dry_run VARCHAR(1),
+        tm_user_files CLOB DEFAULT '[]',
+        tm_transfer_outputs VARCHAR(1),
+        tm_output_lfn VARCHAR(1000),
+        tm_ignore_locality VARCHAR(1),
+        tm_fail_limit NUMBER(38),
+        tm_one_event_mode VARCHAR(1),
         CONSTRAINT taskname_pk PRIMARY KEY(tm_taskname),
         CONSTRAINT check_tm_publication CHECK (tm_publication IN ('T', 'F')),
         CONSTRAINT check_tm_save_logs CHECK (tm_save_logs IN ('T', 'F')),
-        CONSTRAINT check_tm_dry_run CHECK (tm_dry_run IN ('T', 'F'))
+        CONSTRAINT check_tm_dry_run CHECK (tm_dry_run IN ('T', 'F')),
+        CONSTRAINT check_tm_transfer_outputs CHECK (tm_transfer_outputs IN ('T', 'F')),
+        CONSTRAINT check_tm_ignore_locality CHECK (tm_ignore_locality IN ('T', 'F')),
+        CONSTRAINT check_tm_one_event_mode CHECK (tm_one_event_mode IN ('T', 'F'))
         )
         """
         self.create['c_jobgroups'] = """

--- a/src/python/Databases/TaskDB/Oracle/Task/Task.py
+++ b/src/python/Databases/TaskDB/Oracle/Task/Task.py
@@ -18,8 +18,8 @@ class Task(object):
              FROM tasks WHERE tm_taskname=:taskname"
 
     IDAll_sql = "SELECT tm_taskname, tm_task_status, tm_user_role, tm_user_group, \
-             tm_save_logs, tm_username, \
-             tm_user_dn FROM tasks WHERE tm_taskname = :taskname"
+             tm_save_logs, tm_username, tm_user_dn \
+             FROM tasks WHERE tm_taskname = :taskname"
 
     #INSERTED BY ERIC SUMMER STUDENT
     ALLUSER_sql = "SELECT DISTINCT(tm_username) FROM tasks"
@@ -42,16 +42,18 @@ class Task(object):
               tm_job_arch, tm_input_dataset, tm_use_parent, tm_site_whitelist, tm_site_blacklist, \
               tm_split_algo, tm_split_args, tm_totalunits, tm_user_sandbox, tm_cache_url, tm_username, tm_user_dn, \
               tm_user_vo, tm_user_role, tm_user_group, tm_publish_name, tm_asyncdest, tm_dbs_url, tm_publish_dbs_url, \
-              tm_publication, tm_outfiles, tm_tfile_outfiles, tm_edm_outfiles, tm_job_type, tm_generator, tm_arguments,\
-              panda_resubmitted_jobs, tm_save_logs, tm_user_infiles, tm_maxjobruntime, tm_numcores, tm_maxmemory, tm_priority,\
-              tm_scriptexe, tm_scriptargs, tm_extrajdl, tm_asourl, tm_events_per_lumi, tm_collector, tm_schedd, tm_dry_run) \
+              tm_publication, tm_outfiles, tm_tfile_outfiles, tm_edm_outfiles, tm_job_type, tm_generator, tm_arguments, \
+              panda_resubmitted_jobs, tm_save_logs, tm_user_infiles, tm_maxjobruntime, tm_numcores, tm_maxmemory, tm_priority, \
+              tm_scriptexe, tm_scriptargs, tm_extrajdl, tm_asourl, tm_events_per_lumi, tm_collector, tm_schedd, tm_dry_run, \
+              tm_user_files, tm_transfer_outputs, tm_output_lfn, tm_ignore_locality, tm_fail_limit, tm_one_event_mode) \
               VALUES (:task_name, :task_activity, :jobset_id, upper(:task_status), SYS_EXTRACT_UTC(SYSTIMESTAMP), :task_failure, :job_sw, \
               :job_arch, :input_dataset, :use_parent, :site_whitelist, :site_blacklist, :split_algo, :split_args, \
               :total_units, :user_sandbox, :cache_url, :username, :user_dn, \
               :user_vo, :user_role, :user_group, :publish_name, :asyncdest, :dbs_url, :publish_dbs_url, \
-              :publication, :outfiles, :tfile_outfiles, :edm_outfiles, :job_type, :generator, :arguments,\
-              :resubmitted_jobs, :save_logs, :user_infiles, :maxjobruntime, :numcores, :maxmemory, :priority,\
-              :scriptexe, :scriptargs, :extrajdl, :asourl, :events_per_lumi, :collector, :schedd_name, :dry_run)"
+              :publication, :outfiles, :tfile_outfiles, :edm_outfiles, :job_type, :generator, :arguments, \
+              :resubmitted_jobs, :save_logs, :user_infiles, :maxjobruntime, :numcores, :maxmemory, :priority, \
+              :scriptexe, :scriptargs, :extrajdl, :asourl, :events_per_lumi, :collector, :schedd_name, :dry_run, \
+              :user_files, :transfer_outputs, :output_lfn, :ignore_locality, :fail_limit, :one_event_mode)"
 
     #GetFailedTasks
     GetFailedTasks_sql = "SELECT tm_taskname, tm_task_status FROM tasks WHERE tm_task_status = 'FAILED'"
@@ -67,7 +69,11 @@ class Task(object):
                        tm_totalunits, tm_user_sandbox, tm_cache_url, tm_username, tm_user_dn, tm_user_vo, \
                        tm_user_role, tm_user_group, tm_publish_name, tm_asyncdest, tm_dbs_url, \
                        tm_publish_dbs_url, tm_publication, tm_outfiles, tm_tfile_outfiles, tm_edm_outfiles, \
-                       tm_job_type, tm_arguments, panda_resubmitted_jobs, tm_save_logs, tm_user_infiles, tm_asourl, tm_collector, tm_schedd \
+                       tm_job_type, tm_arguments, panda_resubmitted_jobs, tm_save_logs, \
+                       tm_user_infiles, tw_name, tm_maxjobruntime, tm_numcores, tm_maxmemory, tm_priority, tm_activity, \
+                       tm_scriptexe, tm_scriptargs, tm_extrajdl, tm_generator, tm_asourl, tm_events_per_lumi, \
+                       tm_use_parent, tm_collector, tm_schedd, tm_dry_run, \
+                       tm_user_files, tm_transfer_outputs, tm_output_lfn, tm_ignore_locality, tm_fail_limit, tm_one_event_mode \
                        FROM tasks WHERE tm_task_status = 'KILL' """
 
     #GetNewResubmit
@@ -79,7 +85,10 @@ class Task(object):
                        tm_user_role, tm_user_group, tm_publish_name, tm_asyncdest, tm_dbs_url, \
                        tm_publish_dbs_url, tm_publication, tm_outfiles, tm_tfile_outfiles, tm_edm_outfiles, \
                        tm_job_type, tm_arguments, panda_resubmitted_jobs, tm_save_logs, \
-                       tm_user_infiles, tw_name, tm_asourl, tm_collector, tm_schedd \
+                       tm_user_infiles, tw_name, tm_maxjobruntime, tm_numcores, tm_maxmemory, tm_priority, tm_activity, \
+                       tm_scriptexe, tm_scriptargs, tm_extrajdl, tm_generator, tm_asourl, tm_events_per_lumi, \
+                       tm_use_parent, tm_collector, tm_schedd, tm_dry_run, \
+                       tm_user_files, tm_transfer_outputs, tm_output_lfn, tm_ignore_locality, tm_fail_limit, tm_one_event_mode \
                        FROM tasks WHERE tm_task_status = 'NEW' OR tm_task_status = 'RESUBMIT' """
 
     #GetReadyTasks
@@ -93,7 +102,8 @@ class Task(object):
                        tm_job_type, tm_arguments, panda_resubmitted_jobs, tm_save_logs, \
                        tm_user_infiles, tw_name, tm_maxjobruntime, tm_numcores, tm_maxmemory, tm_priority, tm_activity, \
                        tm_scriptexe, tm_scriptargs, tm_extrajdl, tm_generator, tm_asourl, tm_events_per_lumi, \
-                       tm_use_parent, tm_collector, tm_schedd, tm_dry_run \
+                       tm_use_parent, tm_collector, tm_schedd, tm_dry_run, \
+                       tm_user_files, tm_transfer_outputs, tm_output_lfn, tm_ignore_locality, tm_fail_limit, tm_one_event_mode \
                        FROM tasks WHERE tm_task_status = :get_status AND ROWNUM <= :limit AND tw_name = :tw_name"""
 
     #GetUserFromID

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -177,7 +177,10 @@ def makeLFNPrefixes(task):
         hash_input += "," + task['tm_user_group']
     if 'tm_user_role' in task and task['tm_user_role']:
         hash_input += "," + task['tm_user_role']
-    lfn = task.get('tm_arguments', {}).get('lfn', '')
+    lfn = task['tm_output_lfn'] if 'tm_output_lfn' in task else ''
+    ## For backward compatibility: old tasks were putting the outLFN in tm_arguments.
+    if not lfn:
+        lfn = task.get('tm_arguments', {}).get('lfn', '')
     hash = hashlib.sha1(hash_input).hexdigest()
     user = task['tm_username']
     tmp_user = "%s.%s" % (user, hash)
@@ -400,7 +403,10 @@ class DagmanCreator(TaskAction.TaskAction):
         info['addoutputfiles'] = task['tm_outfiles']
         info['tfileoutfiles'] = task['tm_tfile_outfiles']
         info['edmoutfiles'] = task['tm_edm_outfiles']
-        info['oneEventMode'] = 1 if task.get('tm_arguments', {}).get('oneEventMode', 'F') == 'T' else 0
+        if ('tm_one_event_mode' in info) and info['tm_one_event_mode'] is not None:
+            info['oneEventMode'] = 1 if info['tm_one_event_mode'] == 'T' else 0
+        else: ## For backward compatilibity only.
+            info['oneEventMode'] = 1 if task.get('tm_arguments', {}).get('oneEventMode', 'F') == 'T' else 0
         info['ASOURL'] = task['tm_asourl']
         info['taskType'] = self.getDashboardTaskType()
         info['worker_name'] = getattr(self.config.TaskWorker, 'name', 'unknown')
@@ -412,10 +418,16 @@ class DagmanCreator(TaskAction.TaskAction):
         # TODO: pass through these correctly.
         info['runs'] = []
         info['lumis'] = []
-        info['saveoutput'] = 1 if task.get('tm_arguments', {}).get('saveoutput', 'T') == 'T' else 0
+        if ('tm_transfer_outputs' in info) and info['tm_transfer_outputs'] is not None:
+            info['saveoutput'] = 1 if info['tm_transfer_outputs'] == 'T' else 0
+        else: ## For backward compatilibity only.
+            info['saveoutput'] = 1 if task.get('tm_arguments', {}).get('saveoutput', 'T') == 'T' else 0
         info['accounting_group'] = 'analysis.%s' % info['userhn']
         info = transform_strings(info)
-        info['faillimit'] = task.get('tm_arguments', {}).get('faillimit')
+        if ('tm_fail_limit' in info): ## We are not using faillimit currently, so it should be save to just ask if 'tm_fail_limit' is in info.
+            info['faillimit'] = info['tm_fail_limit']
+        else: ## For backward compatilibity only.
+            info['faillimit'] = task.get('tm_arguments', {}).get('faillimit')
         info['extra_jdl'] = '\n'.join(literal_eval(task['tm_extrajdl']))
         if info['jobarch_flatten'].startswith("slc6_"):
             info['opsys_req'] = '&& (GLIDEIN_REQUIRED_OS=?="rhel6" || OpSysMajorVer =?= 6)'
@@ -566,8 +578,10 @@ class DagmanCreator(TaskAction.TaskAction):
             jobs = jobgroup.getJobs()
 
             whitelist = set(kwargs['task']['tm_site_whitelist'])
-
-            ignorelocality = kwargs['task'].get('tm_arguments', {}).get('ignorelocality', 'F') == 'T'
+            if 'tm_ignore_locality' in kwargs['task'] and kwargs['task']['tm_ignore_locality'] is not None:
+                ignorelocality = kwargs['task']['tm_ignore_locality'] == 'T'
+            else: ## For backward compatibility only.
+                ignorelocality = kwargs['task'].get('tm_arguments', {}).get('ignorelocality', 'F') == 'T'
             if not jobs:
                 possiblesites = []
             elif ignorelocality:

--- a/src/python/TaskWorker/Actions/Handler.py
+++ b/src/python/TaskWorker/Actions/Handler.py
@@ -128,7 +128,9 @@ def handleNewTask(resthost, resturi, config, task, procnum, *args, **kwargs):
     handler = TaskHandler(task, procnum)
     handler.addWork( MyProxyLogon(config=config, server=server, resturi=resturi, procnum=procnum, myproxylen=60*60*24) )
     if task['tm_job_type'] == 'Analysis': 
-        if task.get('tm_arguments', {}).get('userfiles'):
+        if task.get('tm_user_files'):
+            handler.addWork( UserDataDiscovery(config=config, server=server, resturi=resturi, procnum=procnum) )
+        elif task.get('tm_arguments', {}).get('userfiles'): ## For backward compatibility only.
             handler.addWork( UserDataDiscovery(config=config, server=server, resturi=resturi, procnum=procnum) )
         else:
             handler.addWork( DBSDataDiscovery(config=config, server=server, resturi=resturi, procnum=procnum) )

--- a/src/python/TaskWorker/Actions/UserDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/UserDataDiscovery.py
@@ -24,7 +24,10 @@ class UserDataDiscovery(DataDiscovery):
     def execute(self, *args, **kwargs):
         self.logger.info("Data discovery and splitting for %s using user-provided files" % kwargs['task']['tm_taskname'])
 
-        userfiles = kwargs['task']['tm_arguments'].get('userfiles')
+        if 'tm_user_files' in kwargs['task'] and kwargs['task']['tm_user_files']:
+            userfiles = kwargs['task']['tm_user_files']
+        else: ## For backward compatibility only.
+            userfiles = kwargs['task']['tm_arguments'].get('userfiles')
         splitting = kwargs['task']['tm_split_algo']
         total_units = kwargs['task']['tm_totalunits']
         if not userfiles or splitting != 'FileBased':


### PR DESCRIPTION
To test this I did:

1- updated the tasks table in the oracle database
2- turned off the TW
3- injected a task using the unpatched CRAB server
4- updated to the patched CRAB server
5- injected another similar task
6- turned on the TW

Both tasks were submitted (and completed) fine.
And I could see that both use the correct values for the parameters. 
I tried also changing some of the values (outLFN, ignoreLocality, transferOutputs) and see again that they are correctly read.
I also did crab status for old/new tasks and it woks fine.