### PR TITLE
Don't remove temp from source_lfn when direct stageout is done.

### DIFF
--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -625,7 +625,6 @@ class ASOServerJob(object):
                     ## this should not be needed anymore.
                     if not needs_transfer:
                         doc['lfn'] = source_lfn.replace('/store/temp', '/store', 1)
-                        doc['source_lfn'] = source_lfn.replace('/store/temp', '/store', 1)
                 except Exception as ex:
                     msg = "Error loading document from ASO database: %s" % (str(ex))
                     try:


### PR DESCRIPTION
ASO is not using yet source_lfn and destination_lfn, so this should be irrelevant for the current behavior of ASO.
source_lfn should stay unmodified since it is the lfn used originally to calculate the hash of the doc_id.
