### PR TITLE
Use TagCollector class to get CMSSW releases by arch

### DIFF
--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -36,6 +36,7 @@ class RESTUserWorkflow(RESTEntity):
         self.allPNNNames = CMSSitesCache(cachetime=0, sites={})
         self.centralcfg = centralcfg
         self.Task = getDBinstance(config, 'TaskDB', 'Task')
+        self.tagCollector = TagCollector(anytype = 1, anyarch = 0)
 
     def _expandSites(self, sites, pnn=False):
         """Check if there are sites cotaining the '*' wildcard and convert them in the corresponding list
@@ -289,11 +290,10 @@ class RESTUserWorkflow(RESTEntity):
             If the list of releases is empty (reason may be an ExpatError) then report an error message
             If the asked released is not there then report an error message
         """
-        tagCollector = TagCollector()
         msg = False
         goodReleases = {}
         try:
-            goodReleases = tagCollector.releases_by_architecture()
+            goodReleases = self.tagCollector.releases_by_architecture()
         except (IOError, HTTPException, HttpLib2Error):
             msg = "Error connecting to %s (params: %s) and determining the list of available releases. " % \
                   (tagCollector['endpoint'], tagCollector.tcArgs) + "Skipping the check of the releases"


### PR DESCRIPTION
In the new WMCore version the there is now a separate service for this: https://github.com/dmwm/WMCore/pull/7484. Though I'm not completely sure if the new behavior suits us - previously, this url was used to get the releases: https://cmssdt.cern.ch/SDT/cgi-bin/ReleasesXML?anytype=1 (482 releases). TagCollector by default now uses this url: https://cmssdt.cern.ch/SDT/cgi-bin/ReleasesXML?anytype=1&anyarch=1 (695 releases). Is this something that I should fix or is it fine?