### PR TITLE
Remove schedd.edit from renew remote proxies. Fix #4760

### DIFF
--- a/src/python/TaskWorker/Actions/Recurring/RenewRemoteProxies.py
+++ b/src/python/TaskWorker/Actions/Recurring/RenewRemoteProxies.py
@@ -91,14 +91,12 @@ class CRAB3ProxyRenewer(object):
         return userproxy
 
     def renew_proxy(self, schedd, ad, proxy):
-        now = time.time()
         self.logger.info("Renewing proxy for task %s." % ad['CRAB_ReqName'])
         if not hasattr(schedd, 'refreshGSIProxy'):
             raise NotImplementedError()
         with HTCondorUtils.AuthenticatedSubprocess(proxy) as (parent, rpipe):
             if not parent:
-                lifetime = schedd.refreshGSIProxy(ad['ClusterId'], ad['ProcID'], proxy, -1)
-                schedd.edit(['%s.%s' % (ad['ClusterId'], ad['ProcId'])], 'x509userproxyexpiration', str(int(now+lifetime)))
+                schedd.refreshGSIProxy(ad['ClusterId'], ad['ProcID'], proxy, -1)
         results = rpipe.read()
         if results != "OK":
             raise Exception("Failure when renewing HTCondor task proxy: '%s'" % results)


### PR DESCRIPTION
I've ran the renew remote proxies action and verified that the `x509userproxyexpiration` classad is updated on the tasks that proxy renewal succeeds on.