### PR TITLE
Add WMCore Utils to the Taskworker tarballs

### DIFF
--- a/bin/htcondor_make_runtime.sh
+++ b/bin/htcondor_make_runtime.sh
@@ -57,7 +57,7 @@ if [[ "x$RPM_RELEASE" != "x" ]]; then
 
     pushd $ORIGDIR/../WMCore-$WMCOREVER/build/lib/
     zip -r $STARTDIR/WMCore.zip *
-    zip -rq $STARTDIR/CRAB3.zip WMCore PSetTweaks -x \*.pyc || exit 3
+    zip -rq $STARTDIR/CRAB3.zip WMCore PSetTweaks Utils -x \*.pyc || exit 3
     popd
 
     pushd $ORIGDIR/build/lib
@@ -135,7 +135,7 @@ else
 
     pushd $WMCORE_PATH/src/python
     zip -rq $STARTDIR/WMCore.zip * || exit 3
-    zip -rq $STARTDIR/CRAB3.zip WMCore PSetTweaks -x \*.pyc || exit 3
+    zip -rq $STARTDIR/CRAB3.zip WMCore PSetTweaks Utils -x \*.pyc || exit 3
     popd
 
     pushd $CRABSERVER_PATH/src/python


### PR DESCRIPTION
Because of a recent change in WMCore, Taskworker is missing some modules from the WMCore Utils directory. Putting it in the TaskManagerRun.tar.gz tarball would solve this problem. 