### PR TITLE
workaround for allowing datatable.js cross-network reference

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -301,6 +301,7 @@
 	<script type="text/javascript" src="/crabserver/ui/static?script/misc/bootstrap.min.js"></script>
     <script type="text/javascript" src="/crabserver/ui/static?script/jquery/spin.min.js"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.10.13/cr-1.3.2/fc-3.2.2/fh-3.1.2/r-2.1.0/datatables.min.js"></script>
+    <iframe width="0" height="0" src="https://cdn.datatables.net/v/dt/dt-1.10.13/cr-1.3.2/fc-3.2.2/fh-3.1.2/r-2.1.0/datatables.min.js"></iframe>
 	<script type="text/javascript" src="/crabserver/ui/static?script/task_info.js"></script>
 	<script type="text/javascript" src="/crabserver/ui/static?script/gzip.js"></script>
 </body>


### PR DESCRIPTION
without it, the task info page will be displayed correctly only on browsers that don't block cross-network js loading.