### PR TITLE
Stageout check before submitting task.

### DIFF
--- a/src/python/TaskWorker/Actions/Handler.py
+++ b/src/python/TaskWorker/Actions/Handler.py
@@ -16,6 +16,7 @@ from TaskWorker.Actions.DagmanKiller import DagmanKiller
 from TaskWorker.Actions.MyProxyLogon import MyProxyLogon
 from TaskWorker.Actions.DagmanCreator import DagmanCreator
 from TaskWorker.Actions.PanDAgetSpecs import PanDAgetSpecs
+from TaskWorker.Actions.StageoutCheck import StageoutCheck
 from TaskWorker.Actions.PanDABrokerage import PanDABrokerage
 from TaskWorker.Actions.PanDAInjection import PanDAInjection
 from TaskWorker.Actions.DryRunUploader import DryRunUploader
@@ -134,6 +135,7 @@ def handleNewTask(resthost, resturi, config, task, procnum, *args, **kwargs):
     server = HTTPRequests(resthost, config.TaskWorker.cmscert, config.TaskWorker.cmskey, retry=2)
     handler = TaskHandler(task, procnum, server)
     handler.addWork(MyProxyLogon(config=config, server=server, resturi=resturi, procnum=procnum, myproxylen=60 * 60 * 24))
+    handler.addWork(StageoutCheck(config=config, server=server, resturi=resturi, procnum=procnum))
     if task['tm_job_type'] == 'Analysis':
         if task.get('tm_user_files'):
             handler.addWork(UserDataDiscovery(config=config, server=server, resturi=resturi, procnum=procnum))

--- a/src/python/TaskWorker/Actions/StageoutCheck.py
+++ b/src/python/TaskWorker/Actions/StageoutCheck.py
@@ -1,0 +1,92 @@
+import os
+import re
+import time
+import socket
+import urllib
+import datetime
+import traceback
+
+from httplib import HTTPException
+import TaskWorker.WorkerExceptions
+from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
+from TaskWorker.Actions.TaskAction import TaskAction
+from TaskWorker.WorkerExceptions import TaskWorkerException
+from ServerUtilities import getCheckWriteCommand, createDummyFile 
+from ServerUtilities import removeDummyFile, getPFN, executeCommand
+from ServerUtilities import isFailurePermanent
+
+class StageoutCheck(TaskAction):
+
+    """
+    Check if able to stageout dump file to destination site.
+    Will not check this for ActivitiesToRunEverywhere - mainly HC usage or
+    if stageout output and logs is false or
+    if dryrun option True
+    """
+
+    def checkPermissions(self, Cmd):
+        """
+        Execute command and in case of permanent issue, raise error
+        If issue unknown, upload warning message
+        """
+        self.logger.info("Executing command: %s " % Cmd)
+        out, err, exitcode = executeCommand(Cmd)
+        if exitcode != 0:
+            isPermanent, failure = isFailurePermanent(err)
+            if isPermanent:
+                msg = "CRAB3 refuses to send jobs to grid scheduler for %s. Error message: %s" %(self.task['tm_taskname'], failure)
+                self.logger.warning(msg)
+                raise TaskWorkerException(msg)
+            else:
+                # Unknown error. Operators should check it from time to time and add failures if they are permanent.
+                self.logger.warning("CRAB3 was not able to identify if failure is permanent. Err: %s Out: %s ExitCode: %s" %(err, out, exitcode))
+                # Upload warning to user about not being able to check stageout
+                msg = "CRAB3 was not able to check write permissions to destination site. If there is stageout problems, please contact experts."
+                self.uploadWarning(msg, self.task['user_proxy'], self.task['tm_taskname'])
+                self.logger.info("UNKNOWN ERROR. Operator should check if it is permanent, but for now we go ahead and submit a task.")
+                return
+
+
+    def execute(self, *args, **kw):
+        """
+        Main execute
+        """
+        self.task = kw['task']
+        # Do not check it for HC
+        # ActivitiesToRunEverywhere is used mainly for HC and there is no need to check for it.
+        if hasattr(self.config.TaskWorker, 'ActivitiesToRunEverywhere') and \
+                   self.task['tm_activity'] in self.config.TaskWorker.ActivitiesToRunEverywhere:
+            self.logger.info("Will not check possibility to write to destination site because activity: %s is in ActivitiesToRunEverywhere" % self.task['tm_activity'])
+            return
+        # If user specified no output and no logs transfer, there is also no need to check it.
+        if self.task['tm_save_logs'] == 'F' and self.task['tm_transfer_outputs'] == 'F':
+            self.logger.info("Will not check possibility to write to destination site because user specified not transfer any output/log files.")
+            return
+        # Do not need to check if it is dryrun.
+        if self.task['tm_dry_run'] == 'T':
+            self.logger.info("Will not check possibility to write to destination site. User specified dryrun option.")
+            return
+        self.workflow = self.task['tm_taskname']
+        self.proxy = self.task['user_proxy']
+        self.logger.info(self.task)
+        cpCmd, rmCmd, append = getCheckWriteCommand(self.proxy, self.logger)
+        if not cpCmd:
+            self.logger.info("CRAB3 is not configured to check write permissions. There is no GFAL2 or LCG commands installed. Continuing")
+            return
+        filename = re.sub("[:-_]", "", self.task['tm_taskname']) + '_crab3check.tmp'
+        try:
+            createDummyFile(filename, self.logger)
+            pfn = getPFN(self.proxy, self.task['tm_output_lfn'], filename, self.task['tm_asyncdest'], self.logger)
+            cpCmd += append + os.path.abspath(filename) + " " + pfn
+            rmCmd += " " + pfn
+            self.logger.info("Executing cp command: %s " % cpCmd)
+            self.checkPermissions(cpCmd)
+            self.logger.info("Executing rm command: %s " % rmCmd)
+            self.checkPermissions(rmCmd)
+            removeDummyFile(filename, self.logger)
+        except IOError as er:
+            self.logger.info('IOError %s. CRAB3 backend disk is full. Please report to experts. Task will not be submitted' % er)
+            raise
+        except HTTPException as er:
+            self.logger.warning("CRAB3 is not able to get pfn from PhEDEx. Error %s" % er)
+        return


### PR DESCRIPTION
Not check stageout if:
   activity is in ActivitiesToRunEverywhere - mainly HC usage
   if stageout parameters for output and logs is false
   if dryrun option is True

Known errors: (First part - what gfal2 returns, second, what user will get with a bit more information)
".*cancelled aso transfer after timeout.*" : "Transfer canceled due to timeout.",
".*permission denied.*" : "Permission denied.",
".*disk quota exceeded.*" : "Disk quota exceeded.",
".*operation not permitted*" : "Operation not allowed.",
".*mkdir\(\) fail.*" : "Can`t create directory.",
".*open/create error.*" : "Can`t create directory/file on destination site.",
".*mkdir\: cannot create directory.*" : "Can`t create directory.",
".*does not have enough space.*" : "User quota exceeded.",
".*reports could not open connection to.*" : "Storage element is not accessible.",
".*530-login incorrect.*" : "Permission denied to write to destination site."

Reused in Postjob checking permanent failure also exported all needed functionality for crab checkwrite/getoutput/getlog to ServerUtilities.py. Need to reuse same code from CRABClient. Issue created. https://github.com/dmwm/CRABClient/issues/4546