### PR TITLE
Allow tm_task_command column in Oracle Create.py to be NULL

### DIFF
--- a/src/python/Databases/TaskDB/Oracle/Create.py
+++ b/src/python/Databases/TaskDB/Oracle/Create.py
@@ -36,7 +36,7 @@ class Create(DBCreator):
         tm_activity VARCHAR(255),
         panda_jobset_id NUMBER(11),
         tm_task_status VARCHAR(255) NOT NULL,
-        tm_task_command VARCHAR(20) NOT NULL,
+        tm_task_command VARCHAR(20),
         tm_start_time TIMESTAMP,
         tm_start_injection TIMESTAMP,
         tm_end_injection TIMESTAMP,


### PR DESCRIPTION
Discovered a small issue when trying to kill tasks where the server couldn't set the tm_task_command column to NULL. This was because I used the creation script to create the DB tables (which contains an incorrect column definition), whereas on production, update [1] commands are used to modify the database which are correct. 

[1] https://github.com/dmwm/CRABServer/blob/master/etc/updateOracle.sql