### PR TITLE
send correct SyncCE to dashboard

### DIFF
--- a/scripts/CMSRunAnalysis.py
+++ b/scripts/CMSRunAnalysis.py
@@ -117,7 +117,7 @@ def earlyDashboardMonitoring(myad):
         'WNHostName': socket.getfqdn(),
         'SyncGridJobId': 'https://glidein.cern.ch/%d/%s' % (myad['CRAB_Id'], myad['CRAB_ReqName'].replace("_", ":")),
         'SyncSite': myad['JOB_CMSSite'],
-        'SyncCE': myad['Used_Gatekeeper'].split(":")[0],
+        'SyncCE': myad['Used_Gatekeeper'].split(":")[0].split(" ")[0],
         'OverflowFlag': calcOverflowFlag(myad),
     }
     populateDashboardMonitorInfo(myad, params)


### PR DESCRIPTION
Sites which are running Condor-CE are reporting:
== JOB AD: Used_Gatekeeper = "byggvir.princeton.edu byggvir.princeton.edu:9619"
Dashboard is making exception for some sites and creating a fake mapping for these sites to match to correct SiteName.
There was a thread here: https://hypernews.cern.ch/HyperNews/CMS/get/computing-tools/417.html about site being Unknown.