### PR TITLE
Check there is no input dataset in PrivateMC. Fixes #4512

### DIFF
--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -105,9 +105,8 @@ class RESTUserWorkflow(RESTEntity):
         kwargs['publishname'] = publishDataNameToCheck #that's what the version earlier than 1509 were putting in the DB
         if 'publishgroupname' in kwargs and int(kwargs['publishgroupname']): #the first half of the if is for backward compatibility
             if not (outlfn.startswith('/store/group/') and outlfn.split('/')[3]):
-                msg  = "Invalid CRAB configuration."
-                msg += " Parameter Data.publishWithGroupName is True,"
-                msg += " but Data.outLFNDirBase does not start with '/store/group/<groupname>'."
+                msg  = "Parameter 'publishgroupname' is True,"
+                msg += " but parameter 'lfn' does not start with '/store/group/<groupname>'."
                 raise InvalidParameter(msg)
             group_user_prefix = outlfn.split('/')[3]
         else:
@@ -155,9 +154,8 @@ class RESTUserWorkflow(RESTEntity):
         ##Determine if it's a dataset that will go into a group space and therefore the (group)username prefix it will be used
         if 'publishgroupname' in kwargs and int(kwargs['publishgroupname']): #the first half of the if is for backward compatibility
             if not (outlfn.startswith('/store/group/') and outlfn.split('/')[3]):
-                msg  = "Invalid CRAB configuration."
-                msg += " Parameter Data.publishWithGroupName is True,"
-                msg += " but Data.outLFNDirBase does not start with '/store/group/<groupname>'."
+                msg  = "Parameter 'publishgroupname' is True,"
+                msg += " but parameter 'lfn' does not start with '/store/group/<groupname>'."
                 raise InvalidParameter(msg)
             group_user_prefix = outlfn.split('/')[3]
         else:
@@ -349,6 +347,14 @@ class RESTUserWorkflow(RESTEntity):
             validate_num("publishgroupname", param, safe, optional=True)
             ## This line must come after _checkPublishDataName()
             validate_str("workflow", param, safe, RX_WORKFLOW, optional=False)
+
+            if safe.kwargs['jobtype'] == 'PrivateMC':
+                if param.kwargs['inputdata']:
+                    msg  = "Invalid 'inputdata' parameter."
+                    msg += " Job type PrivateMC does not accept an input dataset."
+                    msg += " If you really intend to run over an input dataset, then you must use job type Analysis."
+                    raise InvalidParameter(msg)
+
             if jobtype == 'Analysis':
                 validate_str("inputdata", param, safe, RX_DATASET, optional=False)
             ## In case of PrivateMC with publication, 'inputdata' was already validated

--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -351,8 +351,13 @@ class RESTUserWorkflow(RESTEntity):
             if safe.kwargs['jobtype'] == 'PrivateMC':
                 if param.kwargs['inputdata']:
                     msg  = "Invalid 'inputdata' parameter."
-                    msg += " Job type PrivateMC does not accept an input dataset."
+                    msg += " Job type PrivateMC does not take any input dataset."
                     msg += " If you really intend to run over an input dataset, then you must use job type Analysis."
+                    raise InvalidParameter(msg)
+                if safe.kwargs['userfiles']:
+                    msg  = "Invalid 'userfiles' parameter."
+                    msg += " Job type PrivateMC does not take any input files."
+                    msg += " If you really intend to run over input files, then you must use job type Analysis."
                     raise InvalidParameter(msg)
 
             if jobtype == 'Analysis':


### PR DESCRIPTION
Since the client uses the `inputdata` parameter to pass the primary dataset name in PrivateMC workflows, this PR will make the server incompatible with the client if these other PRs are not put in production first: https://github.com/dmwm/CRABServer/pull/5037 and https://github.com/dmwm/CRABClient/pull/4568 