### PR TITLE
Handle TW stop message in the correct place. Fix #5316

### DIFF
--- a/src/python/TaskWorker/Worker.py
+++ b/src/python/TaskWorker/Worker.py
@@ -51,13 +51,13 @@ def processWorkerLoop(inputs, results, resthost, resturi, procnum, logger):
             ## Get (and remove) an item from the input queue. If the queue is empty, wait
             ## until an item is available.
             workid, work, task, failstatus, inputargs = inputs.get()
+            if work == 'STOP':
+                break
             taskhandler = addTaskLogHandler(logger, task['tm_username'], task['tm_taskname'])
         except (EOFError, IOError):
             crashMessage = "Hit EOF/IO in getting new work\n"
             crashMessage += "Assuming this is a graceful break attempt.\n"
             logger.error(crashMessage)
-            break
-        if work == 'STOP':
             break
 
         outputs = None


### PR DESCRIPTION
The workers are not exiting properly because they are getting a string (which is "control") instead of a "task" dictionary they normally get [1]. These inputs are passed to each worker when the master exits [2]. I personally don't see any changes to the code that coincide with this problem appearing, but my fix should at least catch the stop message before it's interpreted as a task and allow the worker to halt correctly.

[1]
https://github.com/emaszs/CRABServer/blob/ed5290989134f2121edbe6d02df492f4fafacbae/src/python/TaskWorker/Worker.py#L56
[2]
https://github.com/emaszs/CRABServer/blob/ed5290989134f2121edbe6d02df492f4fafacbae/src/python/TaskWorker/Worker.py#L182