### PR TITLE
Remove dependency on custom analyzer for use parent testing.

### DIFF
--- a/test/templates/config/psets/pset_use_parent.py
+++ b/test/templates/config/psets/pset_use_parent.py
@@ -7,7 +7,11 @@ process.source = cms.Source('PoolSource',
         ),
 )
 
-process.dump = cms.EDAnalyzer("Validation")
+process.dump = cms.EDAnalyzer(
+    "DumpFEDRawDataProduct",
+    label = cms.untracked.string("rawDataCollector"),
+    feds = cms.untracked.vint32(0)
+)
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1


### PR DESCRIPTION
Replaces custom analyzer with `DumpFEDRawDataProduct`, which will fail if no `RAW` input is present.