### PR TITLE
JobIds are strings now. Fixes #5363

### DIFF
--- a/src/python/TaskWorker/Actions/PreJob.py
+++ b/src/python/TaskWorker/Actions/PreJob.py
@@ -282,7 +282,7 @@ class PreJob:
         use_resubmit_info = False
         resubmit_jobids = []
         if 'CRAB_ResubmitList' in self.task_ad:
-            resubmit_jobids = self.task_ad['CRAB_ResubmitList']
+            resubmit_jobids = map(str, self.task_ad['CRAB_ResubmitList'])
             try:
                 resubmit_jobids = set(resubmit_jobids)
                 if resubmit_jobids and self.job_id not in resubmit_jobids:


### PR DESCRIPTION
Withj the changes for the automatic splitting jobids turned to strings
since they can be like '3-2' (jobid and subjob). As a consequence we
were comparing a string and an integer making the condition of the if
always false.