### PR TITLE
Fix uninitialized logger bug in new schedd picker function

### DIFF
--- a/src/python/HTCondorLocator.py
+++ b/src/python/HTCondorLocator.py
@@ -34,7 +34,8 @@ def filterScheddsByClassAds(schedds, classAds, logger=None):
         scheddValid = True
         for classAd in classAds:
             if classAd not in schedd:
-                logger.debug("Ignoring %s schedd since it is missing the %s ClassAd." % (schedd['Name'], classAd))
+                if logger:
+                    logger.debug("Ignoring %s schedd since it is missing the %s ClassAd." % (schedd['Name'], classAd))
                 scheddValid = False
         if scheddValid:
             validSchedds.append(schedd)
@@ -48,7 +49,7 @@ def capacityMetricsChoicesHybrid(schedds, goodSchedds, logger=None):
     """
 
     classAdsRequired = ['DetectedMemory', 'TotalFreeMemoryMB', 'MaxJobsRunning', 'TotalRunningJobs', 'TransferQueueMaxUploading', 'TransferQueueNumUploading', 'Name']
-    schedds = filterScheddsByClassAds(schedds, classAdsRequired)
+    schedds = filterScheddsByClassAds(schedds, classAdsRequired, logger)
 
     # Get only those schedds that are in our external rest configuration and their status is ok
     schedds = [schedd for schedd in schedds if schedd['Name'] in goodSchedds and classad.ExprTree.eval(schedd['IsOk'])]

--- a/src/python/TaskWorker/Actions/DagmanSubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanSubmitter.py
@@ -211,7 +211,7 @@ class DagmanSubmitter(TaskAction.TaskAction):
         currentBackendurls['htcondorSchedds'] = dict([(s,restSchedulers[s]) for s in restSchedulers if s not in alreadyTriedSchedds])
         if len(currentBackendurls['htcondorSchedds']) == 0:
             return None
-        loc = HTCondorLocator.HTCondorLocator(currentBackendurls)
+        loc = HTCondorLocator.HTCondorLocator(currentBackendurls, self.logger)
         if hasattr(self.config.TaskWorker, 'scheddPickerFunction'):
             schedd = loc.getSchedd(chooserFunction=self.config.TaskWorker.scheddPickerFunction)
         else:


### PR DESCRIPTION
Noticed submission failures at some point, caused by the logger variable not being initialized. Some scheduler was not returning all of the needed classads for the picker function, though unfortunately I can't say which one.