### PR TITLE
CRABMon: fix webdir link not being proxied

### DIFF
--- a/src/script/task_info.js
+++ b/src/script/task_info.js
@@ -191,14 +191,14 @@ $(document).ready(function() {
                 if (proxiedWebDirUrl === undefined || proxiedWebDirUrl == "None") {
                     proxiedWebDirUrl = "";
                 }
-
-                displayConfigAndPSet(handleConfigPSetErr);
-                displayScriptExe(handleScriptExeErr);
             })
             .fail(function(xhr) {
                 proxiedWebDirUrl = "";
+            })
+            .complete(function(xhr) {
                 displayConfigAndPSet(handleConfigPSetErr);
                 displayScriptExe(handleScriptExeErr);
+                displayMainPage(handleMainErr);
             });
     }
 
@@ -596,7 +596,6 @@ $(document).ready(function() {
         displayTaskWorkerLog(handleTaskWorkerLogErr);
         displayUploadLog(handleUploadLogErr);
         // displayScriptExe(handleScriptExeErr);
-        displayMainPage(handleMainErr);
     }
 
     function clearPreviousContent() {


### PR DESCRIPTION
Jadir noticed that the webdir link wasn't being proxied as it should've been on some occasions. This was likely being caused by the asynchronicity of the ajax request when getting the link of the proxied webdir from our API. Waiting until this request finishes solves the problem.