### PR TITLE
When reporting ExeExitCode to dashbaord use the FJR['jobExitCode'].

### DIFF
--- a/scripts/CMSRunAnalysis.py
+++ b/scripts/CMSRunAnalysis.py
@@ -148,7 +148,8 @@ def startDashboardMonitoring(myad):
 def addReportInfo(params, fjr):
     if 'exitCode' in fjr:
         params['JobExitCode'] = fjr['exitCode']
-        params['ExeExitCode'] = fjr['exitCode']
+    if 'jobExitCode' in report:
+        params['ExeExitCode'] = fjr['jobExitCode']
     if 'steps' not in fjr or 'cmsRun' not in fjr['steps']:
         return
     fjr = fjr['steps']['cmsRun']

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -1863,7 +1863,8 @@ class PostJob():
                         report = json.load(fd)
                         if 'exitCode' in report:
                             params['JobExitCode'] = report['exitCode']
-                            params['ExeExitCode'] = report['exitCode']
+                        if 'jobExitCode' in report:
+                            params['ExeExitCode'] = report['jobExitCode']
                     except ValueError as e:
                         self.logger.debug("Not able to load the fwjr because of a ValueError %s. \
                                            Not setting exit code for dashboard. Continuing normally" % (e))

--- a/src/python/TaskWorker/Actions/RetryJob.py
+++ b/src/python/TaskWorker/Actions/RetryJob.py
@@ -136,12 +136,16 @@ class RetryJob(object):
 
     ##= = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
-    def create_fake_fjr(self, exitMsg, exitCode):
+    def create_fake_fjr(self, exitMsg, exitCode, jobExitCode = None):
         """If FatalError is got, fjr is not generated and it is needed for error_summary"""
 
         fake_fjr = {}
-        fake_fjr['exitCode'] = exitCode
         fake_fjr['exitMsg'] = exitMsg
+        if jobExitCode:
+            fake_fjr['jobExitCode'] = jobExitCode
+            fake_fjr['exitCode'] = jobExitCode
+        else:
+            fake_fjr['exitCode'] = exitCode
         jobReport = "job_fjr.%d.%d.json" % (self.job_id, self.crab_retry)
         if os.path.isfile(jobReport) and os.path.getsize(jobReport) > 0:
             #File exists and it is not empty
@@ -166,7 +170,8 @@ class RetryJob(object):
         """
         # If job was killed on the worker node, we probably don't have a FJR.
         if self.ad.get("RemoveReason", "").startswith("Removed due to wall clock limit"):
-            self.create_fake_fjr("Not retrying job due to wall clock limit (job automatically killed on the worker node)", 50664)
+            exitMsg = "Not retrying job due to wall clock limit (job automatically killed on the worker node)"
+            self.create_fake_fjr(exitMsg, 50664, 50664)
         subreport = self.report
         for attr in ['steps', 'cmsRun', 'performance', 'cpu', 'TotalJobTime']:
             subreport = subreport.get(attr, None)
@@ -198,7 +203,8 @@ class RetryJob(object):
         """
         # If job was killed on the worker node, we probably don't have a FJR.
         if self.ad.get("RemoveReason", "").startswith("Removed due to memory use"):
-            self.create_fake_fjr("Not retrying job due to excessive memory use (job automatically killed on the worker node)", 50660)
+            exitMsg = "Not retrying job due to excessive memory use (job automatically killed on the worker node)"
+            self.create_fake_fjr(exitMsg, 50660, 50660)
         subreport = self.report
         for attr in ['steps', 'cmsRun', 'performance', 'memory', 'PeakValueRss']:
             subreport = subreport.get(attr, None)
@@ -223,7 +229,7 @@ class RetryJob(object):
         # If job was killed on the WN, we probably don't have a FJR.
         if self.ad.get("RemoveReason", "").startswith("Removed due to disk usage"):
             exitMsg = "Not retrying job due to excessive disk usage (job automatically killed on the worker node)"
-            self.create_fake_fjr(exitMsg, 50662)
+            self.create_fake_fjr(exitMsg, 50662, 50662)
 
     ##= = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 


### PR DESCRIPTION
This is my proposition to improve the situation discussed in https://github.com/dmwm/CRABServer/pull/4820

1) Use FJR['jobExitCode'] whenever we report ExeExitCode to dashboard.
2) When creating a "fake" FJR in RetryJob, add the possibility to set FJR['jobExitCode']. And of course, if a (non-zero) jobExitCode is given, use it to set both FJR['jobExitCode'] and FJR['exitCode'].
3) When creating a "fake" FJR in RetryJob because the job was killed in the WN due to walltime/cpu/disk limit, set both FJR['exitCode'] and FJR\['jobExitCode'] (with the same exit code that is already used). => Both ExeExitCode and JobExitCode will be reported to dashboard (with equal value) by the PostJob. This doesn't change anything wrt the current behavior.
4) When creating a "fake" FJR in RetryJob because of total (or integrated) walltime/memory limit, set only the FJR['exitCode'], but not the FJR['jobExitCode']. => Only the JobExitCode will be reported to dashboard by the PostJob. The problem here is that, when the application has failed, the new non-zero JobExitCode reported to dashboard by the PostJob will be different than the ExeExitCode/JobExitCode already reported from WN. The other option would be that the PostJob reports also ExeExitCode = JobExitCode, but then we give up the concept that ExeExitCode is the application exit code and can not be changed.