### PR TITLE
Map user to groups

### DIFF
--- a/src/python/CMSGroupMapper.py
+++ b/src/python/CMSGroupMapper.py
@@ -1,0 +1,54 @@
+
+import os
+import re
+import time
+
+g_cache = {}
+g_expire_time = 0
+
+def cache_users():
+    global g_expire_time
+    global g_cache
+
+    base_dir = '/cvmfs/cms.cern.ch/SITECONF'
+    cache = {}
+    user_re = re.compile(r'[-_A-Za-z0-9.]+')
+    sites = None
+    try:
+        if os.path.isdir(base_dir):
+            sites = os.listdir(base_dir)
+    except:
+        pass
+    if not sites:
+        g_expire_time = time.time() + 60
+        return
+    for entry in sites:
+        full_path = os.path.join(base_dir, entry, 'GlideinConfig', 'local-users.txt')
+        if (entry == 'local') or (not os.path.isfile(full_path)):
+        #if not os.path.isfile(full_path):
+            continue
+        try:
+            fd = open(full_path)
+            for line in fd:
+                line = line.strip()
+                if user_re.match(line):
+                    group_set = cache.setdefault(line, set())
+                    group_set.add(entry)
+        except:
+            raise
+            pass
+    for key, val in cache.items():
+        cache[key] = ",".join(val)
+
+    g_cache = cache
+    g_expire_time = time.time() + 15*60
+
+
+def map_user_to_groups(user):
+    if time.time() > g_expire_time:
+        cache_users()
+    return g_cache.setdefault(user, "")
+
+if __name__ == '__main__':
+   print map_user_to_groups("bbockelm")
+

--- a/src/python/TaskWorker/Actions/DagmanSubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanSubmitter.py
@@ -12,6 +12,7 @@ import traceback
 import subprocess
 
 import HTCondorUtils
+import CMSGroupMapper
 import HTCondorLocator
 
 from httplib import HTTPException
@@ -334,6 +335,10 @@ class DagmanSubmitter(TaskAction.TaskAction):
         """
         dagAd = classad.ClassAd()
         addCRABInfoToClassAd(dagAd, info)
+
+        groups = CMSGroupMapper.map_user_to_groups(dagAd["CRAB_UserHN"])
+        if groups:
+            dagAd["CMSGroups"] = groups
 
         # NOTE: Changes here must be synchronized with the job_submit in DagmanCreator.py in CAFTaskWorker
         dagAd["Out"] = str(os.path.join(info['scratch'], "request.out"))

--- a/src/python/TaskWorker/Actions/PreJob.py
+++ b/src/python/TaskWorker/Actions/PreJob.py
@@ -305,7 +305,7 @@ class PreJob:
         ## Add group information:
         username = self.task_ad.get('CRAB_UserHN')
         if 'CMSGroups' in self.task_ad:
-            new_submit_text += '+CMSGroups = %s\n' % classad.quote(groups)
+            new_submit_text += '+CMSGroups = %s\n' % classad.quote(self.task_ad['CMSGroups'])
         elif username:
             groups = CMSGroupMapper.map_user_to_groups(username)
             if groups:

--- a/src/python/TaskWorker/Actions/PreJob.py
+++ b/src/python/TaskWorker/Actions/PreJob.py
@@ -12,49 +12,7 @@ from ApmonIf import ApmonIf
 
 from TaskWorker.Actions.RetryJob import JOB_RETURN_CODES 
 
-def cache_users():
-    global g_expire_time
-    global g_cache
-
-    base_dir = '/cvmfs/cms.cern.ch/SITECONF'
-    cache = {}
-    user_re = re.compile(r'[-_A-Za-z0-9.]+')
-    sites = None
-    try:
-        if os.path.isdir(base_dir):
-            sites = os.listdir(base_dir)
-    except:
-        pass
-    if not sites:
-        g_expire_time = time.time() + 60
-        return
-    for entry in sites:
-        full_path = os.path.join(base_dir, entry, 'GlideinConfig', 'local-users.txt')
-        print full_path
-        if (entry == 'local') or (not os.path.isfile(full_path)):
-        #if not os.path.isfile(full_path):
-            continue
-        try:
-            fd = open(full_path)
-            for line in fd:
-                line = line.strip()
-                if user_re.match(line):
-                    group_set = cache.setdefault(line, set())
-                    group_set.add(entry)
-        except:
-            raise
-            pass
-    for key, val in cache.items():
-        cache[key] = ",".join(val)
-
-    g_cache = cache
-    g_expire_time = time.time() + 15*60
-
-
-def map_user_to_groups(user):
-    if time.time() > g_expire_time:
-        cache_users()
-    return g_cache.setdefault(user, "")
+import CMSGroupMapper
 
 
 class PreJob:
@@ -346,12 +304,12 @@ class PreJob:
 
         ## Add group information:
         username = self.task_ad.get('CRAB_UserHN')
-        if username:
-            groups = map_user_to_groups(username)
+        if 'CMSGroups' in self.task_ad:
+            new_submit_text += '+CMSGroups = %s\n' % classad.quote(groups)
+        elif username:
+            groups = CMSGroupMapper.map_user_to_groups(username)
             if groups:
-                new_submit_text += '+CMSGroups = "%s"' % ",".join(groups)
-            elif 'CMSGroups' in self.task_ad:
-                new_submit_text += '+CMSGroups = "%s"' % ",".join(self.task_ad)
+                new_submit_text += '+CMSGroups = %s\n' % classad.quote(groups)
 
         ## Finally add (copy) all the content of the generic Job.submit file.
         with open("Job.submit", 'r') as fd:


### PR DESCRIPTION
(Resubmitting PR for main repo)

If CVMFS is present on the TW or the schedd, set the CMS group names for the user's jobs.

With this patch, if @juztas submits a task, he should see the following attribute added to the DAG job:

CMSGroups = "T2_US_Nebraska"

- James is making the corresponding changes to the pilot environment to obey the CMSGroups attribute in ITB.
- Farrukh is adding the group to ITB for launching the local pilots.

@jamesletts 
