### PR TITLE
Separate Ops monitoring files into another tarball. Fixes #5153

### DIFF
--- a/etc/updateOracle.sql
+++ b/etc/updateOracle.sql
@@ -81,3 +81,5 @@ UPDATE tasks SET tm_task_status='NEW',tm_task_command='SUBMIT' WHERE tm_task_sta
 
 --Changes that will be needed for version 3.3.1605
 alter table tasks add (clusterid NUMBER(10));
+--Changes that will be needed for version 3.3.1607
+alter table tasks add (tm_debug_files VARCHAR(255));

--- a/scripts/AdjustSites.py
+++ b/scripts/AdjustSites.py
@@ -194,6 +194,8 @@ def makeWebDir(ad):
         os.makedirs(path)
         ## Copy the sandbox to the web directory.
         shutil.copy2(os.path.join(".", "sandbox.tar.gz"), os.path.join(path, "sandbox.tar.gz"))
+        shutil.copy2(os.path.join(".", "debug_files.tar.gz"), os.path.join(path, "debug_files.tar.gz"))
+
         ## Make all the necessary symbolic links in the web directory.
         sourceLinks = ["debug",
                        "RunJobs.dag", "RunJobs.dag.dagman.out", "RunJobs.dag.nodes.log",

--- a/scripts/AdjustSites.py
+++ b/scripts/AdjustSites.py
@@ -194,7 +194,9 @@ def makeWebDir(ad):
         os.makedirs(path)
         ## Copy the sandbox to the web directory.
         shutil.copy2(os.path.join(".", "sandbox.tar.gz"), os.path.join(path, "sandbox.tar.gz"))
-        shutil.copy2(os.path.join(".", "debug_files.tar.gz"), os.path.join(path, "debug_files.tar.gz"))
+        ## Copy the debug folder. It might not be available if an older (<3.3.1607) crabclient is used.
+        if os.path.isfile(os.path.join(".", "debug_files.tar.gz")):
+            shutil.copy2(os.path.join(".", "debug_files.tar.gz"), os.path.join(path, "debug_files.tar.gz"))
 
         ## Make all the necessary symbolic links in the web directory.
         sourceLinks = ["debug",

--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -99,7 +99,7 @@ class DataWorkflow(object):
 
     @conn_handler(services=['centralconfig'])
     def submit(self, workflow, activity, jobtype, jobsw, jobarch, use_parent, secondarydata, generator, events_per_lumi, siteblacklist,
-               sitewhitelist, splitalgo, algoargs, cachefilename, cacheurl, addoutputfiles,
+               sitewhitelist, splitalgo, algoargs, cachefilename, debugfilename, cacheurl, addoutputfiles,
                username, userdn, savelogsflag, publication, publishname, publishname2, asyncdest, dbsurl, publishdbsurl, vorole, vogroup, tfileoutfiles, edmoutfiles,
                runs, lumis, totalunits, adduserfiles, oneEventMode=False, maxjobruntime=None, numcores=None, maxmemory=None, priority=None, lfn=None,
                ignorelocality=None, saveoutput=None, faillimit=10, userfiles=None, userproxy=None, asourl=None, asodb=None, scriptexe=None, scriptargs=None,
@@ -203,6 +203,7 @@ class DataWorkflow(object):
                                                 splitArgName : algoargs, 'runs': runs, 'lumis': lumis})],
                             total_units     = [totalunits],
                             user_sandbox    = [cachefilename],
+                            debug_files     = [debugfilename],
                             cache_url       = [cacheurl],
                             username        = [username],
                             user_dn         = [userdn],

--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -1,11 +1,10 @@
 import copy
 import time
 import logging
-import cherrypy
 from ast import literal_eval
 
 ## WMCore dependecies
-from WMCore.REST.Error import ExecutionError, InvalidParameter
+from WMCore.REST.Error import ExecutionError
 
 ## CRAB dependencies
 from ServerUtilities import TASKLIFETIME
@@ -99,11 +98,12 @@ class DataWorkflow(object):
 
     @conn_handler(services=['centralconfig'])
     def submit(self, workflow, activity, jobtype, jobsw, jobarch, use_parent, secondarydata, generator, events_per_lumi, siteblacklist,
-               sitewhitelist, splitalgo, algoargs, cachefilename, debugfilename, cacheurl, addoutputfiles,
+               sitewhitelist, splitalgo, algoargs, cachefilename, cacheurl, addoutputfiles,
                username, userdn, savelogsflag, publication, publishname, publishname2, asyncdest, dbsurl, publishdbsurl, vorole, vogroup, tfileoutfiles, edmoutfiles,
                runs, lumis, totalunits, adduserfiles, oneEventMode=False, maxjobruntime=None, numcores=None, maxmemory=None, priority=None, lfn=None,
                ignorelocality=None, saveoutput=None, faillimit=10, userfiles=None, userproxy=None, asourl=None, asodb=None, scriptexe=None, scriptargs=None,
-               scheddname=None, extrajdl=None, collector=None, dryrun=False, publishgroupname=False, nonvaliddata=False, inputdata=None, primarydataset=None):
+               scheddname=None, extrajdl=None, collector=None, dryrun=False, publishgroupname=False, nonvaliddata=False, inputdata=None, primarydataset=None,
+               debugfilename=None):
         """Perform the workflow injection
 
            :arg str workflow: workflow name requested by the user;

--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -342,6 +342,7 @@ class RESTUserWorkflow(RESTEntity):
             validate_num("algoargs", param, safe, optional=False)
             validate_num("totalunits", param, safe, optional=True)
             validate_str("cachefilename", param, safe, RX_CACHENAME, optional=False)
+            validate_str("debugfilename", param, safe, RX_CACHENAME, optional=False)
             validate_str("cacheurl", param, safe, RX_CACHEURL, optional=False)
             validate_str("lfn", param, safe, RX_LFN, optional=True)
             self._checkOutLFN(safe.kwargs, username)
@@ -531,7 +532,7 @@ class RESTUserWorkflow(RESTEntity):
     @restcall
     #@getUserCert(headers=cherrypy.request.headers)
     def put(self, workflow, activity, jobtype, jobsw, jobarch, inputdata, primarydataset, nonvaliddata, useparent, secondarydata, generator, eventsperlumi,
-                siteblacklist, sitewhitelist, splitalgo, algoargs, cachefilename, cacheurl, addoutputfiles,
+                siteblacklist, sitewhitelist, splitalgo, algoargs, cachefilename, debugfilename, cacheurl, addoutputfiles,
                 savelogsflag, publication, publishname, publishname2, publishgroupname, asyncdest, dbsurl, publishdbsurl, vorole, vogroup,
                 tfileoutfiles, edmoutfiles, runs, lumis,
                 totalunits, adduserfiles, oneEventMode, maxjobruntime, numcores, maxmemory, priority, blacklistT1, nonprodsw, lfn, saveoutput,
@@ -555,6 +556,7 @@ class RESTUserWorkflow(RESTEntity):
            :arg str splitalgo: algorithm to be used for the workflow splitting;
            :arg str algoargs: argument to be used by the splitting algorithm;
            :arg str cachefilename: name of the file inside the cache
+           :arg str debugfilename: name of the debugFiles tarball inside the cache
            :arg str cacheurl: URL of the cache
            :arg str list addoutputfiles: list of additional output files;
            :arg int savelogsflag: archive the log files? 0 no, everything else yes;
@@ -598,7 +600,7 @@ class RESTUserWorkflow(RESTEntity):
                                        inputdata=inputdata, primarydataset=primarydataset, nonvaliddata=nonvaliddata, use_parent=useparent,
                                        secondarydata=secondarydata, generator=generator, events_per_lumi=eventsperlumi,
                                        siteblacklist=siteblacklist, sitewhitelist=sitewhitelist, splitalgo=splitalgo, algoargs=algoargs,
-                                       cachefilename=cachefilename, cacheurl=cacheurl,
+                                       cachefilename=cachefilename, debugfilename=debugfilename, cacheurl=cacheurl,
                                        addoutputfiles=addoutputfiles, userdn=cherrypy.request.user['dn'],
                                        username=cherrypy.request.user['login'], savelogsflag=savelogsflag, vorole=vorole, vogroup=vogroup,
                                        publication=publication, publishname=publishname, publishname2=publishname2, publishgroupname=publishgroupname, asyncdest=asyncdest,

--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -342,7 +342,7 @@ class RESTUserWorkflow(RESTEntity):
             validate_num("algoargs", param, safe, optional=False)
             validate_num("totalunits", param, safe, optional=True)
             validate_str("cachefilename", param, safe, RX_CACHENAME, optional=False)
-            validate_str("debugfilename", param, safe, RX_CACHENAME, optional=False)
+            validate_str("debugfilename", param, safe, RX_CACHENAME, optional=True)
             validate_str("cacheurl", param, safe, RX_CACHEURL, optional=False)
             validate_str("lfn", param, safe, RX_LFN, optional=True)
             self._checkOutLFN(safe.kwargs, username)

--- a/src/python/Databases/TaskDB/Oracle/Task/Task.py
+++ b/src/python/Databases/TaskDB/Oracle/Task/Task.py
@@ -41,7 +41,7 @@ class Task(object):
     New_sql = "INSERT INTO tasks ( \
               tm_taskname, tm_activity, panda_jobset_id, tm_task_status, tm_task_command, tm_start_time, tm_task_failure, tm_job_sw, \
               tm_job_arch, tm_input_dataset, tm_primary_dataset, tm_nonvalid_input_dataset, tm_use_parent, tm_secondary_input_dataset, tm_site_whitelist, tm_site_blacklist, \
-              tm_split_algo, tm_split_args, tm_totalunits, tm_user_sandbox, tm_cache_url, tm_username, tm_user_dn, \
+              tm_split_algo, tm_split_args, tm_totalunits, tm_user_sandbox, tm_debug_files, tm_cache_url, tm_username, tm_user_dn, \
               tm_user_vo, tm_user_role, tm_user_group, tm_publish_name, tm_publish_groupname, tm_asyncdest, tm_dbs_url, tm_publish_dbs_url, \
               tm_publication, tm_outfiles, tm_tfile_outfiles, tm_edm_outfiles, tm_job_type, tm_generator, tm_arguments, \
               panda_resubmitted_jobs, tm_save_logs, tm_user_infiles, tm_maxjobruntime, tm_numcores, tm_maxmemory, tm_priority, \
@@ -49,7 +49,7 @@ class Task(object):
               tm_user_files, tm_transfer_outputs, tm_output_lfn, tm_ignore_locality, tm_fail_limit, tm_one_event_mode) \
               VALUES (:task_name, :task_activity, :jobset_id, upper(:task_status), upper(:task_command), SYS_EXTRACT_UTC(SYSTIMESTAMP), :task_failure, :job_sw, \
               :job_arch, :input_dataset, :primary_dataset, :nonvalid_data, :use_parent, :secondary_dataset, :site_whitelist, :site_blacklist, \
-              :split_algo, :split_args, :total_units, :user_sandbox, :cache_url, :username, :user_dn, \
+              :split_algo, :split_args, :total_units, :user_sandbox, :debug_files, :cache_url, :username, :user_dn, \
               :user_vo, :user_role, :user_group, :publish_name, :publish_groupname, :asyncdest, :dbs_url, :publish_dbs_url, \
               :publication, :outfiles, :tfile_outfiles, :edm_outfiles, :job_type, :generator, :arguments, \
               :resubmitted_jobs, :save_logs, :user_infiles, :maxjobruntime, :numcores, :maxmemory, :priority, \
@@ -60,7 +60,7 @@ class Task(object):
                        "tm_start_time", "tm_start_injection", "tm_end_injection", \
                        "tm_task_failure", "tm_job_sw", "tm_job_arch", "tm_input_dataset", \
                        "tm_site_whitelist", "tm_site_blacklist", "tm_split_algo", "tm_split_args", \
-                       "tm_totalunits", "tm_user_sandbox", "tm_cache_url", "tm_username", "tm_user_dn", "tm_user_vo", \
+                       "tm_totalunits", "tm_user_sandbox", "tm_debug_files", "tm_cache_url", "tm_username", "tm_user_dn", "tm_user_vo", \
                        "tm_user_role", "tm_user_group", "tm_publish_name", "tm_asyncdest", "tm_dbs_url", \
                        "tm_publish_dbs_url", "tm_publication", "tm_outfiles", "tm_tfile_outfiles", "tm_edm_outfiles", \
                        "tm_job_type", "tm_arguments", "panda_resubmitted_jobs", "tm_save_logs", \
@@ -74,7 +74,7 @@ class Task(object):
                        tm_start_time, tm_start_injection, tm_end_injection, \
                        tm_task_failure, tm_job_sw, tm_job_arch, tm_input_dataset, \
                        tm_site_whitelist, tm_site_blacklist, tm_split_algo, tm_split_args, \
-                       tm_totalunits, tm_user_sandbox, tm_cache_url, tm_username, tm_user_dn, tm_user_vo, \
+                       tm_totalunits, tm_user_sandbox, tm_debug_files, tm_cache_url, tm_username, tm_user_dn, tm_user_vo, \
                        tm_user_role, tm_user_group, tm_publish_name, tm_asyncdest, tm_dbs_url, \
                        tm_publish_dbs_url, tm_publication, tm_outfiles, tm_tfile_outfiles, tm_edm_outfiles, \
                        tm_job_type, tm_arguments, panda_resubmitted_jobs, tm_save_logs, \

--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -53,6 +53,18 @@ def USER_SANDBOX_EXCLUSIONS(tarmembers):
     """
     if BOOTSTRAP_CFGFILE_DUMP in map(lambda x: x.name, tarmembers):
         #exclude the pickle pset if the dumpPython PSet is there
+        return ['PSet.py', 'PSet.pkl', 'debug/crabConfig.py', 'debug/originalPSet.py.py']
+    else:
+        return ['debug/crabConfig.py', 'debug/originalPSet.py.py']
+    
+def NEW_USER_SANDBOX_EXCLUSIONS(tarmembers):
+    """ Exclusion function used with the new crabclient (>= 3.3.1607). Since the new client sandbox no longer
+        contains the debug files, it's pointless to exclude them. Also, this function is used when getting
+        the hash of the debug tarball (a new addition in 3.3.1607). If the debug files are excluded, the tarball
+        would always have the same hash and stay the same, serving no purpose.
+    """
+    if BOOTSTRAP_CFGFILE_DUMP in map(lambda x: x.name, tarmembers):
+        #exclude the pickle pset if the dumpPython PSet is there
         return ['PSet.py', 'PSet.pkl']
     else:
         return []

--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -53,9 +53,9 @@ def USER_SANDBOX_EXCLUSIONS(tarmembers):
     """
     if BOOTSTRAP_CFGFILE_DUMP in map(lambda x: x.name, tarmembers):
         #exclude the pickle pset if the dumpPython PSet is there
-        return ['PSet.py', 'PSet.pkl', 'debug/crabConfig.py', 'debug/originalPSet.py.py']
+        return ['PSet.py', 'PSet.pkl']
     else:
-        return ['debug/crabConfig.py', 'debug/originalPSet.py.py']
+        return []
 
 
 def checkOutLFN(lfn, username):

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -820,14 +820,14 @@ class DagmanCreator(TaskAction.TaskAction):
         Also modified inputFiles list by appending a debug folder if extraction succeeds.
         """
         try:
-            sandboxTar = tarfile.open('sandbox.tar.gz')
-            sandboxTar.extract('debug/crabConfig.py')
-            sandboxTar.extract('debug/originalPSet.py')
+            debugTar = tarfile.open('debug_files.tar.gz')
+            debugTar.extract('debug/crabConfig.py')
+            debugTar.extract('debug/originalPSet.py')
             scriptExeName = kw['task'].get('tm_scriptexe')
             if scriptExeName != None:
-                sandboxTar.extract(scriptExeName)
+                debugTar.extract(scriptExeName)
                 shutil.copy(scriptExeName, 'debug/' + scriptExeName)
-            sandboxTar.close()
+            debugTar.close()
 
             inputFiles.append('debug')
 
@@ -866,6 +866,7 @@ class DagmanCreator(TaskAction.TaskAction):
             ufc = UserFileCache(mydict={'cert': kw['task']['user_proxy'], 'key': kw['task']['user_proxy'], 'endpoint' : kw['task']['tm_cache_url']})
             try:
                 ufc.download(hashkey=kw['task']['tm_user_sandbox'].split(".")[0], output="sandbox.tar.gz")
+                ufc.download(hashkey=kw['task']['tm_debug_files'].split(".")[0], output="debug_files.tar.gz")
             except Exception as ex:
                 self.logger.exception(ex)
                 raise TaskWorkerException("The CRAB3 server backend could not download the input sandbox with your code "+\
@@ -901,6 +902,7 @@ class DagmanCreator(TaskAction.TaskAction):
         if kw['task']['tm_input_dataset']:
             inputFiles.append("input_dataset_lumis.json")
             inputFiles.append("input_dataset_duplicate_lumis.json")
+        inputFiles.append("debug_files.tar.gz")
 
         info, splitterResult = self.createSubdag(*args, **kw)
 

--- a/src/python/UserFileCache/RESTExtensions.py
+++ b/src/python/UserFileCache/RESTExtensions.py
@@ -4,7 +4,7 @@ These are extensions which are not directly contained in WMCore.REST module.
 Collecting all here since aren't supposed to be many.
 """
 
-from ServerUtilities import USER_SANDBOX_EXCLUSIONS
+from ServerUtilities import USER_SANDBOX_EXCLUSIONS, NEW_USER_SANDBOX_EXCLUSIONS
 
 # WMCore dependecies here
 from WMCore.REST.Validation import _validate_one
@@ -63,7 +63,7 @@ def list_users(cachedir):
                 yield username
 
 def list_files(quotapath):
-    for dirpath, dirnames, filenames in walk(quotapath):
+    for _, _, filenames in walk(quotapath):
         for f in filenames:
             yield f
 
@@ -73,7 +73,7 @@ def get_size(quotapath):
     :arg str quotapath: the directory for which is needed to calculate the quota
     :return: bytes taken by the directory"""
     totalsize = 0
-    for dirpath, dirnames, filenames in walk(quotapath):
+    for dirpath, _, filenames in walk(quotapath):
         for f in filenames:
             fp = path.join(dirpath, f)
             totalsize += path.getsize(fp)
@@ -85,7 +85,7 @@ def quota_user_free(quotadir, infile):
     :arg str quotadir: the user path where the file will be written
     :arg file|cStringIO.StringIO infile: file object handler or cStringIO.StringIO
     :return: Nothing"""
-    filesize, realfile = file_size(infile.file)
+    filesize, _ = file_size(infile.file)
     quota = get_size(quotadir)
     quotaLimit = QUOTA_USER_LIMIT*10 if cherrypy.request.user['login'] in POWER_USERS_LIST else QUOTA_USER_LIMIT
     if filesize + quota > quotaLimit:
@@ -130,9 +130,11 @@ def _check_tarfile(argname, val, hashkey, newchecksum):
 
     digest = None
     try:
-        #This newchecksum param and the "else" branch is there for backward compatibility.
-        #We can remove the whole commit at some point in the future
-        if newchecksum:
+        #This newchecksum param and the if/else branch is there for backward compatibility.
+        #The parameter, older exclusion and checksum functions should be removed in the future.
+        if newchecksum == 2:
+            digest = calculateChecksum(val.file, exclude=NEW_USER_SANDBOX_EXCLUSIONS)
+        elif newchecksum == 1:
             digest = calculateChecksum(val.file, exclude=USER_SANDBOX_EXCLUSIONS)
         else:
             tar = tarfile.open(fileobj=val.file, mode='r')

--- a/src/script/task_info.js
+++ b/src/script/task_info.js
@@ -146,8 +146,8 @@ $(document).ready(function() {
         } else if (proxiedWebDirUrl === "") {
             // In case proxy api returned empty or failed
             // Set links, show error and don't load anything else.
-            $("#task-config-link").attr("href", userWebDir + "/sandbox.tar.gz");
-            $("#task-pset-link").attr("href", userWebDir + "/sandbox.tar.gz");
+            $("#task-config-link").attr("href", userWebDir + "/debug_files.tar.gz");
+            $("#task-pset-link").attr("href", userWebDir + "/debug_files.tar.gz");
             errHandler(new ProxyNotFoundErrorError);
             return;
         }


### PR DESCRIPTION
A rather involved fix for a simple problem - the crabcache component, in order to be able to recycle the user sandbox, had to ignore the monitoring debug files when calculating the hash. That means that the monitoring page would sometimes give outdated information, because the reused sandbox would contain old config and pset files. The fix separates these files into a different tarball, which has a hash of it's own.

The monitor itself isn't fully backward-compatible with older clients, because it doesn't know if the new tarball is available or not, and I think that solving this would complicate things beyond the benefit it would provide. The monitoring links for downloading the tarball point to the new tarball version, however, it would only be a problem when the files cannot be displayed through the browser and an old client version is used.

A one-line PR on WMCore will also need to be merged, but I'll wait until these bigger changes are approved.

#5153 