### PR TITLE
Don't consider T0_CH_CERN_Disk as a valid disk location. Don't abort submission if only some blocks have no locations.

### DIFF
--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -96,7 +96,10 @@ class DBSDataDiscovery(DataDiscovery):
             if str(dbsexc).find('No matching data'):
                 raise TaskWorkerException("The CRAB3 server backend could not find dataset %s in this DBS instance: %s" % (kwargs['task']['tm_input_dataset'], dbsurl))
             raise
-        #Create a map for block's locations: for each block get the list of locations
+        ## Create a map for block's locations: for each block get the list of locations.
+        ## Note: listFileBlockLocation() gets first the locations from PhEDEx, and if no
+        ## locations are found it gets the original locations from DBS. So it should
+        ## never be the case at this point that some blocks have no locations.
         try:
             locationsMap = self.dbs.listFileBlockLocation(list(blocks), phedexNodes=True)
         except Exception as ex: #TODO should we catch HttpException instead?
@@ -172,7 +175,7 @@ if __name__ == '__main__':
     from WMCore.Configuration import Configuration
     config = Configuration()
     config.section_("Services")
-    config.Services.DBSUrl = 'https://cmsweb.cern.ch/dbs/prod/%s/DBSReader/' % dbsInstance
+    config.Services.DBSUrl = 'https://cmsweb.cern.ch/dbs/%s/DBSReader/' % dbsInstance
     config.section_("TaskWorker")
     # will use X509_USER_PROXY var for this test
     config.TaskWorker.cmscert = os.environ["X509_USER_PROXY"]


### PR DESCRIPTION
This PR fixes https://github.com/dmwm/CRABServer/issues/4970 and provides an (still maybe incomplete) solution to https://github.com/dmwm/CRABServer/issues/4823 
By "incomplete" I mean that it doesn't implement any explicit fork in DBSDataDiscovery between datasets in global or phys03. But it does implement what FMPOV is the most important, which is to not abort the submission of the blocks that do have PSN locations, and if there are blocks for which no PSN locations where found, it gives a warning. This is done in DagmanCreator (i.e. when creating the DAGs for job submission; after data discovery, splitting, whitelist/blacklist) like Marco suggested.