### PR TITLE
Remove two printouts from tw log

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -685,8 +685,6 @@ class DagmanCreator(TaskAction.TaskAction):
         self.logger.debug("Ignore locality: %s" % (ignoreLocality))
 
         for jobgroup in splitterResult[0]:
-            self.logger.error(dir(jobgroup))
-            self.logger.error(type(jobgroup))
             jobs = jobgroup.getJobs()
 
             jgblocks = set() #job group blocks


### PR DESCRIPTION
Doubt these are useful to anyone anymore, looks like something that was used only during development of autosplitting. 

```
2017-02-17 12:11:35,180:ERROR:DagmanCreator,688:['__class__', '__delattr__', '__dict__', '__doc__', '__format__', '__getattribute__', '__hash__', '__init__', '__len__', '__module__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '_
_setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', 'add', 'addOutput', 'commit', 'commitBulk', 'flatten', 'getJobs', 'getLength', 'getOutput', 'id', 'jobs', 'last_update', 'makelist', 'makeset', 'newjobs', 'output', '
subscription']
2017-02-17 12:11:35,181:ERROR:DagmanCreator,689:<class 'WMCore.DataStructs.JobGroup.JobGroup'>
```