### PR TITLE
Fix intersection of LumiLists for secondary dataset.

### DIFF
--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -132,7 +132,7 @@ class DBSDataDiscovery(DataDiscovery):
                     infos['Parents'] = []
                     lumis = LumiList(runsAndLumis=infos['Lumis'])
                     for secfilename, secinfos in moredetails.items():
-                        if len(lumis and secinfos['lumiobj']) > 0:
+                        if (lumis & secinfos['lumiobj']):
                             infos['Parents'].append(secfilename)
                 self.logger.info("Done matching files from secondary dataset")
                 kwargs['task']['tm_use_parent'] = 1


### PR DESCRIPTION
```
Python 2.7.6 (default, Aug 14 2014, 12:34:17) 
[GCC 4.9.1] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from WMCore.DataStructs.LumiList import LumiList
>>> a = LumiList(runsAndLumis={1: [1,2]})
>>> b = LumiList(runsAndLumis={1: [4,5]})
>>> (a and b).compactList
{'1': [[4, 5]]}
>>> (b and a).compactList
{'1': [[1, 2]]}
>>> len(a and b)
1
>>> len(b and a)
1
>>> (a & b).compactList
{}
>>> (b & a).compactList
{}
>>> if (a & b):
...     print 'yes'
... 
>>> a = LumiList(runsAndLumis={1: [1,4]})
>>> b = LumiList(runsAndLumis={1: [4,5]})
>>> (a and b).compactList
{'1': [[4, 5]]}
>>> (b and a).compactList
{'1': [[1, 1], [4, 4]]}
>>> len(a and b)
1
>>> len(b and a)
1
>>> (a & b).compactList
{'1': [[4, 4]]}
>>> (b & a).compactList
{'1': [[4, 4]]}
>>> if (a & b):
...     print 'yes'
... 
yes
```