### PR TITLE
json fjr file not send to dashboard. #4795

### DIFF
--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -20,7 +20,7 @@ def checkOutLFN(lfn, username):
 
 #setDashboardLogs function is shared between the postjob and the job wrapper. Sharing it here
 def setDashboardLogs(params, webdir, jobid, retry):
-    log_files = [("job_out", "txt"), ("job_fjr", "json"), ("postjob", "txt")]
+    log_files = [("job_out", "txt"), ("postjob", "txt")]
     for i, log_file in enumerate(log_files):
         log_file_basename, log_file_extension = log_file
         log_file_name = "%s/%s.%d.%d.%s" % (webdir, \


### PR DESCRIPTION
With this json file is not send to the dashboard task monitoring.

Job Log JSON is still printed under the Job Log with: 

{
 "OriginalJSONURL": "http://vocms0114.cern.ch/mon/cms591/150605_122658:nizam_crab_analysis_20150605_142645/job_fjr.1.0.json", 
 "DashboardPrettifiedJSONLog": "JSON file does not exist!!!"
}

as content.