### PR TITLE
Unbound local variable. Make it empty

### DIFF
--- a/src/python/CRABInterface/HTCondorDataWorkflow.py
+++ b/src/python/CRABInterface/HTCondorDataWorkflow.py
@@ -298,6 +298,7 @@ class HTCondorDataWorkflow(DataWorkflow):
         taskStatus = {}
         jobList = []
         results = {}
+        pool = ""
         #Add scheduler and collector to return information
         if row.schedd:
             result['schedd'] = row.schedd


### PR DESCRIPTION
```
[28/May/2015:15:31:27]      File "/data/srv/beHG1506b/sw.pre/slc6_amd64_gcc481/cms/crabserver/3.3.1506.rc1/lib/python2.6/site-packages/CRABInterface/HTCondorDataWorkflow.py", line 475, in status
[28/May/2015:15:31:27]        result['pool'] = pool
[28/May/2015:15:31:27]    UnboundLocalError: local variable 'pool' referenced before assignment
```
It might happen whenever task is newly submitted and it is in status Holding or been submitted to scheduler few seconds ago, but it still can not retrieve this information from scheduler