### PR TITLE
Exclude secondary files with no lumis to analyze.

### DIFF
--- a/src/python/TaskWorker/Actions/DataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DataDiscovery.py
@@ -89,6 +89,7 @@ class DataDiscovery(TaskAction):
                 for lumi in lumis:
                     uniquelumis.add((run, lumi))
                 lumi_counter += len(lumis)
+            wmfile['parentslumis'] = infos.get('ParentsLumis', {})
             wmfiles.append(wmfile)
             file_counter += 1
 


### PR DESCRIPTION
Requires https://github.com/dmwm/WMCore/pull/6417

I tested this PR running the same task as I described in the issue #5061 
The result is what I expected, that the secondary input (parent) files which have no lumis to be analyzed are not included in the list of input files for the jobs and therefore they do not appear in the FJR.
This is the task in dashboard: http://dashb-cms-job.cern.ch/dashboard/templates/task-analysis/#user=crab&refresh=0&table=Jobs&p=1&records=25&activemenu=2&status=&site=&tid=151127_201402%3Aatanasi_crab_test_parents_4
This is the relevant part of the job_fjr.1.0.json:
```
...
{"cmsRun": {
"analysis": {},
"cleanup": {},
"errors": [],
"input": {"source": [
{"catalog": "", "events": 919, "guid": "003B900F-E9EE-E111-834F-00259073E3A0", "input_source_class": "PoolSource", "input_type": "primaryFiles", "lfn": "/store/data/Run2012C/SingleMu/AOD/24Aug2012-v1/00000/003B900F-E9EE-E111-834F-00259073E3A0.root", "module_label": "source", "pfn": "root://cmsxrootd-site.fnal.gov//store/data/Run2012C/SingleMu/AOD/24Aug2012-v1/00000/003B900F-E9EE-E111-834F-00259073E3A0.root", "runs": {"198271": [749]}},
{"catalog": "", "events": 919, "guid": "E2EEB799-60C6-E111-B84C-0025901D631E", "input_source_class": "PoolSource", "input_type": "secondaryFiles", "lfn": "/store/data/Run2012C/SingleMu/RAW/v1/000/198/271/E2EEB799-60C6-E111-B84C-0025901D631E.root", "module_label": "source", "pfn": "root://cmsxrootd-site.fnal.gov//store/data/Run2012C/SingleMu/RAW/v1/000/198/271/E2EEB799-60C6-E111-B84C-0025901D631E.root", "runs": {"198271": [749]}}
]},
"logs": {},
"output": {"analysis": [], "output1": [
{"branch_hash": "536a5ef195df9f8c657c867ef96c6dfa", "catalog": "", "checksums": {"adler32": "7ce8ae2e", "cksum": "4177915558"}, "direct_stageout": true, "events": 919, "guid": "04B914F4-4495-E511-B92B-0CC47A4D76CC", "input": ["/store/data/Run2012C/SingleMu/AOD/24Aug2012-v1/00000/003B900F-E9EE-E111-834F-00259073E3A0.root", "/store/data/Run2012C/SingleMu/RAW/v1/000/198/271/E2EEB799-60C6-E111-B84C-0025901D631E.root"], "inputpfns": ["root://cmsxrootd-site.fnal.gov//store/data/Run2012C/SingleMu/AOD/24Aug2012-v1/00000/003B900F-E9EE-E111-834F-00259073E3A0.root", "root://cmsxrootd-site.fnal.gov//store/data/Run2012C/SingleMu/RAW/v1/000/198/271/E2EEB799-60C6-E111-B84C-0025901D631E.root"], "lfn": "", "module_label": "output1", "ouput_module_class": "PoolOutputModule", "pfn": "output1.root", "pset_hash": "7d4851d47bb073facc0d96017716ee10", "runs": {"198271": [749]}, "size": 42781292, "storage_site": "T2_US_Nebraska"}
]},
...
```
This is the result of 'crab report':
```
2 files have been processed
3794 events have been read
1897 events have been written
Analyzed luminosity sections written to /afs/cern.ch/work/a/atanasi/crab3/CMSSW_7_4_12_patch4/src/crab_test_parents_4/results/lumiSummary.json
Log file is /afs/cern.ch/work/a/atanasi/crab3/CMSSW_7_4_12_patch4/src/crab_test_parents_4/crab.log
```