### PR TITLE
Add traceback when catching StageOutMgr initialisation exceptions.

### DIFF
--- a/scripts/cmscp.py
+++ b/scripts/cmscp.py
@@ -1490,7 +1490,8 @@ def main():
         except Exception:
             print("       <----- Stageout manager log finish")
             msg  = "WARNING: Error initializing StageOutMgr."
-            msg += " Will not be able to do local stageouts."
+            msg += " Will not be able to do local stageouts.\n"
+            msg += traceback.format_exc()
             print(msg)
             cmscp_status['init_local_stageout_mgr']['return_code'] = 60311
             cmscp_status['init_local_stageout_mgr']['return_msg'] = msg


### PR DESCRIPTION
This patch would prove useful as we spend ages at Imperial debugging what had caused this exception and a stack trace would have helped.