### PR TITLE
Use gunzip instead of tar z to unzip the user sandbox.

### DIFF
--- a/scripts/CMSRunAnalysis.py
+++ b/scripts/CMSRunAnalysis.py
@@ -522,7 +522,7 @@ def prepSandbox(opts):
                     handleException("FAILED", EC_WGET, 'CMSRunAnalysisERROR: could not get jobO files from panda server')
                     sys.exit(EC_WGET)
                 time.sleep(30)
-        print commands.getoutput('tar xvfzm %s' % opts.archiveJob)
+        print commands.getoutput('gunzip -q < %s | tar xvfm -' % opts.archiveJob)
     print "==== Sandbox preparation FINISHING at %s ====" % time.asctime(time.gmtime())
 
     #move the pset in the right place
@@ -543,7 +543,7 @@ def prepSandbox(opts):
 
 def extractUserSandbox(archiveJob, cmsswVersion):
     os.chdir(cmsswVersion)
-    print commands.getoutput('tar xvfzm %s ' % os.path.join('..', archiveJob))
+    print commands.getoutput('gunzip -q < %s | tar xvfm -' % os.path.join('..', archiveJob))
     os.chdir('..')
 
 def getProv(filename, scram):


### PR DESCRIPTION
https://hypernews.cern.ch/HyperNews/CMS/get/computing-tools/1065.html

I downloaded the sandbox from crabcache:

https://cmsweb.cern.ch/crabcache/file?hashkey=d03e916a6797ce7b8027ac3ceebf65f3bb317d37b1872f1d395370a553d03a6a&username=brfranco

and I got the same error [1].

From http://www.gzip.org/#faq8 it seems this is a harmless error. And to avoid it one can execute

gunzip -q < sandbox.tar.gz | tar xvfm -
instead of
tar xvfzm sandbox.tar.gz

This worked for me [2].

[1]
```
[atanasi@lxplus0075][/afs/cern.ch/work/a/atanasi/public/brfranco_tarball_from_crabcache/]$ tar xvfzm d03e916a6797ce7b8027ac3ceebf65f3bb317d37b1872f1d395370a553d03a6a.gz
lib/
lib/slc6_amd64_gcc491/
lib/slc6_amd64_gcc491/pluginRecoEgammaElectronIdentificationCapabilities.so
lib/slc6_amd64_gcc491/libcp3_llbbHHAnalysis.so
...
...
PSet.py
PSet.pkl
PSetDump.py

gzip: stdin: decompression OK, trailing garbage ignored
debug/originalPSet.py
debug/crabConfig.py
tar: Child returned status 2
tar: Error is not recoverable: exiting now
[atanasi@lxplus0075][/afs/cern.ch/work/a/atanasi/public/brfranco_tarball_from_crabcache/]$ echo $?
2
```

[2]
```
[atanasi@lxplus0075][/afs/cern.ch/work/a/atanasi/public/brfranco_tarball_from_crabcache/]$ gunzip -q < d03e916a6797ce7b8027ac3ceebf65f3bb317d37b1872f1d395370a553d03a6a.gz | tar xvfm -
lib/
lib/slc6_amd64_gcc491/
lib/slc6_amd64_gcc491/pluginRecoEgammaElectronIdentificationCapabilities.so
lib/slc6_amd64_gcc491/libcp3_llbbHHAnalysis.so
...
...
PSet.py
PSet.pkl
PSetDump.py
debug/originalPSet.py
debug/crabConfig.py
[atanasi@lxplus0075][/afs/cern.ch/work/a/atanasi/public/brfranco_tarball_from_crabcache/]$ echo $?
0
```