### PR TITLE
Don't pass dict by reference in status2 script

### DIFF
--- a/scripts/task_process/cache_status.py
+++ b/scripts/task_process/cache_status.py
@@ -9,6 +9,7 @@ import json
 import sys
 import classad
 import glob
+import copy
 from shutil import move
 # Need to import HTCondorUtils from a parent directory, not easy when the files are not in python packages.
 # Solution by ajay, SO: http://stackoverflow.com/questions/11536764
@@ -66,7 +67,7 @@ def parseJobLog(fp, nodes, node_map):
             if m:
                 node = m.groups()[0]
                 proc = event['Cluster'], event['Proc']
-                info = nodes.setdefault(node, NODE_DEFAULTS)
+                info = nodes.setdefault(node, copy.deepcopy(NODE_DEFAULTS))
                 info['State'] = 'idle'
                 info['JobIds'].append("%d.%d" % proc)
                 info['RecordedSite'] = False
@@ -211,7 +212,7 @@ def parseNodeStateV2(fp, nodes):
         status = ad.get('NodeStatus', -1)
         retry = ad.get('RetryCount', -1)
         msg = ad.get("StatusDetails", "")
-        info = nodes.setdefault(nodeid, NODE_DEFAULTS)
+        info = nodes.setdefault(nodeid, copy.deepcopy(NODE_DEFAULTS))
         if status == 1: # STATUS_READY
             if info.get("State") == "transferring":
                 info["State"] = "cooloff"


### PR DESCRIPTION
Found a pretty silly bug in the task_process status script where the dictionary used to initialize the job information dictionary is being passed as a reference. Each time a single job information is modified, all of the other jobs are modified as well which resulted in an exponential growth of the status dictionary.