### PR TITLE
Let task_process restart after a schedd crash

### DIFF
--- a/scripts/task_process/task_proc_wrapper.sh
+++ b/scripts/task_process/task_proc_wrapper.sh
@@ -4,13 +4,9 @@ if [ ! -f /etc/enable_task_daemon ]; then
     exit 1
 fi
 
-if [ -f task_process/task_process_running ]; then
-    echo "task_process/task_process_running file already present, not starting a new task_process and exiting"
-    exit 1
-else
-    touch task_process/task_process_running
-    echo "task_process/task_process_running file not found, starting a new task_process"
-fi
+touch task_process/task_process_running
+echo "Starting a new task_process, creating task_process_running file"
+
 
 HOURS_BETWEEN_QUERIES=24
 


### PR DESCRIPTION
Noticed that the task_process would not restart along with other jobs after a schedd comes back up because of this check, since the task_process_running file is not removed during an unexpected stop. Not quite sure why I put it there but should be safe to remove, this check is also performed during submission in dag_bootstrap_startup.sh.