### PR TITLE
Add a "lock" file to the task_process

### DIFF
--- a/scripts/dag_bootstrap_startup.sh
+++ b/scripts/dag_bootstrap_startup.sh
@@ -149,7 +149,7 @@ else
     # which is done by passing the cluster_id of the dagman to the daemon process via the jdl. With this, we are 
     # able to use condor_q in the daemon to check if the task/job status will no longed be updated 
     # and if the daemon needs to exit.
-    if [ -f /etc/enable_task_daemon ];
+    if [ -f /etc/enable_task_daemon ] && [ ! -f task_process/task_process_running ];
     then
         echo "creating and executing task process daemon jdl"
 cat > task_process/daemon.jdl << EOF
@@ -165,7 +165,7 @@ EOF
         chmod 777 task_process/task_proc_wrapper.sh
         condor_submit task_process/daemon.jdl
     else
-        echo "/etc/enable_task_daemon not found, not submitting the daemon task"
+        echo "/etc/enable_task_daemon not found or task_process/task_process_runing found, not submitting the daemon task"
     fi
     # --- End new status prototype ---
 

--- a/scripts/task_process/task_proc_wrapper.sh
+++ b/scripts/task_process/task_proc_wrapper.sh
@@ -4,34 +4,55 @@ if [ ! -f /etc/enable_task_daemon ]; then
     exit 1
 fi
 
+if [ -f task_process/task_process_running ]; then
+    echo "task_process/task_process_running file already present, not starting a new task_process and exiting"
+    exit 1
+else
+    touch task_process/task_process_running
+    echo "task_process/task_process_running file not found, starting a new task_process"
+fi
+
 HOURS_BETWEEN_QUERIES=24
 
-
-echo "Starting task daemon wrapper"
 # Cluster ID is passed from the dagman_bootstrap_startup.sh and points to the main dag
 CLUSTER_ID=$1
 echo "CLUSTER_ID: $CLUSTER_ID"
+
 # Sleeping until files in the spool dir are created. TODO - make this smarter
 sleep 60s
 TIME_OF_LAST_QUERY=$(date +"%s")
-# Loop will exit when condor_q returns empty, meaning the main dag has been removed and will no longer be updated.
-# For the initial query period, set CONDOR_RES to something other than empty. Since querying condor sooner 
-# is most likely pointless, the script will run normally and perform the query later.
-CONDOR_RES="init"
-while true
-do 
-    # Calculate how much time has passed since the last query and perform it again if it has been long enough. 
-    if [ $(($(date +"%s") - $TIME_OF_LAST_QUERY)) -gt $(($HOURS_BETWEEN_QUERIES * 3600)) ]; then
-        CONDOR_RES=$(condor_q $CLUSTER_ID -af JobStatus)
-        echo "Query done on $(date)"
-        TIME_OF_LAST_QUERY=$(date +"%s")
-    fi
 
-    echo "Dag status code: $CONDOR_RES"
-    if [ -z "$CONDOR_RES" ]; then
-        echo "dag status code empty. task daemon exiting"
-        exit 0
-    fi
+# Loop will exit when condor_q returns 5 or 6, meaning that the main dag has been stopped and will no longer be updated.
+# For the initial query period, set CONDOR_RES to something other than empty. Since querying condor immediatly after
+# submission is most likely pointless and relatively expensive, the script will run normally and perform the query later.
+CONDOR_RES="init"
+
+echo "Starting task daemon wrapper"
+while true
+do
+    # Run the parsing script
     python task_process/cache_status.py
     sleep 300s
+
+    # Calculate how much time has passed since the last condor_q and perform it again if it has been long enough.
+    if [ $(($(date +"%s") - $TIME_OF_LAST_QUERY)) -gt $(($HOURS_BETWEEN_QUERIES * 3600)) ]; then
+        CONDOR_RES=$(condor_q $CLUSTER_ID -af JobStatus)
+        TIME_OF_LAST_QUERY=$(date +"%s")
+
+        echo "Query done on $(date)"
+    fi
+
+    # Once the dag reaches one of the final states (5 or 6), no further updates are expected to the log files
+    # and the task_process can exit.
+    # In a rare case (if this script does condor_q right after the the dag changes states),
+    # it is actually possible that task_process would exit before the changes contributing to the status are propagated.
+    # Adding a short sleep would solve this, however, that then presents another problem of task_process not starting
+    # at all if the task is resubmitted during this short sleep period.
+    echo "Dag status code: $CONDOR_RES"
+    if [[ "$CONDOR_RES" == 5 || "$CONDOR_RES" == 6 ]]; then
+        echo "Dag is in one of the final states. Removing the task_process/task_process_running file and exiting."
+        rm task_process/task_process_running
+
+        exit 0
+    fi
 done


### PR DESCRIPTION
This ensures that at most only one task_process will run for a given task at one time.  In case of problems during submission, it is possible that multiple task_processes would be started otherwise.