### PR TITLE
Allow operators to kill and resubmit tasks

### DIFF
--- a/src/python/CRABInterface/DataUserWorkflow.py
+++ b/src/python/CRABInterface/DataUserWorkflow.py
@@ -134,14 +134,14 @@ class DataUserWorkflow(object):
         """
         return self.workflow.status(workflow, userdn, userproxy, verbose=verbose)
 
-    def kill(self, workflow, force, jobids, userdn, userproxy=None):
+    def kill(self, workflow, force, jobids, killwarning, userdn, userproxy=None):
         """Request to Abort a workflow.
 
            :arg str workflow: a workflow name
            :arg str force: a flag to know if kill should be brutal
            :arg str userproxy: the user proxy retrieved by `retrieveUserCert`
            :arg int force: force to delete the workflows in any case; 0 no, everything else yes"""
-        return self.workflow.kill(workflow, force, jobids, userdn, userproxy)
+        return self.workflow.kill(workflow, force, jobids, killwarning, userdn, userproxy)
 
     def proceed(self, workflow):
         """Continue a task initialized with 'crab submit --dryrun'.

--- a/src/python/CRABInterface/RESTExtensions.py
+++ b/src/python/CRABInterface/RESTExtensions.py
@@ -23,17 +23,20 @@ def authz_operator(username = None):
 
 
 def authz_owner_match(dbapi, workflows, Task):
-    """Match user against authorisation requirements to modify an existing resource.
-       Allows to cache couchdb fetched documents if the caller needs them.
+    """ Match user against authorization requirements to modify an existing (list of) workflows.
+        Either the user is the one who submitted the workflow, or it is an operator.
 
-       :arg WMCore.CMSCouch.Database database: database connection to retrieve the docs
-       :arg str list workflows: a list of workflows unique name as positive check
-       :return: in case retrieve_docs is not false the list of couchdb documents."""
+        :arg str list workflows: a list of workflows unique name as positive check
+    """
     user = cherrypy.request.user
     log = cherrypy.log
 
-    alldocs = []
+    #if the user trying to access the resource is an operator just exit to allow access
+    if 'crab3' in cherrypy.request.user.get('roles', {}).get('operator', {}).get('group', set()):
+        log("DEBUG: authz operator %s to access resources %s" % (user, workflows))
+        return
 
+    alldocs = []
     for wf in workflows:
         wfrow = None
         try:

--- a/src/python/Databases/TaskDB/Oracle/Task/Task.py
+++ b/src/python/Databases/TaskDB/Oracle/Task/Task.py
@@ -132,9 +132,11 @@ class Task(object):
     SetStartInjection_sql = "UPDATE tasks SET tm_start_injection = SYS_EXTRACT_UTC(SYSTIMESTAMP) \
                             WHERE tm_taskname = :tm_taskname"
    
-    #SetStatusTask -- Used by DataWorkflow.resubmit (crab resubmit), DataWorkflow.kill (crab kill), and DataWorkflow.proceed (crab proceed)
+    #SetStatusTask -- Used by DataWorkflow.resubmit (crab resubmit), and DataWorkflow.proceed (crab proceed)
     #              -- Also used by RESTWorkerWorkflow
     SetStatusTask_sql = "UPDATE tasks SET tm_task_status = upper(:status), tm_task_command = upper(:command) WHERE tm_taskname = :taskname"
+    #SetStatusTask -- Used by DataWorkflow.kill (crab kill). Really similar to SetStatusTask_sql but also set a warning.
+    SetStatusWarningTask_sql = "UPDATE tasks SET tm_task_status = upper(:status), tm_task_command = upper(:command), tm_task_warnings = :warnings WHERE tm_taskname = :taskname"
    
     #UpdateWorker
     UpdateWorker_sql = """UPDATE tasks SET tw_name = :tw_name, tm_task_status = :set_status \


### PR DESCRIPTION
After a discussion summarized here
https://github.com/dmwm/AsyncStageout/wiki/Protecting-from-disaster
turned out it would be useful in the future if oeprators had an easy way
to kill users task. That's a prerequisite for that.