### PR TITLE
Make sure to always use pycurl

### DIFF
--- a/src/python/RESTInteractions.py
+++ b/src/python/RESTInteractions.py
@@ -129,7 +129,7 @@ class HTTPRequests(dict):
 
         decode the response result reveiced from the server
         """
-        encoder = JSONRequests()
+        encoder = JSONRequests(idict={"pycurl" : True})
         return encoder.decode(result)
 
 


### PR DESCRIPTION
The new "lightweight" client was blowing up without this