### PR TITLE
Report the correct NEventsProcessed for multiple input file jobs

### DIFF
--- a/scripts/CMSRunAnalysis.py
+++ b/scripts/CMSRunAnalysis.py
@@ -172,11 +172,11 @@ def addReportInfo(params, fjr):
             if fjr['performance']['memory'].get("PeakValueRss"):
                 params['CRABUserPeakRss'] = float(fjr['performance']['memory']['PeakValueRss'])
     # Num Events Statistics
-    inputEvents = 0
+    params['NEventsProcessed'] = 0
     if 'input' in fjr and 'source' in fjr['input']:
         for info in fjr['input']['source']:
             if 'events' in info:
-                params['NEventsProcessed'] = info['events']
+                params['NEventsProcessed'] += info['events']
 
 
 def reportPopularity(monitorId, monitorJobId, myad, fjr):


### PR DESCRIPTION
Currently if cmsRun has multiple input files per job, it is reporting only events from the last file.