### PR TITLE
Schedd picker printout, logic modifications

### DIFF
--- a/src/python/HTCondorLocator.py
+++ b/src/python/HTCondorLocator.py
@@ -60,15 +60,18 @@ def capacityMetricsChoicesHybrid(schedds, goodSchedds, logger=None):
         totalJobs += schedd['MaxJobsRunning']
         totalUploads += schedd['TransferQueueMaxUploading']
 
+    logger.debug("Total Mem: %d, Total Jobs: %d, Total Uploads: %d" % (totalMemory, totalJobs, totalUploads))
     weights = {}
     for schedd in schedds:
         memPerc = schedd['TotalFreeMemoryMB']/totalMemory
-        uplPerc = (schedd['TransferQueueMaxUploading']-schedd['TransferQueueNumUploading'])/totalUploads
         jobPerc = (schedd['MaxJobsRunning']-schedd['TotalRunningJobs'])/totalJobs
-        weight = max(memPerc, uplPerc, jobPerc)
+        uplPerc = (schedd['TransferQueueMaxUploading']-schedd['TransferQueueNumUploading'])/totalUploads
+        weight = min(memPerc, uplPerc, jobPerc)
         weights[schedd['Name']] = weight
-        logger.debug("%s: Mem %s, Mx %s;  Run %s, Mx %s;  Trf %s, Max %s, weight: %f" % (schedd['Name'], schedd['TotalFreeMemoryMB'], totalMemory,
-                schedd['JobsRunning'], totalJobs, schedd['TransferQueueNumUploading'], totalUploads, weight))
+        logger.debug("%s: Mem %d, MemPrct %0.2f, Run %d, RunPrct %0.2f, Trf %d, TrfPrct %0.2f, weight: %f" %
+                    (schedd['Name'], schedd['TotalFreeMemoryMB'], memPerc,
+                     schedd['JobsRunning'], jobPerc,
+                     schedd['TransferQueueNumUploading'], uplPerc, weight))
 
     if schedds:
         choices = [(schedd['Name'], weights[schedd['Name']]) for schedd in schedds]


### PR DESCRIPTION
Instead of picking the schedd's "best" statistic to use for it's weight it should use it's worst. For example, when a schedd is especially low on memory, it should have a low weight overall to be picked less often, instead of being optimistic and using some other statistic like the number running jobs which may be much lower (and give a much higher weight in the end).