### PR TITLE
When retrieving CRAB_ResubmitList from task_ad it is already python object.

### DIFF
--- a/scripts/AdjustSites.py
+++ b/scripts/AdjustSites.py
@@ -292,11 +292,8 @@ def main():
     resubmitJobIds = []
     if 'CRAB_ResubmitList' in ad:
         resubmitJobIds = ad['CRAB_ResubmitList']
-        try:
-            resubmitJobIds = set(resubmitJobIds)
-            resubmitJobIds = [str(i) for i in resubmitJobIds]
-        except TypeError:
-            resubmitJobIds = True
+        if resubmitJobIds != True:
+            resubmitJobIds = [str(i) for i in set(resubmitJobIds)]
     if resubmitJobIds:
         adjustedJobIds = []
         if hasattr(htcondor, 'lock'):

--- a/src/python/TaskWorker/Actions/PreJob.py
+++ b/src/python/TaskWorker/Actions/PreJob.py
@@ -244,15 +244,11 @@ class PreJob:
         ## as used by the previous job retry (which are saved in self.resubmit_info).
         CRAB_ResubmitList_in_taskad = ('CRAB_ResubmitList' in self.task_ad)
         use_resubmit_info = False
-        resubmit_jobids = []
         if 'CRAB_ResubmitList' in self.task_ad:
             resubmit_jobids = self.task_ad['CRAB_ResubmitList']
-            try:
-                resubmit_jobids = set(resubmit_jobids)
+            if resubmit_jobids != True:
                 if resubmit_jobids and self.job_id not in resubmit_jobids:
                     use_resubmit_info = True
-            except TypeError:
-                resubmit_jobids = True
         ## If there is no resubmit_info, we can of course not use it.
         if not self.resubmit_info:
             use_resubmit_info = False


### PR DESCRIPTION
I know you will say is not possible.
I am sure that when I tested the resubmission patch https://github.com/dmwm/CRABServer/commit/5ec4a681cac0d325fbcaf400f846217e3c944e7d without having the try/except in https://github.com/dmwm/CRABServer/commit/5ec4a681cac0d325fbcaf400f846217e3c944e7d#diff-3fa1996a22a9c377b41882d6cf77ab1cR295 I was getting an error in https://github.com/dmwm/CRABServer/commit/5ec4a681cac0d325fbcaf400f846217e3c944e7d#diff-3fa1996a22a9c377b41882d6cf77ab1cL293 saying basically that could not compare classad.ExprTree object with True. So I concluded that https://github.com/dmwm/CRABServer/commit/5ec4a681cac0d325fbcaf400f846217e3c944e7d#diff-3fa1996a22a9c377b41882d6cf77ab1cR294 returned a classad.ExprTree object and added the try/except because didn't know how to use classad to convert back to python object. Today I found that I can use classad.ExprTree.eval(). I wanted to test it doing ad['CRAB_ResubmitList'].eval() and got the error the bool/list object has not eval() method. And when I print the type of ad['CRAB_ResubmitList'] it is indeed already a python object (in this case bool(True) or list). So I am removing the try/except and simplifying back the code.

Note: 
Earlier version of this code, for example https://github.com/dmwm/CRABServer/blob/c498367605b79e6557ca7dea0b060eeb1d1aa5ee/scripts/AdjustSites.py was also assuming ad['CRAB_ResubmitList'] was a python object, just that it had:
if 'CRAB_ResubmitList' in ad: resubmitJobIds = set(ad['CRAB_ResubmitList'])
and set(ad['CRAB_ResubmitList']) breaks when ad['CRAB_ResubmitList'] = bool(True).
