### PR TITLE
Use blacklist from dashboard. Fixes #4657

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -560,19 +560,14 @@ class DagmanCreator(TaskAction.TaskAction):
 
         os.chmod("CMSRunAnalysis.sh", 0755)
 
-        # This config setting acts as a global black / white list
-        global_whitelist = set()
+        # This config setting acts as a global black list
         global_blacklist = set()
-        if hasattr(self.config.Sites, 'available'):
-            global_whitelist = set(self.config.Sites.available)
-        if hasattr(self.config.Sites, 'banned'):
-            global_blacklist = set(self.config.Sites.banned)
+
         # This is needed for Site Metrics
         # It should not block any site for Site Metrics and if needed for other activities
         # self.config.TaskWorker.ActivitiesToRunEverywhere = ['hctest', 'hcdev']
         if hasattr(self.config.TaskWorker, 'ActivitiesToRunEverywhere') and \
                    kwargs['task']['tm_activity'] in self.config.TaskWorker.ActivitiesToRunEverywhere:
-            global_whitelist = set()
             global_blacklist = set()
 
         sitead = classad.ClassAd()
@@ -588,7 +583,7 @@ class DagmanCreator(TaskAction.TaskAction):
             if not jobs:
                 possiblesites = []
             elif ignorelocality:
-                possiblesites = global_whitelist | whitelist
+                possiblesites = whitelist
                 if not possiblesites:
                     sbj = SiteDB.SiteDBJSON({"key":self.config.TaskWorker.cmskey,
                           "cert":self.config.TaskWorker.cmscert})
@@ -606,8 +601,6 @@ class DagmanCreator(TaskAction.TaskAction):
 
             # Apply globals
             availablesites = set(possiblesites) - global_blacklist
-            if global_whitelist:
-                availablesites &= global_whitelist
 
             if not availablesites:
                 msg = "The CRAB3 server backend refuses to send jobs to the Grid scheduler. No site available for submission of task %s" % (kwargs['task']['tm_taskname'])

--- a/src/python/TaskWorker/Actions/Recurring/BanDestinationSites.py
+++ b/src/python/TaskWorker/Actions/Recurring/BanDestinationSites.py
@@ -1,0 +1,87 @@
+import os
+import re
+import sys
+import time
+import json
+import shutil
+import urllib2
+import logging
+import traceback
+
+from TaskWorker.Actions.Recurring.BaseRecurringAction import BaseRecurringAction
+
+class BanDestinationSites(BaseRecurringAction):
+    pollingTime = 15 #minutes
+
+    def _execute(self, resthost, resturi, config, task):
+        renewer = CRAB3BanDestinationSites(config, resthost, resturi, self.logger)
+        return renewer.execute()
+
+class CRAB3BanDestinationSites(object):
+
+    def __init__(self, config, resthost, resturi, logger=None):
+        if not logger:
+            self.logger = logging.getLogger(__name__)
+            handler = logging.StreamHandler(sys.stdout)
+            formatter = logging.Formatter("%(asctime)s:%(levelname)s:%(module)s %(message)s")
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
+            self.logger.setLevel(logging.DEBUG)
+        else:
+            self.logger = logger
+
+        self.config = config
+
+    def writeBannedSitesToFile(self, bannedSites, saveLocation):
+        # Create temporary file with save_location.txt.tmp and later we can move it
+        tmpLocation = saveLocation + ".tmp"
+        with open(tmpLocation, 'w') as fd:
+            json.dump(bannedSites, fd)
+        shutil.move(tmpLocation, saveLocation) 
+
+    def execute(self):
+        blacklistedSites = []
+        try:
+            usableSites = urllib2.urlopen(self.config.Sites.DashboardURL).read()
+        except Exception as e:
+            # If exception is got, don`t change anything and previous data will be used
+            self.logger.error("Got exception in retrieving usable sites list from %s. Exception: %s" \
+                              % (self.config.Sites.DashboardURL, traceback.format_exc()))
+            return
+        usableSitesList = []
+        try:
+            usableSitesList = json.loads(usableSites)
+        except ValueError as e:
+            self.logger.error("Can not load usableSites json. Output %s Error %s" %(bannedSites, e))
+            return
+        for row in usableSitesList:
+            if 'value' in row and row['value'] == 'not_usable':
+                blacklistedSites.append(row['name'])
+        saveLocation = os.path.join(self.config.TaskWorker.scratchDir, "blacklistedSites.txt")
+        self.writeBannedSitesToFile(blacklistedSites, saveLocation)
+
+if __name__ == '__main__':
+    """ Simple main to execute the action standalon. You just need to set the task worker environment.
+        The main is set up to work with the production task worker. If you want to use it on your own
+        instance you need to change twconfig. For example:
+            twconfig = '/data/srv/TaskManager/current/TaskWorkerConfig.py'
+            resthost = 'hostname' # not used in this script, but required for Recurring action
+            resturi = 'resturi' # also not used, but required. 
+    """
+    twconfig = '/data/srv/TaskManager/current/TaskWorkerConfig.py'
+    resthost = 'cmsweb.cern.ch' # Fake resthost and it is not used, but required for Recurring actions
+    resturi = 'crabserver' # Fake resturi and it is not used, but required for Recurring actions
+
+    logger = logging.getLogger()
+    handler = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter("%(asctime)s:%(levelname)s:%(module)s %(message)s", datefmt="%a, %d %b %Y %H:%M:%S %Z(%z)")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+
+    from WMCore.Configuration import loadConfigurationFile
+    config = loadConfigurationFile(twconfig)
+
+    pr = CRAB3BanDestinationSites(config, resthost, resturi, logger)
+    pr.execute()
+

--- a/src/python/TaskWorker/Actions/TaskAction.py
+++ b/src/python/TaskWorker/Actions/TaskAction.py
@@ -1,3 +1,5 @@
+import os
+import json
 import urllib
 import logging
 from base64 import b64encode
@@ -44,3 +46,15 @@ class TaskAction(object):
         except HTTPException, hte:
             self.logger.error(hte.headers)
             self.logger.warning("Cannot add a warning to REST interface. Warning message: %s" % warning)
+
+    def getBlacklistedSites(self):
+        bannedSites = []
+        fileLocation = os.path.join(self.config.TaskWorker.scratchDir, "blacklistedSites.txt")
+        if os.path.isfile(fileLocation):
+            with open(fileLocation) as fd:
+                try:
+                    bannedSites = json.load(fd)
+                except ValueError as e:
+                    self.logger.error("Failed to load json from file %s. Error message: %s" % (fileLocation, e))
+                    return []
+        return bannedSites


### PR DESCRIPTION
With this fix users will not be allowed to submit to any blacklisted site (Sites which are blacklisted in dashbiard). To have this working, these parameters must be set in TaskWorkerConfig.py

In recurringActions add 'BanDestinationSites' (This will fetch from morgue list every 15 minutes)
And specify location where to save and morgue url from which to parse
```
config.Sites.DashboardURL = "https://cmst1.web.cern.ch/CMST1/SST/analysis/usableSites.json"
```
@altundag @mmascher please review