### PR TITLE
Revert copy of job_log

### DIFF
--- a/src/python/TaskWorker/Actions/RetryJob.py
+++ b/src/python/TaskWorker/Actions/RetryJob.py
@@ -68,7 +68,9 @@ class RetryJob(object):
         except ValueError:
             pass
 
-        p = subprocess.Popen(["condor_q", "-debug", "-l", "-userlog", "job_log"], stdout=subprocess.PIPE, stderr=sys.stderr)
+        shutil.copy("job_log", "job_log.%s" % str(self.dag_jobid))
+
+        p = subprocess.Popen(["condor_q", "-debug", "-l", "-userlog", "job_log.%s" % str(self.dag_jobid), str(self.dag_jobid)], stdout=subprocess.PIPE, stderr=sys.stderr)
         output, _ = p.communicate()
         status = p.returncode
 


### PR DESCRIPTION
This definetly fixes memory report and PostJob identifies correct job exit reason.
This should also fix not retried job due to integrated_job_time is too big as it will check only particular job and not iterate through all jobs(finished/failed)