### PR TITLE
Revert change to st2 node state parsing logic

### DIFF
--- a/scripts/task_process/cache_status.py
+++ b/scripts/task_process/cache_status.py
@@ -242,8 +242,7 @@ def parseNodeStateV2(fp, nodes):
             # some status parsing logic to try and guess whether the job would
             # be tried again in the near future.  This behavior is no longer
             # observed; STATUS_ERROR is terminal.
-            if info['State'] != 'killed':
-                info['State'] = 'failed'
+            info['State'] = 'failed'
 
 # --- New code ----
 


### PR DESCRIPTION
In an older commit [1] Marco added the `if` branch to show `killed` jobs as `killed` in status2 instead of `failed`, which is the old status behavior. However, in case the job is killed by HTCondor (for using too much memory, for example), this job would also be shown as `killed` in status2. This makes it confusing to the user (because he might've not killed any jobs himself) and also tricky to distinguish whether the job was killed by the user or HTCondor in status2. Instead, at least in the meantime, to avoid uncomfortable changes to status2 code I'm reverting this to the old behavior to show both `killed` and `failed` jobs as `failed`.

[1]
https://github.com/dmwm/CRABServer/commit/665ed6b2949a887da911c2af3094b9a4d7523cd0#diff-6cc292d0ae2f3ef927c720e8da41e9a7R241
