### PR TITLE
change source_site if fallback stageout happened. Fixes #5101

### DIFF
--- a/scripts/cmscp.py
+++ b/scripts/cmscp.py
@@ -485,6 +485,13 @@ def perform_local_stageout(local_stageout_mgr, \
         ## Fallback to previous behaviour where phedex is queried for location
         if source_site == 'unknown':
             source_site = G_NODE_MAP.get(dest_temp_se, 'unknown')
+        
+        # If fallback stageout happens, PNN can be different as source
+        if 'PNN' in stageout_info:
+            print("INFO: PNN is defined in site-local-config. %s changed to %s" % (source_site, stageout_info['PNN']))
+            source_site = stageout_info['PNN']
+        else:
+            print("WARNING: PNN is not defined in site-local-config.")
 
         sites_added_ok = add_sites_to_job_report(dest_temp_file_name, \
                                                  is_log, source_site, \


### PR DESCRIPTION
Tested fallback and here is return value
>>> returnV
{'SEName': 'bsrm-3.t2.ucsd.edu', 'LFN': '/store/temp/user/jbalcas/storage.xml', 'PNN': 'T2_US_UCSD', 'StageOutCommand': 'gfal2', 'PFN': 'srm://bsrm-3.t2.ucsd.edu:8443/srm/v2/server?SFN=/hadoop/cms/phedex//store/temp/user/jbalcas/storage.xml'}

For now this is a hack, in future cmscp should tak PNN value which it got from WMCore. No need to do round trip everywhere and identify source site.