### PR TITLE
Use totalUnits in EventAwareLumiBased splitting. For #4800. Patch in WMCore needed.

### DIFF
--- a/src/python/TaskWorker/Actions/Splitter.py
+++ b/src/python/TaskWorker/Actions/Splitter.py
@@ -33,6 +33,8 @@ class Splitter(TaskAction):
                 splitparam['total_files'] = kwargs['task']['tm_totalunits']
             elif kwargs['task']['tm_split_algo'] == 'LumiBased':
                 splitparam['total_lumis'] = kwargs['task']['tm_totalunits']
+            elif kwargs['task']['tm_split_algo'] == 'EventAwareLumiBased':
+                splitparam['total_events'] = kwargs['task']['tm_totalunits']
         elif kwargs['task']['tm_job_type'] == 'PrivateMC':
             if 'tm_events_per_lumi' in kwargs['task'] and kwargs['task']['tm_events_per_lumi']:
                 splitparam['events_per_lumi'] = kwargs['task']['tm_events_per_lumi']


### PR DESCRIPTION
total_events is not implemented in https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/JobSplitting/EventAwareLumiBased.py 
I am preparing a patch for WMCore. But this pull in crab server won't break anything even if the WMCore patch is not there.