### PR TITLE
tm_transfer_failure_reason can be null

### DIFF
--- a/src/python/Databases/FileTransfersDB/Oracle/Create.py
+++ b/src/python/Databases/FileTransfersDB/Oracle/Create.py
@@ -56,7 +56,7 @@ class Create(DBCreator):
         tm_rest_uri VARCHAR(255) NOT NULL,
         tm_transfer_state NUMBER(1) NOT NULL,
         tm_publication_state NUMBER(1) NOT NULL,
-        tm_transfer_failure_reason VARCHAR(1000) NOT NULL,
+        tm_transfer_failure_reason VARCHAR(1000),
         tm_publication_failure_reason VARCHAR(1000),
         tm_fts_id VARCHAR(255),
         tm_fts_instance VARCHAR(255),


### PR DESCRIPTION
Removing the NOT NULL clause from the Create.py code. Also run:

ALTER TABLE filetransfersdb modify (TM_TRANSFER_FAILURE_REASON NULL);

on preprod to fix the DB. Should be fine on prod since we'll run the
updated code to create the table from scratch.