### PR TITLE
Add a small api for status2 publication information

### DIFF
--- a/src/python/CRABInterface/DataUserWorkflow.py
+++ b/src/python/CRABInterface/DataUserWorkflow.py
@@ -179,3 +179,13 @@ class DataUserWorkflow(object):
            :arg str workflow: a workflow name
         """
         return self.workflow.proceed(workflow)
+
+    def publicationStatus(self, workflow, asourl, asodb, username):
+        """Retrieve the status of the publication, used by status2 when displaying publication information
+
+           :arg str workflow: a workflow name
+           :arg str asourl: url of where the aso DB is located
+           :arg str asodb: which aso DB instance to use
+           :yield:  dictionary with the number of jobs in certain publication state and failure reasons
+        """
+        yield self.workflow.publicationStatus(workflow, asourl, asodb, username)

--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -276,9 +276,6 @@ class DataWorkflow(object):
     def publicationStatusWrapper(self, workflow, asourl, asodb, username, publicationenabled):
         publicationInfo = {}
         if (publicationenabled == 'T'):
-            # value is used in the publicationStatus method.
-            self.isCouchDBURL = isCouchDBURL(asourl)
-
             #let's default asodb to asynctransfer, for old task this is empty!
             asodb = asodb or 'asynctransfer'
             publicationInfo = self.publicationStatus(workflow, asourl, asodb, username)

--- a/src/python/CRABInterface/HTCondorDataWorkflow.py
+++ b/src/python/CRABInterface/HTCondorDataWorkflow.py
@@ -825,6 +825,7 @@ class HTCondorDataWorkflow(DataWorkflow):
             fp.close()
             hbuf.close()
 
+    @conn_handler(services=['servercert'])
     def publicationStatus(self, workflow, asourl, asodb, user):
         """Here is what basically the function return, a dict called publicationInfo in the subcalls:
                 publicationInfo['status']: something like {'publishing': 0, 'publication_failed': 0, 'not_published': 0, 'published': 5}.
@@ -833,7 +834,7 @@ class HTCondorDataWorkflow(DataWorkflow):
                                                     Later on goes into dictresult['publication']['error']
                 publicationInfo['failure_reasons']: errors of single files (not yet implemented for oracle..)
         """
-        if self.isCouchDBURL:
+        if isCouchDBURL(asourl):
             return self.publicationStatusCouch(workflow, asourl, asodb)
         else:
             return self.publicationStatusOracle(workflow, asourl, asodb, user)

--- a/src/python/CRABInterface/HTCondorDataWorkflow.py
+++ b/src/python/CRABInterface/HTCondorDataWorkflow.py
@@ -460,7 +460,7 @@ class HTCondorDataWorkflow(DataWorkflow):
         if row.collector:
             result['collector'] = row.collector
 
-        self.isCouchDBURL = isCouchDBURL(row.asourl)
+        self.asoDBURL = row.asourl
 
         # 0 - simple crab status
         # 1 - crab status -long
@@ -1057,7 +1057,7 @@ class HTCondorDataWorkflow(DataWorkflow):
         data = json.load(fp)
         for docid, result in data['results'].iteritems():
             #Oracle has an improved structure in aso_status
-            if self.isCouchDBURL:
+            if isCouchDBURL(self.asoDBURL):
                 result = result['value']
             else:
                 result = result[0]

--- a/src/python/CRABInterface/HTCondorDataWorkflow.py
+++ b/src/python/CRABInterface/HTCondorDataWorkflow.py
@@ -837,7 +837,7 @@ class HTCondorDataWorkflow(DataWorkflow):
         if isCouchDBURL(asourl):
             return self.publicationStatusCouch(workflow, asourl, asodb)
         else:
-            return self.publicationStatusOracle(workflow, asourl, asodb, user)
+            return self.publicationStatusOracle(workflow, user)
 
     def publicationStatusCouch(self, workflow, asourl, asodb):
         publicationInfo = {'status': {}, 'failure_reasons': {}}
@@ -891,7 +891,7 @@ class HTCondorDataWorkflow(DataWorkflow):
 
         return publicationInfo
 
-    def publicationStatusOracle(self, workflow, asourl, asodb, user):
+    def publicationStatusOracle(self, workflow, user):
         publicationInfo = {}
 
         #query oracle for the information

--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -511,6 +511,10 @@ class RESTUserWorkflow(RESTEntity):
             ## used by errors and report (short format in report means we do not query DBS)
             validate_num('shortformat', param, safe, optional=True)
 
+            # used by publicationStatus
+            validate_str("asourl", param, safe, RX_ASOURL, optional=True)
+            validate_str("asodb", param, safe, RX_ASODB, optional=True)
+
             ## validation parameters
             if not safe.kwargs['workflow'] and safe.kwargs['subresource']:
                 raise InvalidParameter("Invalid input parameters")
@@ -648,7 +652,7 @@ class RESTUserWorkflow(RESTEntity):
             return self.userworkflowmgr.proceed(workflow=workflow)
 
     @restcall
-    def get(self, workflow, subresource, username, limit, shortformat, exitcode, jobids, verbose, timestamp):
+    def get(self, workflow, subresource, username, limit, shortformat, exitcode, jobids, verbose, timestamp, asourl, asodb):
         """Retrieves the workflow information, like a status summary, in case the workflow unique name is specified.
            Otherwise returns all workflows since (now - age) for which the user is the owner.
            The caller needs to be a valid CMS user.
@@ -680,6 +684,8 @@ class RESTUserWorkflow(RESTEntity):
                 result = self.userworkflowmgr.report(workflow, userdn=userdn, usedbs=shortformat)
             elif subresource == 'report2':
                 result = self.userworkflowmgr.report2(workflow, userdn=userdn, usedbs=shortformat)
+            elif subresource == 'publicationstatus':
+                result = self.userworkflowmgr.publicationStatus(workflow, asourl, asodb, username)
             # if here means that no valid subresource has been requested
             # flow should never pass through here since validation restrict this
             else:

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -70,7 +70,7 @@ RX_CLUSTERID = re.compile(r"^[0-9.]+$")
 RX_CERT = re.compile(r'^[-]{5}BEGIN CERTIFICATE[-]{5}[\w\W]+[-]{5}END CERTIFICATE[-]{5}\n$')
 
 #subresourced of DataUserWorkflow (/workflow) resource
-RX_SUBRESTAT = re.compile(r"^errors|report|logs|data|logs2|data2|resubmit|resubmit2|proceed$")
+RX_SUBRESTAT = re.compile(r"^errors|report|logs|data|logs2|data2|resubmit|resubmit2|proceed|publicationstatus$")
 
 #subresources of the ServerInfo (/info) and Task (/task) resources
 RX_SUBRES_SI = re.compile(r"^delegatedn|backendurls|version|bannedoutdest|scheddaddress|ignlocalityblacklist|$")


### PR DESCRIPTION
It returns something like this:
```
{"result": [
 {"status": {"published": 2, "publication_failed": 0, "not_published": 15, "publishing": 0}, "failure_reasons": {}}
]}
```
Another option is to avoid the server completely and query the DB from the client directly, but this is api is relatively simple, shouldn't break anything and allows the reuse of some code. Contains a few hacks though which I'm hoping to review with Marco.