### PR TITLE
Use 'python', not 'python2.6' in dag_bootstrap* scripts. Fix #5320

### DIFF
--- a/scripts/dag_bootstrap.sh
+++ b/scripts/dag_bootstrap.sh
@@ -9,16 +9,16 @@ echo "Beginning dag_bootstrap.sh (stderr)" 1>&2
 if [ "X$TASKWORKER_ENV" = "X" -a ! -e CRAB3.zip ]
 then
 
-	command -v python2.6 > /dev/null
+	command -v python > /dev/null
 	rc=$?
 	if [[ $rc != 0 ]]
 	then
-		echo "Error: Python2.6 isn't available on `hostname`." >&2
-		echo "Error: bootstrap execution requires python2.6" >&2
+		echo "Error: Python isn't available on `hostname`." >&2
+		echo "Error: bootstrap execution requires python" >&2
 		exit 1
 	else
-		echo "I found python2.6 at.."
-		echo `which python2.6`
+		echo "I found python at.."
+		echo `which python`
 	fi
 
 	if [ "x$CRAB3_VERSION" = "x" ]; then
@@ -94,7 +94,6 @@ fi
 export PATH="/opt/glidecondor/bin:/opt/glidecondor/sbin:/usr/local/bin:/bin:/usr/bin:/usr/bin:$PATH"
 export PATH="/data/srv/glidecondor/bin:/data/srv/glidecondor/sbin:/usr/local/bin:/bin:/usr/bin:/usr/bin:$PATH"
 export PYTHONPATH=/opt/glidecondor/lib/python:$PYTHONPATH
-export PYTHONPATH=/data/srv/glidecondor/lib/python2.6:$PYTHONPATH
 export LD_LIBRARY_PATH=/opt/glidecondor/lib:/opt/glidecondor/lib/condor:.:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=/data/srv/glidecondor/lib:/data/srv/glidecondor/lib/condor:.:$LD_LIBRARY_PATH
 export PYTHONUNBUFFERED=1
@@ -105,4 +104,4 @@ if [ "X$_CONDOR_JOB_AD" != "X" ]; then
   cat $_CONDOR_JOB_AD
 fi
 echo "Now running the job in `pwd`..."
-exec nice -n 19 python2.6 -m TaskWorker.TaskManagerBootstrap "$@"
+exec nice -n 19 python -m TaskWorker.TaskManagerBootstrap "$@"

--- a/scripts/dag_bootstrap_startup.sh
+++ b/scripts/dag_bootstrap_startup.sh
@@ -14,7 +14,6 @@ done
 export PATH="/opt/glidecondor/bin:/opt/glidecondor/sbin:/usr/local/bin:/bin:/usr/bin:/usr/bin:$PATH"
 export PATH="/data/srv/glidecondor/bin:/data/srv/glidecondor/sbin:/usr/local/bin:/bin:/usr/bin:/usr/bin:$PATH"
 export PYTHONPATH=/opt/glidecondor/lib/python:$PYTHONPATH
-export PYTHONPATH=/data/srv/glidecondor/lib/python2.6:$PYTHONPATH
 export LD_LIBRARY_PATH=/opt/glidecondor/lib:/opt/glidecondor/lib/condor:.:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=/data/srv/glidecondor/lib:/data/srv/glidecondor/lib/condor:.:$LD_LIBRARY_PATH
 
@@ -64,16 +63,16 @@ fi
 # Bootstrap the runtime - we want to do this before DAG is submitted
 # so all the children don't try this at once.
 if [ "X$TASKWORKER_ENV" = "X" -a ! -e CRAB3.zip ]; then
-    command -v python2.6 > /dev/null
+    command -v python > /dev/null
     rc=$?
     if [[ $rc != 0 ]]; then
-        echo "Error: Python2.6 isn't available on `hostname`." >&2
-        echo "Error: Bootstrap execution requires python2.6" >&2
-        condor_qedit $CONDOR_ID DagmanHoldReason "'Error: Bootstrap execution requires python2.6.'"
+        echo "Error: Python isn't available on `hostname`." >&2
+        echo "Error: Bootstrap execution requires python" >&2
+        condor_qedit $CONDOR_ID DagmanHoldReason "'Error: Bootstrap execution requires python.'"
         exit 1
     else
-        echo "I found python2.6 at.."
-        echo `which python2.6`
+        echo "I found python at.."
+        echo `which python`
     fi
 
     if [[ "X$CRAB_TASKMANAGER_TARBALL" == "X" ]]; then
@@ -110,7 +109,7 @@ fi
 
 # Recalculate the black / whitelist
 if [ -e AdjustSites.py ]; then
-    python2.6 AdjustSites.py
+    python AdjustSites.py
 else
     echo "Error: AdjustSites.py does not exist." >&2
     condor_qedit $CONDOR_ID DagmanHoldReason "'AdjustSites.py does not exist.'"


### PR DESCRIPTION
Since our schedulers should all have a python version that is compatible with our code (2.6 or 2.7), it should be safe to simply use the "python" executable to run code. Note that I removed lines [97](https://github.com/dmwm/CRABServer/commit/da1220ee31a12107d264b6cd3fd2bdf94d467d31#diff-74f1344ae5132319ee04de0499dc5ca0L97) from dag_bootstrap and [17](https://github.com/dmwm/CRABServer/commit/da1220ee31a12107d264b6cd3fd2bdf94d467d31#diff-e98f162a128f1955bf1d3e28a6f14048L17) from dag_bootstrap_startup since this directory doesn't seem to exist on our schedds. I don't think this should affect anything negatively?