### PR TITLE
Use client-side status for getlog/getouput commands

### DIFF
--- a/src/python/CRABInterface/DataUserWorkflow.py
+++ b/src/python/CRABInterface/DataUserWorkflow.py
@@ -55,6 +55,16 @@ class DataUserWorkflow(object):
            :return: a generator of list of logs pfns"""
         return self.workflow.logs(workflow, howmany, exitcode, jobids, userdn, userproxy)
 
+    def logs2(self, workflow, howmany, jobids, userdn, userproxy=None):
+        """Returns information about the workflow log files.
+           The client uses this information to get the pfn and initiate the download.
+
+           :arg str workflow: a workflow name
+           :arg int howmany: the limit on the number of PFN to return
+           :arg int exitcode: the log has to be of a job ended with this exit_code
+           :return: a generator of list of logs pfns"""
+        return self.workflow.logs2(workflow, howmany, jobids, userdn, userproxy)
+
     def output(self, workflow, howmany, jobids, userdn, userproxy=None):
         """Returns the workflow output PFN. It takes care of the LFN - PFN conversion too.
 
@@ -62,6 +72,15 @@ class DataUserWorkflow(object):
            :arg int howmany: the limit on the number of PFN to return
            :return: a generator of list of output pfns"""
         return self.workflow.output(workflow, howmany, jobids, userdn, userproxy)
+
+    def output2(self, workflow, howmany, jobids, userdn, userproxy=None):
+        """Returns information about the workflow output files.
+           The client uses this information to get the pfn and initiate the download.
+
+           :arg str list workflow: a workflow name
+           :arg int howmany: the limit on the number of PFN to return
+           :return: a generator of output file info lists - site, lfn, ... for each file"""
+        return self.workflow.output2(workflow, howmany, jobids, userdn, userproxy)
 
     def submit(self, *args, **kwargs):
         """Perform the workflow injection

--- a/src/python/CRABInterface/RESTFileMetadata.py
+++ b/src/python/CRABInterface/RESTFileMetadata.py
@@ -58,6 +58,7 @@ class RESTFileMetadata(RESTEntity):
         elif method in ['GET']:
             validate_str("taskname", param, safe, RX_TASKNAME, optional=False)
             validate_str("filetype", param, safe, RX_OUTTYPES, optional=False)
+            validate_num("howmany", param, safe, optional=True)
         elif method in ['DELETE']:
             authz_operator()
             validate_str("taskname", param, safe, RX_TASKNAME, optional=True)
@@ -92,13 +93,14 @@ class RESTFileMetadata(RESTEntity):
         return self.jobmetadata.changeState(taskname=taskname, outlfn=outlfn, filestate=filestate)
 
     @restcall
-    def get(self, taskname, filetype):
+    def get(self, taskname, filetype, howmany):
         """Retrieves a specific job metadata information.
 
            :arg str taskname: unique name identifier of the task;
            :arg str filetype: filter the file type to return;
-           :retrun: generator looping through the resulting db rows."""
-        return self.jobmetadata.getFiles(taskname, filetype)
+           :arg int howmany: how many rows to retrieve;
+           :return: generator looping through the resulting db rows."""
+        return self.jobmetadata.getFiles(taskname, filetype, howmany)
 
     @restcall
     def delete(self, taskname, hours):

--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -657,6 +657,10 @@ class RESTUserWorkflow(RESTEntity):
                 result = self.userworkflowmgr.logs(workflow, limit, exitcode, jobids, userdn=userdn)
             elif subresource == 'data':
                 result = self.userworkflowmgr.output(workflow, limit, jobids, userdn=userdn)
+            elif subresource == 'logs2':
+                result = self.userworkflowmgr.logs2(workflow, limit, jobids, userdn=userdn)
+            elif subresource == 'data2':
+                result = self.userworkflowmgr.output2(workflow, limit, jobids, userdn=userdn)
             elif subresource == 'errors':
                 result = self.userworkflowmgr.errors(workflow, shortformat)
             elif subresource == 'report':

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -69,7 +69,7 @@ RX_CLUSTERID = re.compile(r"^[0-9.]+$")
 RX_CERT = re.compile(r'^[-]{5}BEGIN CERTIFICATE[-]{5}[\w\W]+[-]{5}END CERTIFICATE[-]{5}\n$')
 
 #subresourced of DataUserWorkflow (/workflow) resource
-RX_SUBRESTAT = re.compile(r"^errors|report|logs|data|resubmit|proceed$")
+RX_SUBRESTAT = re.compile(r"^errors|report|logs|data|logs2|data2|resubmit|proceed$")
 
 #subresources of the ServerInfo (/info) and Task (/task) resources
 RX_SUBRES_SI = re.compile(r"^delegatedn|backendurls|version|bannedoutdest|scheddaddress|ignlocalityblacklist|$")

--- a/src/python/Databases/FileMetaDataDB/Oracle/FileMetaData/FileMetaData.py
+++ b/src/python/Databases/FileMetaDataDB/Oracle/FileMetaData/FileMetaData.py
@@ -39,6 +39,7 @@ class FileMetaData(object):
                            fmd_direct_stageout AS directstageout
                     FROM filemetadata \
                     WHERE tm_taskname = :taskname \
+                    AND rownum <= CASE :howmany WHEN -1 then 10000 ELSE :howmany END \
                     AND fmd_type IN (SELECT REGEXP_SUBSTR(:filetype, '[^,]+', 1, LEVEL) FROM DUAL CONNECT BY LEVEL <= REGEXP_COUNT(:filetype, ',') + 1) \
                     ORDER BY fmd_creation_time DESC
              """


### PR DESCRIPTION
Added duplicate logs/output/getfiles methods to the backend. This includes some new logic to avoid querying the server for the task status and move the pfn calculation off to the client. 
Until the transition to status2 is complete, the production client will use the old logic in the backend and the users shouldn't be affected.

