### PR TITLE
Retrieve publication failure reasons in status. Fixes #4865

### DIFF
--- a/src/python/CRABInterface/HTCondorDataWorkflow.py
+++ b/src/python/CRABInterface/HTCondorDataWorkflow.py
@@ -646,6 +646,12 @@ class HTCondorDataWorkflow(DataWorkflow):
                 query = {'group': True, 'startkey': [workflow], 'endkey': [workflow, {}], 'stale': 'update_after'}
                 try:
                     publicationFailedList = db.loadView('DBSPublisher', 'PublicationFailedByWorkflow', query)['rows']
+                except CMSCouch.CouchBadRequestError: ## This is for backward compatibility, as the old view needs a different query: {'key': workflow, 'stale': 'update_after'}.
+                                                      ## But anyway, the old view doesn't return the publication failure reason.
+                    msg  = "Error while querying CouchDB for publication failures information for workflow %s." % (workflow)
+                    msg += " Seems the 'PublicationFailedByWorkflow' view in %s was not yet update to return the publication failures." % (asourl)
+                    self.logger.error(msg)
+                    return publicationInfo
                 except Exception as ex:
                     msg = "Error while querying CouchDB for publication failures information for workflow %s " % (workflow)
                     self.logger.exception(msg)


### PR DESCRIPTION
Requires the updated view _PublicationFailedByWorkflow_ in Couch. The view is included in ASO 1.0.3.pre11 (https://github.com/dmwm/AsyncStageout/releases/tag/1.0.3pre11). Should better wait until that release is in production before merging this PR.