### PR TITLE
Remove jobs which proxy expired.

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -145,11 +145,12 @@ periodic_remove = ((JobStatus =?= 5) && (time() - EnteredCurrentStatus > 7*60)) 
                   ((JobStatus =?= 2) && ( \
                      (MemoryUsage > RequestMemory) || \
                      (MaxWallTimeMins*60 < time() - EnteredCurrentStatus) || \
-                     (DiskUsage > 100000000) \
-                  ))
+                     (DiskUsage > 100000000))) || \
+                  ((JobStatus =?= 1) && (time() > (x509UserProxyExpiration + 86400)))
 +PeriodicRemoveReason = ifThenElse(MemoryUsage > RequestMemory, "Removed due to memory use", \
                           ifThenElse(MaxWallTimeMins*60 < time() - EnteredCurrentStatus, "Removed due to wall clock limit", \
-                            ifThenElse(DiskUsage > 100000000, "Removed due to disk usage", "Removed due to job being held")))
+                            ifThenElse(DiskUsage > 100000000, "Removed due to disk usage", \
+                              ifThenElse(time() > x509UserProxyExpiration, "Removed job due to proxy expiration", "Removed due to job being held"))))
 %(extra_jdl)s
 queue
 """

--- a/src/python/TaskWorker/Actions/Recurring/RenewRemoteProxies.py
+++ b/src/python/TaskWorker/Actions/Recurring/RenewRemoteProxies.py
@@ -111,7 +111,7 @@ class CRAB3ProxyRenewer(object):
         self.logger.info("Schedd found at %s" % schedd_ad['MyAddress'])
         schedd = htcondor.Schedd(schedd_ad)
         self.logger.info("Querying schedd for CRAB3 tasks.")
-        task_ads = list(schedd.xquery('JobStatus =!= 4 && TaskType =?= "ROOT"', QUERY_ATTRS))
+        task_ads = list(schedd.xquery('JobStatus =!= 4 && TaskType =?= "ROOT" && CRAB_HC =!= "True"', QUERY_ATTRS))
         self.logger.info("There were %d tasks found." % len(task_ads))
         ads = {}
         now = time.time()


### PR DESCRIPTION
This will remove jobs if proxy is expired, but will keep task on scheduler.
Also do not update HC proxy as it is not needed and HC jobs should finish in 24h