### PR TITLE
Do not query the schedd and use the node_status file when possible. F…

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -36,7 +36,7 @@ from ApmonIf import ApmonIf
 
 DAG_HEADER = """
 
-NODE_STATUS_FILE node_state 30
+NODE_STATUS_FILE node_state 30 ALWAYS-UPDATE
 
 # NOTE: a file must be present, but 'noop' makes it not be read.
 #FINAL FinalCleanup Job.1.submit NOOP


### PR DESCRIPTION
…ixes #4617

With this pull request, I fixed/added few things:
* Move return result in the top and change return information where is needed;
* Use node_state file if:
   * it exists and it was updated less then in 60s;
   * Only if users use `crab status` or `crab status -long`.
* Not use node_state when:
   * Last time it was updated more then 60s ago;
   * If user use `crab status -idle` which requires site blacklist/whitelist from scheduler;
* Added schedd name and collector name, which can be helpful to debug users problem. This will be printed only in the log files. If needed we can add this print in client;
* use ALWAYS-UPDATE for NODE_STATUS_FILE;
* some comments, descriptions about parameters.

@bbockelm @mmascher @AndresTanasijczuk can you review?