### PR TITLE
Let local stageout work when source_site = dest_site

### DIFF
--- a/scripts/cmscp.py
+++ b/scripts/cmscp.py
@@ -426,13 +426,15 @@ def perform_stageout(local_stageout_mgr, direct_stageout_impl, \
     Wrapper for local and direct stageouts.
     """
     if policy == 'local':
-        retval, retmsg = perform_local_stageout(local_stageout_mgr, \
-                                                source_file, dest_temp_lfn, \
-                                                dest_lfn, dest_site, \
-                                                source_site, is_log, inject)
+        retval, retmsg, is_file_temp = \
+                                    perform_local_stageout(local_stageout_mgr, \
+                                                    source_file, dest_temp_lfn, \
+                                                    dest_lfn, dest_site, \
+                                                    source_site, is_log, inject)
     elif policy == 'remote':
         ## Can return 60311, 60307 or 60403.
-        retval, retmsg = perform_direct_stageout(direct_stageout_impl, \
+        retval, retmsg, is_file_temp = \
+                                    perform_direct_stageout(direct_stageout_impl, \
                                                  direct_stageout_command, \
                                                  direct_stageout_protocol, \
                                                  source_file, dest_pfn, dest_site, \
@@ -440,8 +442,8 @@ def perform_stageout(local_stageout_mgr, direct_stageout_impl, \
     else:
         msg = "ERROR: Skipping unknown stageout policy named '%s'." % (policy)
         print(msg)
-        retval, retmsg = 80000, msg
-    return retval, retmsg
+        retval, retmsg, is_file_temp = 80000, msg, False
+    return retval, retmsg, is_file_temp
 
 ## = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
@@ -507,7 +509,7 @@ def perform_local_stageout(local_stageout_mgr, \
                                   'inject'             : True
                                  }
             G_ASO_TRANSFER_REQUESTS.append(file_transfer_info)
-    return retval, retmsg
+    return retval, retmsg, True
 
 ## = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
@@ -755,7 +757,7 @@ def perform_direct_stageout(direct_stageout_impl, \
             msg = "WARNING: Ignoring failure in adding the above information to the job report."
             print(msg)
 
-    return retval, retmsg
+    return retval, retmsg, False
 
 ## = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
@@ -1577,7 +1579,8 @@ def main():
             print(msg)
             try:
                 cmscp_status['logs_stageout'][policy]['return_code'], \
-                cmscp_status['logs_stageout'][policy]['return_msg'] = \
+                cmscp_status['logs_stageout'][policy]['return_msg'], \
+                cmscp_status['logs_stageout'][policy]['files_temp'], = \
                                                      perform_stageout(local_stageout_mgr, \
                                                                       direct_stageout_impl, \
                                                                       direct_stageout_command, \
@@ -1662,7 +1665,8 @@ def main():
                     output_dest_lfn = os.path.join(dest_final_dir, output_dest_file_name)
                     try:
                         cur_retval, \
-                        cur_retmsg = perform_stageout(local_stageout_mgr, \
+                        cur_retmsg, \
+                        cur_files_temp = perform_stageout(local_stageout_mgr, \
                                                       direct_stageout_impl, \
                                                       direct_stageout_command, \
                                                       direct_stageout_protocol, \

--- a/scripts/cmscp.py
+++ b/scripts/cmscp.py
@@ -124,16 +124,17 @@ G_JOB_WRAPPER_EXIT_CODE = None
 ## as one single atomic thing and we only use G_JOB_WRAPPER_EXIT_CODE.
 G_JOB_EXIT_CODE = None
 
-## List to collect the files that have been staged out directly. The list is
-## filed by the perform_direct_stageout() function. For each file, append a
-## dictionary with relevant information used then in the clean_stageout_area()
-## function. If a file is removed from the remote storage, we still keep the
-## file in this list, but set the 'removed' flag to True.
+## List to collect the files that have been staged out directly the permenant
+## storage location. The list is filed by the perform_<policy>_stageout()
+## functions. For each file, append a dictionary with relevant information used
+## then in the clean_stageout_area() function. If a file is removed from the
+## remote storage, we still keep the file in this list, but set the 'removed'
+## flag to True.
 G_DIRECT_STAGEOUTS = []
 
-## List to collect the transfer requests to ASO for files that were
-## successfully transferred to the local storage. This list is filled in by the
-## perform_local_stageout() function. For each file, append a dictionary with
+## List to collect the transfer requests to ASO for files that were successfully
+## transferred to the local storage. This list is filled in by the
+## perform_<policy>_stageout() functions. For each file, append a dictionary with
 ## the information needed by the inject_to_aso() function.
 G_ASO_TRANSFER_REQUESTS = []
 

--- a/scripts/cmscp.py
+++ b/scripts/cmscp.py
@@ -1568,15 +1568,17 @@ def main():
         ##---------------
         ## Logs stageout.
         ##---------------
-        condition = condition_logs_stageout
+        condition_logs_xfer_okay = False
+        for test_policy in cmscp_status['logs_stageout']:
+            if test_policy['return_code'] == 0:
+                condition_logs_xfer_okay = True
+        condition = condition_logs_stageout and condition_logs_xfer_okay
         if policy == 'local':
             condition = (condition and \
-                         cmscp_status['init_local_stageout_mgr']['return_code'] == 0 and \
-                         cmscp_status['logs_stageout']['remote']['return_code'] != 0)
+                         cmscp_status['init_local_stageout_mgr']['return_code'] == 0)
         elif policy == 'remote':
             condition = (condition and \
-                         cmscp_status['init_direct_stageout_impl']['return_code'] == 0 and \
-                         cmscp_status['logs_stageout']['local']['return_code'] != 0)
+                         cmscp_status['init_direct_stageout_impl']['return_code'] == 0)
         ## There are some cases where we don't have to stage out the log files.
         if condition:
             if skip['logs_stageout'][policy]:
@@ -1628,15 +1630,18 @@ def main():
         ##------------------
         ## Outputs stageout.
         ##------------------
-        condition = condition_outputs_stageout
+        condition_outputs_xfer_okay = False
+        for test_policy in cmscp_status['outputs_stageout']:
+            if test_policy['return_code'] == 0:
+                condition_outputs_xfer_okay = True
+        condition = condition_logs_stageout and condition_outputs_xfer_okay
         if policy == 'local':
             condition = (condition and \
-                         cmscp_status['init_local_stageout_mgr']['return_code'] == 0 and \
-                         cmscp_status['outputs_stageout']['remote']['return_code'] != 0)
+                         cmscp_status['init_local_stageout_mgr']['return_code'] == 0)
         elif policy == 'remote':
             condition = (condition and \
-                         cmscp_status['init_direct_stageout_impl']['return_code'] == 0 and \
-                         cmscp_status['outputs_stageout']['local']['return_code'] != 0)
+                         cmscp_status['init_direct_stageout_impl']['return_code'] == 0)
+
         ## There are some cases where we don't have to stage out the output files.
         if condition:
             if skip['outputs_stageout'][policy]:

--- a/scripts/cmscp.py
+++ b/scripts/cmscp.py
@@ -1265,9 +1265,11 @@ def main():
     if source_site == dest_site:
         # Make sure two policies are used (local, remote) and we can change it
         # It can be that only one policy is specified. See TW configuration file.
-        if stageout_policy == ["local", "remote"]:
+        if stageout_policy[0] != "local" and "local" in stageout_policy:
             print('Job execution site is the same as destination site. Changing stageout policy.')
-            stageout_policy = ["remote", "local"]
+            while "local" in stageout_policy:
+                stageout_policy.remove("local")
+            stageout_policy.insert(0, "local")
             print('New stageout policy: %s' % (", ".join(stageout_policy)))
         else:
             print('Not rewriting stageout policy. Continue with %s stageout policy.' % (", ".join(stageout_policy)))


### PR DESCRIPTION
Needs to be tested (which is surprisingly difficult to do). If source_site == dest_site, use the local stageout manager instead of the remote one (SRM)
- Updates cmscp.py to allow perform_<policy>_stageout the choice of storing files in temp or the permanent location.
- Adds additional metadata in cmscp's status dict to let it know where to find files
- Updates cleanup code to leave log files on WN if the file made it via local policy to permanent storage
- Re-flips (deflips?) the startup logic to add "local" to the front of the policy list if:
  - Local is already in the policy list
  - It's not at the front

Fixes #5156 
