### PR TITLE
Fix issue with stageout

### DIFF
--- a/scripts/cmscp.py
+++ b/scripts/cmscp.py
@@ -1532,7 +1532,7 @@ def main():
     if cmscp_status['init_local_stageout_mgr']['return_code'] != 0:
         update_exit_info(exit_info, \
                          cmscp_status['init_direct_stageout_impl']['return_code'], \
-                         cmscp_status['init_direct_stageout_impl']['return_msg'])
+                         cmscp_status['init_direct_stageout_impl']['return_msg'], True)
     ##--------------------------------------------------------------------------
     ## Finish DIRECT STAGEOUT IMPLEMENTATION INITIALIZATION
     ##--------------------------------------------------------------------------


### PR DESCRIPTION
If local stageout manager fails to initialize, it will not rewrite it with initialization of direct stageout. This leads to files transferred with direct stageout successfully and reported back as a failure because it was not able to rewrite local stageout exit code