### PR TITLE
Increase MaxIdle to 1000

### DIFF
--- a/scripts/dag_bootstrap_startup.sh
+++ b/scripts/dag_bootstrap_startup.sh
@@ -176,7 +176,7 @@ else
     # see subsections 2.10.9 "The Rescue DAG" and 2.10.10 "DAG Recovery".
     #
     # Re-nice the process so, even when we churn through lots of processes, we never starve the schedd or shadows for cycles.
-    exec nice -n 19 condor_dagman -f -l . -Lockfile $PWD/$1.lock -DoRecov -AutoRescue 0 -MaxPre 20 -MaxIdle 400 -MaxPost $MAX_POST -Dag $PWD/$1 -Dagman `which condor_dagman` -CsdVersion "$CONDOR_VERSION" -debug 4 -verbose
+    exec nice -n 19 condor_dagman -f -l . -Lockfile $PWD/$1.lock -DoRecov -AutoRescue 0 -MaxPre 20 -MaxIdle 1000 -MaxPost $MAX_POST -Dag $PWD/$1 -Dagman `which condor_dagman` -CsdVersion "$CONDOR_VERSION" -debug 4 -verbose
     EXIT_STATUS=$?
 fi
 exit $EXIT_STATUS


### PR DESCRIPTION
Increasing maxIdle jobs on scheduler and keeping the same value as default (HTCondor decided to limit to 1000 by default.)
More discussion here: https://cms-logbook.cern.ch/elog/GlideInWMS/2285