### PR TITLE
Masterworker now builds TW tarballs in dev environment. #4826

### DIFF
--- a/src/python/TaskWorker/MasterWorker.py
+++ b/src/python/TaskWorker/MasterWorker.py
@@ -240,6 +240,18 @@ class MasterWorker(object):
                 self.logger.error(msg + traceback.format_exc())
                 retry = False
 
+    def buildDeveloperTarballs(self):
+        """ Builds the TaskManagerRun.tar.gz and CMSRunAnalysis.tar.gz files in case the CRAB_OVERRIDE_SOURCE
+            env variable is set."""
+
+        if os.environ["CRAB_OVERRIDE_SOURCE"] and os.path.isdir(os.environ["CRAB_OVERRIDE_SOURCE"]):
+            self.logger.debug("Building TaskWorker tarballs because CRAB_OVERRIDE_SOURCE is set")
+            os.system("sh $CRAB_OVERRIDE_SOURCE./CRABServer/bin/htcondor_make_runtime.sh")
+            if (os.path.isfile(os.environ["MYTESTAREA"] + "/CMSRunAnalysis-3.3.0-pre1.tar.gz") 
+                and os.path.isfile(os.environ["MYTESTAREA"] + "/TaskManagerRun-3.3.0-pre1.tar.gz")):
+
+                os.system("mv $MYTESTAREA/CMSRunAnalysis-3.3.0-pre1.tar.gz $MYTESTAREA/CMSRunAnalysis.tar.gz")
+                os.system("mv $MYTESTAREA/TaskManagerRun-3.3.0-pre1.tar.gz $MYTESTAREA/TaskManagerRun.tar.gz")
 
     def algorithm(self):
         """I'm the intelligent guy taking care of getting the work
@@ -318,5 +330,6 @@ if __name__ == '__main__':
     mw = MasterWorker(configuration, quiet=options.quiet, debug=options.debug)
     signal.signal(signal.SIGINT, mw.quit)
     signal.signal(signal.SIGTERM, mw.quit)
+    mw.buildDeveloperTarballs()
     mw.algorithm()
     mw.slaves.end()


### PR DESCRIPTION
This doesn't fully implement the idea that was proposed in #4826. Part of that idea was to allow easier code changes on the production taskworkers by simply rebuilding the tarballs and not requiring a full RPM-based patch. However, doing this on production proved a bit too tricky for me, since some of the files needed for the tarballs aren't there and those which are, are in different locations compared to development environment. 

This change will allow the developer's masterworker to initiate the building of tarballs each time it's restarted if the environment variable "CRAB_OVERRIDE_SOURCE" is set to a developer's local repository. This should point to the folder in which git repos are located, for example "~/private/github/repos/". It's somewhat more convenient than running a separate script just for that reason.
