### PR TITLE
Always use /store/temp/user/username.hash/bla for temporary storage directory.

### DIFF
--- a/scripts/gWMS-CMSRunAnalysis.sh
+++ b/scripts/gWMS-CMSRunAnalysis.sh
@@ -62,7 +62,7 @@ then
    echo "CRAB ID: $CRAB_Id"
    echo "Execution site: $JOB_CMSSite"
    echo "Current hostname: $(hostname)"
-   echo "Destination site: $CRAB_Dest"
+   echo "Destination temp dir: $CRAB_Dest"
    echo "Output files: $CRAB_localOutputFiles"
    echo "==== HTCONDOR JOB AD CONTENTS START ===="
    while read i; do

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -187,18 +187,13 @@ def makeLFNPrefixes(task):
     tmp_user = "%s.%s" % (user, hash)
     publish_info = task['tm_publish_name'].rsplit('-', 1) #publish_info[0] is the publishname or the taskname
     timestamp = getCreateTimestamp(task['tm_taskname'])
-    if lfn:
-        splitlfn = lfn.split('/')
-        if splitlfn[2] == 'user':
-            #join:                    /       store    /temp      /user  /mmascher.1234    /lfn          /GENSYM    /publishname     /120414_1634
-            temp_dest = os.path.join('/', splitlfn[1], 'temp', splitlfn[2], tmp_user, *( splitlfn[4:] + [primaryds, publish_info[0], timestamp] ))
-        else:
-            temp_dest = os.path.join('/', splitlfn[1], 'temp', splitlfn[2], *( splitlfn[3:] + [primaryds, publish_info[0], timestamp] ))
-        dest = os.path.join(lfn, primaryds, publish_info[0], timestamp)
+    splitlfn = lfn.split('/')
+    if splitlfn[2] == 'user':
+        #join:                    /       store    /temp   /user  /mmascher.1234    /lfn          /GENSYM    /publishname     /120414_1634
+        temp_dest = os.path.join('/', splitlfn[1], 'temp', 'user', tmp_user, *( splitlfn[4:] + [primaryds, publish_info[0], timestamp] ))
     else:
-        #publish_info[0] will either be the unique taskname (stripped by the username) or the publishname
-        temp_dest = os.path.join("/store/temp/user", tmp_user, primaryds, publish_info[0], timestamp)
-        dest = os.path.join("/store/user", user, primaryds, publish_info[0], timestamp)
+        temp_dest = os.path.join('/', splitlfn[1], 'temp', 'user', tmp_user, *( splitlfn[3:] + [primaryds, publish_info[0], timestamp] ))
+    dest = os.path.join(lfn, primaryds, publish_info[0], timestamp)
 
     return temp_dest, dest
 


### PR DESCRIPTION
We can not implement this in CRAB until ASO doesn't use the source_lfn and destination_lfn from the Couch docs; so far ASO uses one LFN and adds/removes "temp" (and eventually the ".\<hash\>" after the username) for converting final \<--\> temporary LFNs. Issue in ASO: https://github.com/dmwm/AsyncStageout/issues/4347
And of course I can't test this PR.