### PR TITLE
Fix validate taskname

### DIFF
--- a/src/python/CRABInterface/DataUserWorkflow.py
+++ b/src/python/CRABInterface/DataUserWorkflow.py
@@ -76,7 +76,7 @@ class DataUserWorkflow(object):
     def submit(self, *args, **kwargs):
         """Perform the workflow injection
 
-           :arg str workflow: workflow name requested by the user;
+           :arg str workflow: workflow name;
            :arg str activity: workflow activity type, usually analysis;
            :arg str jobtype: job type of the workflow, usually Analysis;
            :arg str jobsw: software requirement;
@@ -96,7 +96,7 @@ class DataUserWorkflow(object):
            :arg str cacheurl: URL of the cache
            :arg str list addoutputfiles: list of additional output files;
            :arg str userdn: DN of user doing the request;
-           :arg str userhn: hyper new name of the user doing the request;
+           :arg str username: username of the user doing the request;
            :arg int savelogsflag: archive the log files? 0 no, everything else yes;
            :arg int publication: flag enabling or disabling data publication;
            :arg str publishname: name to use for data publication;

--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -3,7 +3,7 @@ import copy
 import random
 import logging
 import cherrypy
-from Regexps import RX_WORKFLOW_LEN
+from Regexps import RX_PARTIAL_TASKNAME_LEN
 from ast import literal_eval
 
 ## WMCore dependecies
@@ -170,7 +170,7 @@ class DataWorkflow(object):
         try:
             requestname = '%s:%s_%s' % (timestamp, userhn, workflow)
             schedd_name = self.chooseScheduler(scheddname, backend_urls).split(":")[0]
-            if len(requestname) > RX_WORKFLOW_LEN:
+            if len(requestname) > RX_PARTIAL_TASKNAME_LEN:
               raise InvalidParameter("Taskname exceed maximum allowed lenght, please review parameter requestName in your config file")
         except IOError as err:
             self.logger.debug("Failed to communicate with components %s. Request name %s: " % (str(err), str(requestname)))

--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -3,7 +3,7 @@ import copy
 import random
 import logging
 import cherrypy
-from Regexps import RX_PARTIAL_TASKNAME_LEN
+from Regexps import RX_TASKNAME_LEN
 from ast import literal_eval
 
 ## WMCore dependecies
@@ -170,7 +170,7 @@ class DataWorkflow(object):
         try:
             taskname = '%s:%s_%s' % (timestamp, userhn, workflow)
             schedd_name = self.chooseScheduler(scheddname, backend_urls).split(":")[0]
-            if len(taskname) > RX_PARTIAL_TASKNAME_LEN:
+            if len(taskname) > RX_TASKNAME_LEN:
                 raise InvalidParameter("Taskname exceed maximum allowed lenght, please review parameter requestName in your config file")
         except IOError as err:
             self.logger.debug("Failed to communicate with components %s. Request name %s: " % (str(err), str(taskname)))

--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -15,6 +15,9 @@ class DataWorkflow(object):
     """Entity that allows to operate on workflow resources.
        No aggregation of workflows provided here."""
 
+    successList = ['finished']
+    failedList = ['failed']
+
     @staticmethod
     def globalinit(dbapi, phedexargs=None, credpath='/tmp', centralcfg=None, config=None):
         DataWorkflow.api = dbapi

--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -159,7 +159,7 @@ class DataWorkflow(object):
            :returns: a dict which contaians details of the request"""
 
         timestamp = time.strftime('%y%m%d_%H%M%S', time.gmtime())
-        requestname = ""
+        taskname = ""
         schedd_name = ""
         backend_urls = copy.deepcopy(self.centralcfg.centralconfig.get("backend-urls", {}))
         if collector:
@@ -168,12 +168,12 @@ class DataWorkflow(object):
             collector = backend_urls['htcondorPool']
 
         try:
-            requestname = '%s:%s_%s' % (timestamp, userhn, workflow)
+            taskname = '%s:%s_%s' % (timestamp, userhn, workflow)
             schedd_name = self.chooseScheduler(scheddname, backend_urls).split(":")[0]
-            if len(requestname) > RX_PARTIAL_TASKNAME_LEN:
-              raise InvalidParameter("Taskname exceed maximum allowed lenght, please review parameter requestName in your config file")
+            if len(taskname) > RX_PARTIAL_TASKNAME_LEN:
+                raise InvalidParameter("Taskname exceed maximum allowed lenght, please review parameter requestName in your config file")
         except IOError as err:
-            self.logger.debug("Failed to communicate with components %s. Request name %s: " % (str(err), str(requestname)))
+            self.logger.debug("Failed to communicate with components %s. Request name %s: " % (str(err), str(taskname)))
             raise ExecutionError("Failed to communicate with crabserver components. If problem persist, please report it.")
         splitArgName = self.splitArgMap[splitalgo]
         dbSerializer = str
@@ -198,7 +198,7 @@ class DataWorkflow(object):
 
         ## Insert this new task into the Tasks DB.
         self.api.modify(self.Task.New_sql,
-                            task_name       = [requestname],
+                            task_name       = [taskname],
                             task_activity   = [activity],
                             jobset_id       = [None],
                             task_status     = ['NEW'],
@@ -258,7 +258,7 @@ class DataWorkflow(object):
                             one_event_mode   = ['T' if oneEventMode else 'F']
         )
 
-        return [{'RequestName': requestname}]
+        return [{'RequestName': taskname}]
 
 
     def resubmit(self, workflow, siteblacklist, sitewhitelist, jobids, maxjobruntime, numcores, maxmemory, priority, force, userdn, userproxy):

--- a/src/python/CRABInterface/HTCondorDataWorkflow.py
+++ b/src/python/CRABInterface/HTCondorDataWorkflow.py
@@ -33,9 +33,6 @@ class HTCondorDataWorkflow(DataWorkflow):
     """ HTCondor implementation of the status command.
     """
 
-    successList = ['finished']
-    failedList = ['failed']
-
     @classmethod
     @conn_handler(services=['centralconfig'])
     def chooseScheduler(cls, scheddname=None, backend_urls=None):

--- a/src/python/CRABInterface/RESTCampaign.py
+++ b/src/python/CRABInterface/RESTCampaign.py
@@ -6,7 +6,7 @@ from WMCore.REST.Validation import validate_str, validate_strlist, validate_num
 # CRABServer dependecies here
 from CRABInterface.DataCampaign import DataCampaign
 from CRABInterface.RESTExtensions import  authz_login_valid
-from CRABInterface.Regexps import RX_CAMPAIGN, RX_WORKFLOW, RX_SUBRESTAT
+from CRABInterface.Regexps import RX_CAMPAIGN, RX_PARTIAL_TASKNAME, RX_SUBRESTAT
 
 # external dependecies here
 import cherrypy
@@ -25,7 +25,7 @@ class RESTCampaign(RESTEntity):
 
         if method in ['PUT']:
             validate_str("campaign", param, safe, RX_CAMPAIGN, optional=False)
-            validate_strlist("workflow", param, safe, RX_WORKFLOW)
+            validate_strlist("workflow", param, safe, RX_PARTIAL_TASKNAME)
 
         elif method in ['POST']:
             validate_str("campaign", param, safe, RX_CAMPAIGN, optional=False)

--- a/src/python/CRABInterface/RESTCampaign.py
+++ b/src/python/CRABInterface/RESTCampaign.py
@@ -6,7 +6,7 @@ from WMCore.REST.Validation import validate_str, validate_strlist, validate_num
 # CRABServer dependecies here
 from CRABInterface.DataCampaign import DataCampaign
 from CRABInterface.RESTExtensions import  authz_login_valid
-from CRABInterface.Regexps import RX_CAMPAIGN, RX_PARTIAL_TASKNAME, RX_SUBRESTAT
+from CRABInterface.Regexps import RX_CAMPAIGN, RX_TASKNAME, RX_SUBRESTAT
 
 # external dependecies here
 import cherrypy
@@ -25,7 +25,7 @@ class RESTCampaign(RESTEntity):
 
         if method in ['PUT']:
             validate_str("campaign", param, safe, RX_CAMPAIGN, optional=False)
-            validate_strlist("workflow", param, safe, RX_PARTIAL_TASKNAME)
+            validate_strlist("workflow", param, safe, RX_TASKNAME)
 
         elif method in ['POST']:
             validate_str("campaign", param, safe, RX_CAMPAIGN, optional=False)

--- a/src/python/CRABInterface/RESTFileMetadata.py
+++ b/src/python/CRABInterface/RESTFileMetadata.py
@@ -26,7 +26,7 @@ class RESTFileMetadata(RESTEntity):
         if method in ['PUT']:
             #TODO check optional parameter
             #TODO check all the regexp
-            validate_str("taskname", param, safe, RX_PARTIAL_TASKNAME, optional=False)
+            validate_str("taskname", param, safe, RX_TASKNAME, optional=False)
             validate_strlist("outfilelumis", param, safe, RX_LUMILIST)
             validate_numlist("outfileruns", param, safe)
             if len(safe.kwargs["outfileruns"]) != len(safe.kwargs["outfilelumis"]):
@@ -43,7 +43,7 @@ class RESTFileMetadata(RESTEntity):
             validate_str("checksumadler32", param, safe, RX_CHECKSUM, optional=False)
             validate_str("outlocation", param, safe, RX_CMSSITE, optional=False)
             validate_str("outtmplocation", param, safe, RX_CMSSITE, optional=False)
-            validate_str("acquisitionera", param, safe, RX_PARTIAL_TASKNAME, optional=False)#TODO Do we really need this?
+            validate_str("acquisitionera", param, safe, RX_TASKNAME, optional=False)#TODO Do we really need this?
             validate_str("outdatasetname", param, safe, RX_OUTDSLFN, optional=False)#TODO temporary, need to come up with a regex
             validate_str("outlfn", param, safe, RX_PARENTLFN, optional=False)
             validate_str("outtmplfn", param, safe, RX_PARENTLFN, optional=True)
@@ -52,15 +52,15 @@ class RESTFileMetadata(RESTEntity):
             validate_num("directstageout", param, safe, optional=True)
             safe.kwargs["directstageout"] = 'T' if safe.kwargs["directstageout"] else 'F' #'F' if not provided
         elif method in ['POST']:
-            validate_str("taskname", param, safe, RX_PARTIAL_TASKNAME, optional=False)
+            validate_str("taskname", param, safe, RX_TASKNAME, optional=False)
             validate_str("outlfn", param, safe, RX_LFN, optional=False)
             validate_str("filestate", param, safe, RX_FILESTATE, optional=False)
         elif method in ['GET']:
-            validate_str("taskname", param, safe, RX_PARTIAL_TASKNAME, optional=False)
+            validate_str("taskname", param, safe, RX_TASKNAME, optional=False)
             validate_str("filetype", param, safe, RX_OUTTYPES, optional=False)
         elif method in ['DELETE']:
             authz_operator()
-            validate_str("taskname", param, safe, RX_PARTIAL_TASKNAME, optional=True)
+            validate_str("taskname", param, safe, RX_TASKNAME, optional=True)
             validate_str("hours", param, safe, RX_HOURS, optional=True)
             if bool(safe.kwargs["taskname"]) == bool(safe.kwargs["hours"]):
                raise InvalidParameter("You have to specify a taskname or a number of hours. Files of this task or created before the number of hours"+\

--- a/src/python/CRABInterface/RESTFileMetadata.py
+++ b/src/python/CRABInterface/RESTFileMetadata.py
@@ -26,7 +26,7 @@ class RESTFileMetadata(RESTEntity):
         if method in ['PUT']:
             #TODO check optional parameter
             #TODO check all the regexp
-            validate_str("taskname", param, safe, RX_WORKFLOW, optional=False)
+            validate_str("taskname", param, safe, RX_PARTIAL_TASKNAME, optional=False)
             validate_strlist("outfilelumis", param, safe, RX_LUMILIST)
             validate_numlist("outfileruns", param, safe)
             if len(safe.kwargs["outfileruns"]) != len(safe.kwargs["outfilelumis"]):
@@ -43,7 +43,7 @@ class RESTFileMetadata(RESTEntity):
             validate_str("checksumadler32", param, safe, RX_CHECKSUM, optional=False)
             validate_str("outlocation", param, safe, RX_CMSSITE, optional=False)
             validate_str("outtmplocation", param, safe, RX_CMSSITE, optional=False)
-            validate_str("acquisitionera", param, safe, RX_WORKFLOW, optional=False)#TODO Do we really need this?
+            validate_str("acquisitionera", param, safe, RX_PARTIAL_TASKNAME, optional=False)#TODO Do we really need this?
             validate_str("outdatasetname", param, safe, RX_OUTDSLFN, optional=False)#TODO temporary, need to come up with a regex
             validate_str("outlfn", param, safe, RX_PARENTLFN, optional=False)
             validate_str("outtmplfn", param, safe, RX_PARENTLFN, optional=True)
@@ -52,15 +52,15 @@ class RESTFileMetadata(RESTEntity):
             validate_num("directstageout", param, safe, optional=True)
             safe.kwargs["directstageout"] = 'T' if safe.kwargs["directstageout"] else 'F' #'F' if not provided
         elif method in ['POST']:
-            validate_str("taskname", param, safe, RX_WORKFLOW, optional=False)
+            validate_str("taskname", param, safe, RX_PARTIAL_TASKNAME, optional=False)
             validate_str("outlfn", param, safe, RX_LFN, optional=False)
             validate_str("filestate", param, safe, RX_FILESTATE, optional=False)
         elif method in ['GET']:
-            validate_str("taskname", param, safe, RX_WORKFLOW, optional=False)
+            validate_str("taskname", param, safe, RX_PARTIAL_TASKNAME, optional=False)
             validate_str("filetype", param, safe, RX_OUTTYPES, optional=False)
         elif method in ['DELETE']:
             authz_operator()
-            validate_str("taskname", param, safe, RX_WORKFLOW, optional=True)
+            validate_str("taskname", param, safe, RX_PARTIAL_TASKNAME, optional=True)
             validate_str("hours", param, safe, RX_HOURS, optional=True)
             if bool(safe.kwargs["taskname"]) == bool(safe.kwargs["hours"]):
                raise InvalidParameter("You have to specify a taskname or a number of hours. Files of this task or created before the number of hours"+\

--- a/src/python/CRABInterface/RESTServerInfo.py
+++ b/src/python/CRABInterface/RESTServerInfo.py
@@ -7,7 +7,7 @@ from WMCore.REST.Error import ExecutionError
 
 # CRABServer dependecies here
 from CRABInterface.RESTExtensions import authz_login_valid
-from CRABInterface.Regexps import RX_SUBRES_SI , RX_PARTIAL_TASKNAME
+from CRABInterface.Regexps import RX_SUBRES_SI , RX_TASKNAME
 from CRABInterface.Utils import conn_handler
 from CRABInterface.__init__ import __version__
 
@@ -30,7 +30,7 @@ class RESTServerInfo(RESTEntity):
         authz_login_valid()
         if method in ['GET']:
             validate_str('subresource', param, safe, RX_SUBRES_SI, optional=True)
-            validate_str('workflow', param, safe, RX_PARTIAL_TASKNAME, optional=True)
+            validate_str('workflow', param, safe, RX_TASKNAME, optional=True)
 
     @restcall
     def get(self, subresource , **kwargs):

--- a/src/python/CRABInterface/RESTServerInfo.py
+++ b/src/python/CRABInterface/RESTServerInfo.py
@@ -1,14 +1,18 @@
+import logging
+
 # WMCore dependecies here
 from WMCore.REST.Server import RESTEntity, restcall
 from WMCore.REST.Validation import validate_str
 from WMCore.REST.Error import ExecutionError
+
 # CRABServer dependecies here
 from CRABInterface.RESTExtensions import authz_login_valid
-from CRABInterface.Regexps import RX_SUBRES_SI , RX_WORKFLOW
+from CRABInterface.Regexps import RX_SUBRES_SI , RX_PARTIAL_TASKNAME
 from CRABInterface.Utils import conn_handler
 from CRABInterface.__init__ import __version__
-import logging
+
 import HTCondorLocator
+
 
 class RESTServerInfo(RESTEntity):
     """REST entity for workflows and relative subresources"""
@@ -26,7 +30,7 @@ class RESTServerInfo(RESTEntity):
         authz_login_valid()
         if method in ['GET']:
             validate_str('subresource', param, safe, RX_SUBRES_SI, optional=True)
-            validate_str('workflow', param, safe, RX_WORKFLOW , optional=True)
+            validate_str('workflow', param, safe, RX_PARTIAL_TASKNAME, optional=True)
 
     @restcall
     def get(self, subresource , **kwargs):

--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -6,7 +6,7 @@ from WMCore.REST.Error import InvalidParameter,ExecutionError
 from CRABInterface.Utils import conn_handler
 from CRABInterface.Utils import getDBinstance
 from CRABInterface.RESTExtensions import authz_login_valid, authz_owner_match
-from CRABInterface.Regexps import RX_SUBRES_TASK, RX_WORKFLOW, RX_BLOCK, RX_WORKER_NAME, RX_STATUS, RX_USERNAME, RX_TEXT_FAIL, RX_DN, RX_SUBPOSTWORKER, RX_SUBGETWORKER, RX_RUNS, RX_LUMIRANGE, RX_OUT_DATASET, RX_URL, RX_OUT_DATASET, RX_SCHEDD_NAME
+from CRABInterface.Regexps import RX_SUBRES_TASK, RX_PARTIAL_TASKNAME, RX_BLOCK, RX_WORKER_NAME, RX_STATUS, RX_USERNAME, RX_TEXT_FAIL, RX_DN, RX_SUBPOSTWORKER, RX_SUBGETWORKER, RX_RUNS, RX_LUMIRANGE, RX_OUT_DATASET, RX_URL, RX_OUT_DATASET, RX_SCHEDD_NAME
 
 # external dependecies here
 import re
@@ -34,14 +34,14 @@ class RESTTask(RESTEntity):
         authz_login_valid()
         if method in ['POST']:
             validate_str('subresource', param, safe, RX_SUBRES_TASK, optional=False)
-            validate_str("workflow", param, safe, RX_WORKFLOW, optional=True)
+            validate_str("workflow", param, safe, RX_PARTIAL_TASKNAME, optional=True)
             validate_str("warning", param, safe, RX_TEXT_FAIL, optional=True)
             validate_str("webdirurl", param, safe, RX_URL, optional=True)
             validate_str("scheddname", param, safe, RX_SCHEDD_NAME, optional=True)
             validate_strlist("outputdatasets", param, safe, RX_OUT_DATASET)
         elif method in ['GET']:
             validate_str('subresource', param, safe, RX_SUBRES_TASK, optional=False)
-            validate_str("workflow", param, safe, RX_WORKFLOW, optional=True)
+            validate_str("workflow", param, safe, RX_PARTIAL_TASKNAME, optional=True)
             validate_str('taskstatus', param, safe, RX_STATUS, optional=True)
             validate_str('username', param, safe, RX_USERNAME, optional=True)
             validate_str('minutes', param, safe, RX_RUNS, optional=True)

--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -6,7 +6,7 @@ from WMCore.REST.Error import InvalidParameter,ExecutionError
 from CRABInterface.Utils import conn_handler
 from CRABInterface.Utils import getDBinstance
 from CRABInterface.RESTExtensions import authz_login_valid, authz_owner_match
-from CRABInterface.Regexps import RX_SUBRES_TASK, RX_PARTIAL_TASKNAME, RX_BLOCK, RX_WORKER_NAME, RX_STATUS, RX_USERNAME, RX_TEXT_FAIL, RX_DN, RX_SUBPOSTWORKER, RX_SUBGETWORKER, RX_RUNS, RX_LUMIRANGE, RX_OUT_DATASET, RX_URL, RX_OUT_DATASET, RX_SCHEDD_NAME
+from CRABInterface.Regexps import RX_SUBRES_TASK, RX_TASKNAME, RX_BLOCK, RX_WORKER_NAME, RX_STATUS, RX_USERNAME, RX_TEXT_FAIL, RX_DN, RX_SUBPOSTWORKER, RX_SUBGETWORKER, RX_RUNS, RX_LUMIRANGE, RX_OUT_DATASET, RX_URL, RX_OUT_DATASET, RX_SCHEDD_NAME
 
 # external dependecies here
 import re
@@ -34,14 +34,14 @@ class RESTTask(RESTEntity):
         authz_login_valid()
         if method in ['POST']:
             validate_str('subresource', param, safe, RX_SUBRES_TASK, optional=False)
-            validate_str("workflow", param, safe, RX_PARTIAL_TASKNAME, optional=True)
+            validate_str("workflow", param, safe, RX_TASKNAME, optional=True)
             validate_str("warning", param, safe, RX_TEXT_FAIL, optional=True)
             validate_str("webdirurl", param, safe, RX_URL, optional=True)
             validate_str("scheddname", param, safe, RX_SCHEDD_NAME, optional=True)
             validate_strlist("outputdatasets", param, safe, RX_OUT_DATASET)
         elif method in ['GET']:
             validate_str('subresource', param, safe, RX_SUBRES_TASK, optional=False)
-            validate_str("workflow", param, safe, RX_PARTIAL_TASKNAME, optional=True)
+            validate_str("workflow", param, safe, RX_TASKNAME, optional=True)
             validate_str('taskstatus', param, safe, RX_STATUS, optional=True)
             validate_str('username', param, safe, RX_USERNAME, optional=True)
             validate_str('minutes', param, safe, RX_RUNS, optional=True)

--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -328,7 +328,7 @@ class RESTUserWorkflow(RESTEntity):
 
             validate_num("publishgroupname", param, safe, optional=True)
             ## This line must come after _checkPublishDataName()
-            validate_str("workflow", param, safe, RX_WORKFLOW, optional=False)
+            validate_str("workflow", param, safe, RX_PARTIAL_TASKNAME, optional=False)
 
             ## Client versions < 3.3.1511 may put in the input dataset something that is not
             ## really an input dataset (for PrivateMC or user input files). So the only case

--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -391,7 +391,7 @@ class RESTUserWorkflow(RESTEntity):
             validate_num("dryrun", param, safe, optional=True)
 
         elif method in ['POST']:
-            validate_str("workflow", param, safe, RX_UNIQUEWF, optional=False)
+            validate_str("workflow", param, safe, RX_TASKNAME, optional=False)
             validate_str("subresource", param, safe, RX_SUBRESTAT, optional=True)
             ## In a resubmission, the site black- and whitelists need to be interpreted
             ## differently than in an initial task submission. If there is no site black-
@@ -423,7 +423,7 @@ class RESTUserWorkflow(RESTEntity):
             validate_num("force", param, safe, optional=True)
 
         elif method in ['GET']:
-            validate_str("workflow", param, safe, RX_UNIQUEWF, optional=True)
+            validate_str("workflow", param, safe, RX_TASKNAME, optional=True)
             validate_str('subresource', param, safe, RX_SUBRESTAT, optional=True)
             validate_str('username', param, safe, RX_USERNAME, optional=True)
             validate_str('timestamp', param, safe, RX_DATE, optional=True) ## inserted by eric
@@ -447,7 +447,7 @@ class RESTUserWorkflow(RESTEntity):
                 raise InvalidParameter("You need to specify the number of jobs to retrieve or their ids.")
 
         elif method in ['DELETE']:
-            validate_str("workflow", param, safe, RX_UNIQUEWF, optional=False)
+            validate_str("workflow", param, safe, RX_TASKNAME, optional=False)
             validate_num("force", param, safe, optional=True)
             validate_numlist('jobids', param, safe)
 

--- a/src/python/CRABInterface/RESTWorkerWorkflow.py
+++ b/src/python/CRABInterface/RESTWorkerWorkflow.py
@@ -5,7 +5,7 @@ from WMCore.REST.Error import InvalidParameter
 
 from CRABInterface.Utils import getDBinstance
 from CRABInterface.RESTExtensions import authz_login_valid
-from CRABInterface.Regexps import RX_WORKFLOW, RX_BLOCK, RX_WORKER_NAME, RX_STATUS, RX_TEXT_FAIL, RX_DN, RX_SUBPOSTWORKER, \
+from CRABInterface.Regexps import RX_PARTIAL_TASKNAME, RX_BLOCK, RX_WORKER_NAME, RX_STATUS, RX_TEXT_FAIL, RX_DN, RX_SUBPOSTWORKER, \
                                   RX_SUBGETWORKER, RX_RUNS, RX_LUMIRANGE
 
 # external dependecies here
@@ -28,14 +28,14 @@ class RESTWorkerWorkflow(RESTEntity):
                             #      Actually, maybe something even more strict is necessary (only the prod TW machine can access this resource)
 
         if method in ['PUT']:
-            validate_str("workflow", param, safe, RX_WORKFLOW, optional=False)
+            validate_str("workflow", param, safe, RX_PARTIAL_TASKNAME, optional=False)
             validate_num("subjobdef", param, safe, optional=True)
             validate_str("substatus", param, safe, RX_STATUS, optional=False)
             validate_strlist("subblocks", param, safe, RX_BLOCK)
             validate_str("subfailure", param, safe, RX_TEXT_FAIL, optional=True)
             validate_str("subuser", param, safe, RX_DN, optional=False)
         elif method in ['POST']:
-            validate_str("workflow", param, safe, RX_WORKFLOW, optional=True)
+            validate_str("workflow", param, safe, RX_PARTIAL_TASKNAME, optional=True)
             validate_str("status", param, safe, RX_STATUS, optional=True)
             validate_str("getstatus", param, safe, RX_STATUS, optional=True)
             validate_num("jobset", param, safe, optional=True)

--- a/src/python/CRABInterface/RESTWorkerWorkflow.py
+++ b/src/python/CRABInterface/RESTWorkerWorkflow.py
@@ -5,7 +5,7 @@ from WMCore.REST.Error import InvalidParameter
 
 from CRABInterface.Utils import getDBinstance
 from CRABInterface.RESTExtensions import authz_login_valid
-from CRABInterface.Regexps import RX_PARTIAL_TASKNAME, RX_BLOCK, RX_WORKER_NAME, RX_STATUS, RX_TEXT_FAIL, RX_DN, RX_SUBPOSTWORKER, \
+from CRABInterface.Regexps import RX_TASKNAME, RX_BLOCK, RX_WORKER_NAME, RX_STATUS, RX_TEXT_FAIL, RX_DN, RX_SUBPOSTWORKER, \
                                   RX_SUBGETWORKER, RX_RUNS, RX_LUMIRANGE
 
 # external dependecies here
@@ -28,14 +28,14 @@ class RESTWorkerWorkflow(RESTEntity):
                             #      Actually, maybe something even more strict is necessary (only the prod TW machine can access this resource)
 
         if method in ['PUT']:
-            validate_str("workflow", param, safe, RX_PARTIAL_TASKNAME, optional=False)
+            validate_str("workflow", param, safe, RX_TASKNAME, optional=False)
             validate_num("subjobdef", param, safe, optional=True)
             validate_str("substatus", param, safe, RX_STATUS, optional=False)
             validate_strlist("subblocks", param, safe, RX_BLOCK)
             validate_str("subfailure", param, safe, RX_TEXT_FAIL, optional=True)
             validate_str("subuser", param, safe, RX_DN, optional=False)
         elif method in ['POST']:
-            validate_str("workflow", param, safe, RX_PARTIAL_TASKNAME, optional=True)
+            validate_str("workflow", param, safe, RX_TASKNAME, optional=True)
             validate_str("status", param, safe, RX_STATUS, optional=True)
             validate_str("getstatus", param, safe, RX_STATUS, optional=True)
             validate_num("jobset", param, safe, optional=True)

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -8,17 +8,22 @@ from WMCore.Lexicon import lfnParts, DATASET_RE
 RX_ANYTHING = re.compile(r"^.*$")
 # TODO: we should start replacing most of the regex here with what we have in WMCore.Lexicon
 #       (this probably requires to adapt something on Lexicon)
-wfBase = r"^[a-zA-Z0-9\-_:]{1,%s}$"
 pNameRE      = r"(?=.{0,400}$)[a-zA-Z0-9\-_.]+"
 lfnParts.update( {'publishname' : pNameRE,
                   'psethash'    : '[a-f0-9]+',
                   'filename'    : '[a-zA-Z0-9\-_\.]'}
 )
-RX_PARTIAL_TASKNAME_LEN = 232 #232 = column length in the db (255) - username (8) - timestamp (12) - unserscores (3)
+wfBase = r"^[a-zA-Z0-9\-_:]{1,%s}$"
+RX_TASKNAME  = re.compile(wfBase % 255)
+## From https://account.cern.ch/account/Help/?kbid=020015
+## - All logins must be at least 3 characters long, start with a letter and contain only letters and numbers.
+## - The maximum length of the login varies with the account type.
+## - Primary accounts logins are limited to 8 characters, to ensure compatibility with all existing applications.
+## - Secondary and Service accounts can have logins up to 15 characters, but logins longer than 8 characters could cause problems with some applications or services.
+RX_PARTIAL_TASKNAME_LEN = 225 # 225 = column length in the DB (255) - username (max 15) - timestamp (12) - unserscores (2) - colon (1)
 RX_PARTIAL_TASKNAME = re.compile(wfBase % RX_PARTIAL_TASKNAME_LEN) 
 #analysis-crab3=prod jobs; analysistest=preprod jobs; analysis-crab3-hc=special HC tests (CSA14, AAA, ...); hctest=site readiness; test=middlewere validation
 RX_ACTIVITY  = re.compile(r'^analysis(test|-crab3(-hc)?)|hc(test|xrootd)|test|integration$')
-RX_TASKNAME  = re.compile(wfBase % 255)
 RX_PUBLISH   = re.compile('^'+pNameRE+'$')
 #RX_LFN       = re.compile(r'^(?=.{0,500}$)/store/(temp/)?(user|group)/%(hnName)s/%(primDS)s/%(publishname)s/%(psethash)s/%(counter)s/(log/)?%(filename)s+$' % lfnParts)
 RX_LFN       = re.compile(r'^(?=[a-zA-Z0-9\-\._/]{0,500}$)/store/(temp/)?(user/%(hnName)s|group|local)/?' % lfnParts)

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -18,13 +18,13 @@ RX_WORKFLOW_LEN = 232 #232 = column length in the db (255) - username (8) - time
 RX_WORKFLOW  = re.compile( wfBase % RX_WORKFLOW_LEN) 
 #analysis-crab3=prod jobs; analysistest=preprod jobs; analysis-crab3-hc=special HC tests (CSA14, AAA, ...); hctest=site readiness; test=middlewere validation
 RX_ACTIVITY  = re.compile(r'^analysis(test|-crab3(-hc)?)|hc(test|xrootd)|test|integration$')
-RX_UNIQUEWF  = re.compile( wfBase % 255)
+RX_TASKNAME  = re.compile(wfBase % 255)
 RX_PUBLISH   = re.compile('^'+pNameRE+'$')
 #RX_LFN       = re.compile(r'^(?=.{0,500}$)/store/(temp/)?(user|group)/%(hnName)s/%(primDS)s/%(publishname)s/%(psethash)s/%(counter)s/(log/)?%(filename)s+$' % lfnParts)
 RX_LFN       = re.compile(r'^(?=[a-zA-Z0-9\-\._/]{0,500}$)/store/(temp/)?(user/%(hnName)s|group|local)/?' % lfnParts)
 RX_PARENTLFN = re.compile(r'^(/[a-zA-Z0-9\-_\.]+/?)+$')
 RX_OUTDSLFN  = re.compile(r'^(?=.{0,500}$)/%(primDS)s/(%(hnName)s|%(physics_group)s)-%(publishname)s-%(psethash)s/USER$' % lfnParts)
-RX_CAMPAIGN  = RX_UNIQUEWF
+RX_CAMPAIGN  = RX_TASKNAME
 RX_JOBTYPE   = re.compile(r"^(?=.{0,255}$)[A-Za-z]*$")
 RX_GENERATOR = re.compile(r'^(lhe|pythia)$')
 RX_LUMIEVENTS = re.compile(r'^\d+$')

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -14,8 +14,8 @@ lfnParts.update( {'publishname' : pNameRE,
                   'psethash'    : '[a-f0-9]+',
                   'filename'    : '[a-zA-Z0-9\-_\.]'}
 )
-RX_WORKFLOW_LEN = 232 #232 = column length in the db (255) - username (8) - timestamp (12) - unserscores (3)
-RX_WORKFLOW  = re.compile( wfBase % RX_WORKFLOW_LEN) 
+RX_PARTIAL_TASKNAME_LEN = 232 #232 = column length in the db (255) - username (8) - timestamp (12) - unserscores (3)
+RX_PARTIAL_TASKNAME = re.compile(wfBase % RX_PARTIAL_TASKNAME_LEN) 
 #analysis-crab3=prod jobs; analysistest=preprod jobs; analysis-crab3-hc=special HC tests (CSA14, AAA, ...); hctest=site readiness; test=middlewere validation
 RX_ACTIVITY  = re.compile(r'^analysis(test|-crab3(-hc)?)|hc(test|xrootd)|test|integration$')
 RX_TASKNAME  = re.compile(wfBase % 255)

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -13,16 +13,15 @@ lfnParts.update( {'publishname' : pNameRE,
                   'psethash'    : '[a-f0-9]+',
                   'filename'    : '[a-zA-Z0-9\-_\.]'}
 )
-wfBase = r"^[a-zA-Z0-9\-_:]{1,%s}$"
-RX_TASKNAME_LEN = 255
-RX_TASKNAME  = re.compile(wfBase % RX_TASKNAME_LEN)
-## From https://account.cern.ch/account/Help/?kbid=020015
-## - All logins must be at least 3 characters long, start with a letter and contain only letters and numbers.
-## - The maximum length of the login varies with the account type.
-## - Primary accounts logins are limited to 8 characters, to ensure compatibility with all existing applications.
-## - Secondary and Service accounts can have logins up to 15 characters, but logins longer than 8 characters could cause problems with some applications or services.
-RX_PARTIAL_TASKNAME_LEN = 225 # 225 = column length in the DB (255) - username (max 15) - timestamp (12) - unserscores (2) - colon (1)
-RX_PARTIAL_TASKNAME = re.compile(wfBase % RX_PARTIAL_TASKNAME_LEN) 
+## Although the taskname column in the TaskDB accepts tasknames of up to 255
+## characters, we limit the taskname to something less than that in order to
+## have room to define filenames based on the taskname (filenames have a limit
+## of 255 characters). The 232 we chose is a relic from releases < 3.3.1512 when
+## we were using RX_TASKNAME to validate both 'crab_<requestname>' from the
+## client and '<taskname>' (or '<workflow>') from the TaskWorker. We keep the
+## 232 to not break backward compatibility.
+RX_TASKNAME_LEN = 232
+RX_TASKNAME  = re.compile(r"^[a-zA-Z0-9\-_:]{1,%s}$" % RX_TASKNAME_LEN)
 #analysis-crab3=prod jobs; analysistest=preprod jobs; analysis-crab3-hc=special HC tests (CSA14, AAA, ...); hctest=site readiness; test=middlewere validation
 RX_ACTIVITY  = re.compile(r'^analysis(test|-crab3(-hc)?)|hc(test|xrootd)|test|integration$')
 RX_PUBLISH   = re.compile('^'+pNameRE+'$')

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -14,7 +14,8 @@ lfnParts.update( {'publishname' : pNameRE,
                   'filename'    : '[a-zA-Z0-9\-_\.]'}
 )
 wfBase = r"^[a-zA-Z0-9\-_:]{1,%s}$"
-RX_TASKNAME  = re.compile(wfBase % 255)
+RX_TASKNAME_LEN = 255
+RX_TASKNAME  = re.compile(wfBase % RX_TASKNAME_LEN)
 ## From https://account.cern.ch/account/Help/?kbid=020015
 ## - All logins must be at least 3 characters long, start with a letter and contain only letters and numbers.
 ## - The maximum length of the login varies with the account type.


### PR DESCRIPTION
WARNING! INCOMPLETE PULL REQUEST.
READ ALL THIS COMMENT BEFORE MERGING.


In the first three commits of this PR I renamed some variables according to the following naming convention:
taskname = \<YYMMDD\>\_\<mmhhss\>:\<username\>\_crab\_\<requestname\> (nothing new)
partial taskname = crab_\<requestname\> (this is a new naming definition, for which you can suggest a better name; we need it because this is what the client passes as the 'workflow' parameter to the server)
Then it comes the relevant commit of this PR, the 4th one. I identified many places where the taskname was being validated with the wrong regular expression (wrong in terms of allowed length, 232 instead of 255, besides the fact that both regular expressions already existed). Notice that here I also changed Jadir's new validation so that the taskname that goes into the DB can be up to 255 characters in length.
The 5th commit is to allow usernames of up to 15 characters in length (see the comment I added in the code).
The 6th commit is to remove the validation Jadir added last week, because the 4th commit should actually be enough. If for safety you prefer to keep Jadir's check, I can remove this last commit.

What I am not sure about:
RESTCampaign, is it used? I left in the validation of the 'workflow' parameter the RX_PARTIAL_TASKNAME regex so to not modify anything, since I don't understand what is this module used for. But I suspect it should be changed to RX_TASKNAME also.

I tested this PR in my private server instance defining in my CRAB config file:
```
requestName = 'test_loooooong_taskname'
config.General.requestName = requestName + 'e'*(225 - len(requestName) - len('crab_'))
```

```
$ crab submit
Will use CRAB configuration file crabConfig.py
Importing CMSSW configuration pset_tutorial_analysis.py
Finished importing CMSSW configuration pset_tutorial_analysis.py
Sending the request to the server
Success: Your task has been delivered to the CRAB3 server.
Task name: 151112_161105:atanasi_crab_test_loooooong_tasknameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
Please use 'crab status' to check how the submission process proceeds.
Log file is /afs/cern.ch/work/a/atanasi/crab3/CMSSW_7_3_5_patch2/src/crab_test_loooooong_tasknameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee/crab.log
```

The task was written into the DB and the TaskWorker could change the status to QUEUED and then to SUBMITTED. (Btw, I could also reproduce the problem of task status left on HOLDING if I don't use this PR and remove Jadir's check.) Everything fine... except one thing: the upload of the TW log to the crabcache fails in this example, because the file name that we intend to give to the file in crabcache (taskname + '_TaskWorker.log') exceeds 255 chars. The upload starts in https://github.com/dmwm/CRABServer/blob/3.3.1511.rc1/src/python/TaskWorker/Actions/Handler.py#L120-L122 and the failure occurs in https://github.com/dmwm/CRABServer/blob/3.3.1511.rc1/src/python/UserFileCache/RESTFile.py#L93

```
[13/Nov/2015:16:43:12]  SERVER OTHER ERROR __builtins__.IOError 3541d4c22853a6c3c78a95926bb39659 ([Errno 36] File name too long: '/data/srv/state/crabcache/files/a/atanasi/15/151113_154259:atanasi_crab_test_loooooong_taskname_223_eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee_TaskWorker.log')
[13/Nov/2015:16:43:12]    Traceback (most recent call last):
[13/Nov/2015:16:43:12]      File "/data/srv/HG1505c/sw.pre/slc6_amd64_gcc481/cms/crabcache/3.3.11.rc7-comp4/lib/python2.6/site-packages/WMCore/REST/Server.py", line 697, in default
[13/Nov/2015:16:43:12]        return self._call(RESTArgs(list(args), kwargs))
[13/Nov/2015:16:43:12]      File "/data/srv/HG1505c/sw.pre/slc6_amd64_gcc481/cms/crabcache/3.3.11.rc7-comp4/lib/python2.6/site-packages/WMCore/REST/Server.py", line 772, in _call
[13/Nov/2015:16:43:12]        obj = apiobj['call'](*safe.args, **safe.kwargs)
[13/Nov/2015:16:43:12]      File "/data/srv/HG1505c/sw.pre/slc6_amd64_gcc481/cms/crabcache/3.3.11.rc7-comp4/lib/python2.6/site-packages/UserFileCache/RESTFile.py", line 141, in put
[13/Nov/2015:16:43:12]        return RESTFile.put(self, inputfile, name)
[13/Nov/2015:16:43:12]      File "/data/srv/HG1505c/sw.pre/slc6_amd64_gcc481/cms/crabcache/3.3.11.rc7-comp4/lib/python2.6/site-packages/UserFileCache/RESTFile.py", line 92, in put
[13/Nov/2015:16:43:12]        handlefile = open(outfilename,'wb')
[13/Nov/2015:16:43:12]    IOError: [Errno 36] File name too long: '/data/srv/state/crabcache/files/a/atanasi/15/151113_154259:atanasi_crab_test_loooooong_taskname_223_eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee_TaskWorker.log'
[13/Nov/2015:16:43:12] osmatanasi2 188.184.135.65 "PUT /crabcache/logfile HTTP/1.1" 500 [data: 10461 in 723 out 18738 us ] [auth: OK "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=atanasi/CN=710186/CN=Andres Jorge Tanasijczuk" "" ] [ref: "" "PycURL/7.19.3 libcurl/7.35.0 OpenSSL/1.0.1m zlib/1.2.8 c-ares/1.10.0" ]
```

Possible solutions:

1) Reduce the maximum allowed taskname length from 255 to e.g. 225, so that we have room to add for example '_TaskWorker.log' and still be below 255 chars.
2) When forming the TW log file name to upload to crabcache, cut the tail of the taskname as much as needed to fit the additional '_TaskWorker.log'. This should be done in a function that would be called every time we form a filename based on the taskname. This requires changes in more places, but I think is the most robust solution.
