### PR TITLE
Rename self.result to result in status.Fixes #5066

### DIFF
--- a/src/python/CRABInterface/HTCondorDataWorkflow.py
+++ b/src/python/CRABInterface/HTCondorDataWorkflow.py
@@ -250,13 +250,11 @@ class HTCondorDataWorkflow(DataWorkflow):
                   "taskFailureMsg"   : '',
                   "taskWarningMsg"   : [],
                   "statusFailureMsg" : '',
-                  "jobSetID"         : '',
                   "jobsPerStatus"    : {},
                   "failedJobdefs"    : 0,
                   "totalJobdefs"     : 0,
                   "jobdefErrors"     : [],
                   "jobList"          : [],
-                  "saveLogs"         : 0,
                   "schedd"           : '',
                   "collector"        : '' }
 
@@ -276,11 +274,9 @@ class HTCondorDataWorkflow(DataWorkflow):
             verbose = 0
         self.logger.info("Status result for workflow %s: %s (detail level %d)" % (workflow, row.task_status, verbose))
 
-        result['jobSetID'] = workflow
-        ## Apply taskWarning and savelogs flags to output.
+        ## Apply taskWarning flag to output.
         taskWarnings = literal_eval(row.task_warnings if isinstance(row.task_warnings, str) else row.task_warnings.read())
         result["taskWarningMsg"] = taskWarnings
-        result["saveLogs"] = row.save_logs
 
         ## Helper function to add the task status and the failure message (both as taken
         ## from the TaskDB) to the result dictionary.

--- a/src/python/CRABInterface/HTCondorDataWorkflow.py
+++ b/src/python/CRABInterface/HTCondorDataWorkflow.py
@@ -246,7 +246,7 @@ class HTCondorDataWorkflow(DataWorkflow):
            :return: a workflow status summary document"""
 
         #Empty results
-        self.result = {"status"           : '',
+        result = {"status"           : '',
                   "taskFailureMsg"   : '',
                   "taskWarningMsg"   : [],
                   "statusFailureMsg" : '',
@@ -276,11 +276,11 @@ class HTCondorDataWorkflow(DataWorkflow):
             verbose = 0
         self.logger.info("Status result for workflow %s: %s (detail level %d)" % (workflow, row.task_status, verbose))
 
-        self.result['jobSetID'] = workflow
+        result['jobSetID'] = workflow
         ## Apply taskWarning and savelogs flags to output.
         taskWarnings = literal_eval(row.task_warnings if isinstance(row.task_warnings, str) else row.task_warnings.read())
-        self.result["taskWarningMsg"] = taskWarnings
-        self.result["saveLogs"] = row.save_logs
+        result["taskWarningMsg"] = taskWarnings
+        result["saveLogs"] = row.save_logs
 
         ## Helper function to add the task status and the failure message (both as taken
         ## from the TaskDB) to the result dictionary.
@@ -304,16 +304,16 @@ class HTCondorDataWorkflow(DataWorkflow):
                 #    result['statusFailureMsg'] += "\n%s" % (failure)
 
         if row.task_status in ['NEW', 'HOLDING', 'UPLOADED', 'SUBMITFAILED', 'KILLFAILED', 'RESUBMITFAILED', 'FAILED']:
-            addStatusAndFailureFromDB(self.result, row)
+            addStatusAndFailureFromDB(result, row)
             if row.task_status in ['NEW', 'UPLOADED', 'SUBMITFAILED']:
-                self.logger.debug("Detailed result for workflow %s: %s\n" % (workflow, self.result))
-                return [self.result]
+                self.logger.debug("Detailed result for workflow %s: %s\n" % (workflow, result))
+                return [result]
 
         ## Add scheduler and collector to the result dictionary.
         if row.schedd:
-            self.result['schedd'] = row.schedd
+            result['schedd'] = row.schedd
         if row.collector:
-            self.result['collector'] = row.collector
+            result['collector'] = row.collector
 
         ## Here we start to retrieve the jobs statuses.
         jobsPerStatus = {}
@@ -340,7 +340,7 @@ class HTCondorDataWorkflow(DataWorkflow):
             try:
                 DBResults = {}
                 DBResults['CRAB_UserWebDir'] = row.user_webdir
-                taskStatus = self.taskWebStatus(DBResults, verbose=verbose)
+                taskStatus = self.taskWebStatus(DBResults, verbose, result)
                 #Check timestamp, if older then 2 minutes, use old logic
                 nodeStateUpd = int(taskStatus.get('DagStatus', {}).get("Timestamp", 0))
                 DAGStatus = int(taskStatus.get('DagStatus', {}).get('DagStatus', -1))
@@ -356,9 +356,9 @@ class HTCondorDataWorkflow(DataWorkflow):
                     self.logger.info(taskStatus)
                     useOldLogic = False
                     if row.task_status in ['QUEUED', 'KILLED', 'KILLFAILED', 'RESUBMITFAILED', 'FAILED']:
-                        self.result['status'] = row.task_status
+                        result['status'] = row.task_status
                     else:
-                        self.result['status'] = dagman_codes.get(DAGStatus, row.task_status)
+                        result['status'] = dagman_codes.get(DAGStatus, row.task_status)
                 else:
                     self.logger.info("Node state file is too old or does not have an update time. Will use condor_q to get the workflow status.")
                     useOldLogic = True
@@ -369,8 +369,8 @@ class HTCondorDataWorkflow(DataWorkflow):
             except ExecutionError as ee:
                 ## The old logic will call again taskWebStatus, probably failing for the same
                 ## reason. So no need to try the old logic; we can already return.
-                addStatusAndFailure(self.result, status = 'UNKNOWN', failure = ee.info)
-                return [self.result]
+                addStatusAndFailure(result, status = 'UNKNOWN', failure = ee.info)
+                return [result]
 
         if useOldLogic:
             self.logger.info("Will get status using condor_q")
@@ -388,7 +388,7 @@ class HTCondorDataWorkflow(DataWorkflow):
             except Exception as exp: # Empty results is catched here, because getRootTasks raises InvalidParameter exception.
                 #when the task is submitted for the first time
                 if row.task_status in ['QUEUED']:
-                    self.result['status'] = row.task_status
+                    result['status'] = row.task_status
                 else:
                     msg  = "The CRAB server frontend was not able to find the task in the Grid scheduler"
                     msg += " (remember, tasks older than 30 days are automatically removed)."
@@ -398,8 +398,8 @@ class HTCondorDataWorkflow(DataWorkflow):
                     if str(exp):
                         msg += " Message from the scheduler: %s" % (str(exp))
                     self.logger.exception("%s: %s" % (workflow, msg))
-                    addStatusAndFailure(self.result, status = 'UNKNOWN', failure = msg)
-                return [self.result]
+                    addStatusAndFailure(result, status = 'UNKNOWN', failure = msg)
+                return [result]
 
             taskStatusCode = int(results[-1]['JobStatus'])
             if 'CRAB_UserWebDir' not in results[-1]:
@@ -408,35 +408,35 @@ class HTCondorDataWorkflow(DataWorkflow):
                     msg  = "The task failed to bootstrap on the Grid scheduler %s." % (address)
                     msg += " Please send an e-mail to %s." % (FEEDBACKMAIL)
                     msg += " Hold reason: %s" % (DagmanHoldReason)
-                    addStatusAndFailure(self.result, status = 'UNKNOWN', failure = msg)
+                    addStatusAndFailure(result, status = 'UNKNOWN', failure = msg)
                 else:
-                    addStatusAndFailure(self.result, status = 'SUBMITTED')
-                    self.result['taskWarningMsg'] = ["Task has not yet bootstrapped. Retry in a minute if you just submitted the task."] + self.result['taskWarningMsg']
-                return [self.result]
+                    addStatusAndFailure(result, status = 'SUBMITTED')
+                    result['taskWarningMsg'] = ["Task has not yet bootstrapped. Retry in a minute if you just submitted the task."] + result['taskWarningMsg']
+                return [result]
 
             try:
-                taskStatus = self.taskWebStatus(results[-1], verbose=verbose)
+                taskStatus = self.taskWebStatus(results[-1], verbose, result)
             except MissingNodeStatus:
                 msg = "Node status file not currently available. Retry in a minute if you just submitted the task."
-                addStatusAndFailure(self.result, status = 'UNKNOWN', failure = msg)
-                return [self.result]
+                addStatusAndFailure(result, status = 'UNKNOWN', failure = msg)
+                return [result]
             except ExecutionError as ee:
-                addStatusAndFailure(self.result, status = 'UNKNOWN', failure = ee.info)
-                return [self.result]
+                addStatusAndFailure(result, status = 'UNKNOWN', failure = ee.info)
+                return [result]
 
             if row.task_status in ['QUEUED']:
-                self.result['status'] = row.task_status
-            elif not self.result['status']:
-                self.result['status'] = task_codes.get(taskStatusCode, 'UNKNOWN')
+                result['status'] = row.task_status
+            elif not result['status']:
+                result['status'] = task_codes.get(taskStatusCode, 'UNKNOWN')
             # HoldReasonCode == 1 indicates that the TW killed the task; perhaps the DB was not properly updated afterward?
             if taskStatusCode == 5:
                 if results[-1]['HoldReasonCode'] == 16:
-                    self.result['status'] = 'InTransition'
+                    result['status'] = 'InTransition'
                 elif row.task_status != 'KILLED':
                     if results[-1]['HoldReasonCode'] == 1:
-                        self.result['status'] = 'KILLED'
-                    elif not self.result['status']:
-                        self.result['status'] = 'FAILED'
+                        result['status'] = 'KILLED'
+                    elif not result['status']:
+                        result['status'] = 'FAILED'
 
             taskJobCount = int(results[-1].get('CRAB_JobCount', 0))
 
@@ -457,35 +457,35 @@ class HTCondorDataWorkflow(DataWorkflow):
             jobsPerStatus.setdefault(status, 0)
             jobsPerStatus[status] += 1
             jobList.append((status, job))
-        self.result['jobsPerStatus'] = jobsPerStatus
-        self.result['jobList'] = jobList
-        self.result['jobs'] = taskStatus
+        result['jobsPerStatus'] = jobsPerStatus
+        result['jobList'] = jobList
+        result['jobs'] = taskStatus
 
         if len(taskStatus) == 0 and results and results[-1]['JobStatus'] == 2:
-            self.result['status'] = 'Running (jobs not submitted)'
+            result['status'] = 'Running (jobs not submitted)'
 
         #Always returning ASOURL also, it is required for kill, resubmit
         self.logger.info("ASO: %s" % row.asourl)
-        self.result['ASOURL'] = row.asourl
+        result['ASOURL'] = row.asourl
 
         ## Retrieve publication information.
         publicationInfo = {}
-        if (row.publication == 'T' and 'finished' in self.result['jobsPerStatus']):
+        if (row.publication == 'T' and 'finished' in result['jobsPerStatus']):
             publicationInfo = self.publicationStatus(workflow, row.asourl)
             self.logger.info("Publication status for workflow %s done" % workflow)
         elif (row.publication == 'F'):
             publicationInfo['status'] = {'disabled': []}
         else:
-            self.logger.info("No files to publish: Publish flag %s, files transferred: %s" % (row.publication, self.result['jobsPerStatus'].get('finished', 0)))
-        self.result['publication'] = publicationInfo.get('status', {})
-        self.result['publicationFailures'] = publicationInfo.get('failure_reasons', {})
+            self.logger.info("No files to publish: Publish flag %s, files transferred: %s" % (row.publication, result['jobsPerStatus'].get('finished', 0)))
+        result['publication'] = publicationInfo.get('status', {})
+        result['publicationFailures'] = publicationInfo.get('failure_reasons', {})
 
         ## The output datasets are written into the Task DB by the post-job
         ## when uploading the output files metadata.
         outdatasets = literal_eval(row.output_dataset.read() if row.output_dataset else 'None')
-        self.result['outdatasets'] = outdatasets
+        result['outdatasets'] = outdatasets
 
-        return [self.result]
+        return [result]
 
 
     cpu_re = re.compile(r"Usr \d+ (\d+):(\d+):(\d+), Sys \d+ (\d+):(\d+):(\d+)")
@@ -536,7 +536,7 @@ class HTCondorDataWorkflow(DataWorkflow):
                                   "contact %s if the error persist. Error from curl: %s"
                                   % (url, FEEDBACKMAIL, str(e))))
 
-    def taskWebStatus(self, task_ad, verbose):
+    def taskWebStatus(self, task_ad, verbose, statusResult):
         nodes = {}
         url = task_ad['CRAB_UserWebDir']
         curl = self.prepareCurl()
@@ -618,7 +618,7 @@ class HTCondorDataWorkflow(DataWorkflow):
             if header.status == 200:
                 fp.seek(0)
                 self.logger.debug("Starting parsing of aso state")
-                self.parseASOState(fp, nodes)
+                self.parseASOState(fp, nodes, statusResult)
                 self.logger.debug("Finished parsing of aso state")
             else:
                 self.logger.debug("No aso state file available")
@@ -672,7 +672,7 @@ class HTCondorDataWorkflow(DataWorkflow):
                     msg += " Seems the 'PublicationFailedByWorkflow' view in %s was not yet update to return the publication failures." % (asourl)
                     self.logger.error(msg)
                     return publicationInfo
-                except Exception as ex:
+                except Exception as dummyEx:
                     msg = "Error while querying CouchDB for publication failures information for workflow %s " % (workflow)
                     self.logger.exception(msg)
                     publicationInfo['failure_reasons']['error'] = msg
@@ -811,10 +811,15 @@ class HTCondorDataWorkflow(DataWorkflow):
                 info['SiteHistory'].append("Unknown")
 
 
-    def parseASOState(self, fp, nodes):
+    def parseASOState(self, fp, nodes, statusResult):
         """ Parse aso_status and for each job change the job status from 'transferring'
             to 'transferred' in case all files in the job have already been successfully
             transferred.
+
+            fp: file pointer to the ASO status file downloaded from the shedd
+            nodes: contains the data-structure representing the node state file created by dagman
+            statusResult: the dictionary it is going to be returned by the status to the client.
+                          we need this to add a warning in case there are jobs missing in the node_state file
         """
         transfers = {}
         data = json.load(fp)
@@ -824,7 +829,7 @@ class HTCondorDataWorkflow(DataWorkflow):
                 msg = ("It seems one or more jobs are missing from the node_state file."
                        " It might be corrupted as a result of a disk failure on the schedd (maybe it is full?)"
                        " This might be interesting for analysis operation (%s) %" + FEEDBACKMAIL)
-                self.result['taskWarningMsg'] = [msg] + self.result['taskWarningMsg']
+                statusResult['taskWarningMsg'] = [msg] + statusResult['taskWarningMsg']
             if jobid in nodes and nodes[jobid]['State'] == 'transferring':
                 transfers.setdefault(jobid, {})[docid] = result['value']['state']
             return
@@ -937,7 +942,7 @@ class HTCondorDataWorkflow(DataWorkflow):
                     info.setdefault('State', 'running')
                 else:
                     info.setdefault('State', 'idle')
-            elif status == 4: # STATUS_POSTRUN 
+            elif status == 4: # STATUS_POSTRUN
                 info = nodes.setdefault(nodeid, {})
                 if info.get("State") != "cooloff":
                     info['State'] = 'transferring'


### PR DESCRIPTION
This fixes a concurrency issue where different thread were writing the
same variable through the same instance of HTCondorDataWorkflow. I am
now passing the variable as an argument to the methods of the class
instead of communicate via self. That means that each thread will have
its own result variable instead of sharing the same self.result.