### PR TITLE
Always call createSubdag.

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -878,7 +878,7 @@ class DagmanCreator(TaskAction.TaskAction):
         if os.path.exists("TaskManagerRun.tar.gz"):
             inputFiles.append("TaskManagerRun.tar.gz")
 
-            info, splitterResult = self.createSubdag(*args, **kw)
+        info, splitterResult = self.createSubdag(*args, **kw)
 
         return info, params, inputFiles, splitterResult
 


### PR DESCRIPTION
@mmascher I think this commit https://github.com/dmwm/CRABServer/commit/26d50a0a0eaad11f7ea279adfec5736318b47df2 forgot to indent this line back when it removed the `try/finally` clause.
