### PR TITLE
Minor fixes for WMCore 1.0.21

### DIFF
--- a/scripts/cmscp.py
+++ b/scripts/cmscp.py
@@ -481,7 +481,7 @@ def perform_local_stageout(local_stageout_mgr, \
         signal.alarm(0)
     if retval == 0:
         dest_temp_file_name = os.path.split(dest_temp_lfn)[-1]
-        dest_temp_se = stageout_info['SEName']
+        dest_temp_se = stageout_info['PNN']
 
         ## Fallback to previous behaviour where phedex is queried for location
         if source_site == 'unknown':

--- a/src/python/HTCondorLocator.py
+++ b/src/python/HTCondorLocator.py
@@ -61,7 +61,7 @@ class HTCondorLocator(object):
         """
         collector = self.getCollector()
 
-        htcondor.param['COLLECTOR_HOST'] = collector
+        htcondor.param['COLLECTOR_HOST'] = collector.encode('ascii', 'ignore')
         coll = htcondor.Collector()
         schedds = coll.query(htcondor.AdTypes.Schedd, 'StartSchedulerUniverse =?= true && CMSGWMS_Type=?="crabschedd" && IsOK=?=True', 
                              ['Name', 'DetectedMemory','TotalFreeMemoryMB','TransferQueueNumUploading', 'TransferQueueMaxUploading', 
@@ -76,9 +76,9 @@ class HTCondorLocator(object):
         Return a tuple (schedd, address) containing an object representing the
         remote schedd and its corresponding address.
         """
-        htcondor.param['COLLECTOR_HOST'] = self.getCollector()
+        htcondor.param['COLLECTOR_HOST'] = self.getCollector().encode('ascii', 'ignore')
         coll = htcondor.Collector()
-        schedds = coll.query(htcondor.AdTypes.Schedd, 'regexp(%s, Name)' % HTCondorUtils.quote(schedd))
+        schedds = coll.query(htcondor.AdTypes.Schedd, 'regexp(%s, Name)' % HTCondorUtils.quote(schedd.encode('ascii', 'ignore')))
         self.scheddAd = ""
         if not schedds:
             self.scheddAd = self.getCachedCollectorOutput(schedd)

--- a/src/python/TaskWorker/Actions/DagmanSubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanSubmitter.py
@@ -302,7 +302,8 @@ class DagmanSubmitter(TaskAction.TaskAction):
             self.logger.exception("%s: %s", workflow, msg)
             raise TaskWorkerException(msg, retry=True)
 
-        rootConst = 'TaskType =?= "ROOT" && CRAB_ReqName =?= %s && (isUndefined(CRAB_Attempt) || CRAB_Attempt == 0)' % HTCondorUtils.quote(workflow)
+        rootConst = 'TaskType =?= "ROOT" && CRAB_ReqName =?= %s && (isUndefined(CRAB_Attempt) || '\
+                    'CRAB_Attempt == 0)' % HTCondorUtils.quote(workflow.encode('ascii', 'ignore'))
 
         self.logger.debug("Duplicate check is querying the schedd: %s", rootConst)
         results = list(schedd.xquery(rootConst, []))
@@ -447,7 +448,7 @@ class DagmanSubmitter(TaskAction.TaskAction):
         dagAd["Cmd"] = cmd
         dagAd['Args'] = arg
         dagAd["TransferInput"] = str(info['inputFilesString'])
-        dagAd["CRAB_TaskSubmitTime"] = classad.ExprTree("%s" % info["start_time"])
+        dagAd["CRAB_TaskSubmitTime"] = classad.ExprTree("%s" % info["start_time"].encode('ascii', 'ignore'))
         # Putting JobStatus == 4 since LeaveJobInQueue is for completed jobs (probably redundant)
         LEAVE_JOB_IN_QUEUE_EXPR = "(JobStatus == 4) && ((time()-CRAB_TaskSubmitTime) < %s)" % TASKLIFETIME
         dagAd["LeaveJobInQueue"] = classad.ExprTree(LEAVE_JOB_IN_QUEUE_EXPR)


### PR DESCRIPTION
Main issues were:
- HTCondor/unicode incompatibility, though only in a few places AFAIK;
- SEName renamed to PNN in WMCore;
- ~~StageOutMgr not initializing with the information for different stageout implementations in cmscp. Not sure what changed, but a simple import fixes this because this line needs to be executed for each implementation: https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/Storage/Backends/RFCP2Impl.py#L108~~ This was fixed in WMCore recently, the import had been removed by an IDE and forgotten about.
