### PR TITLE
OpsMon scriptExe location fix

### DIFF
--- a/src/script/task_info.js
+++ b/src/script/task_info.js
@@ -262,7 +262,7 @@ $(document).ready(function() {
             return;
         }
 
-        $.ajax(proxiedWebDirUrl + "/debug/originalPSet.py")
+        $.ajax(proxiedWebDirUrl + "/debug/" + scriptExe)
             .done(function(data) {
                 $("#script-exe-paragraph").text(data);
             });


### PR DESCRIPTION
Fix for the minor issue @jmarra13 discovered during 3.3.1607 validation: https://github.com/dmwm/CRABServer/issues/5249#issuecomment-232057582.

The location from which the monitor loads scriptExe files was wrong.