### PR TITLE
Add better error message for incorrect userIputFiles param

### DIFF
--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -347,8 +347,9 @@ class RESTUserWorkflow(RESTEntity):
             validate_str("lfn", param, safe, RX_LFN, optional=True)
             self._checkOutLFN(safe.kwargs, username)
             validate_strlist("addoutputfiles", param, safe, RX_ADDFILE, custom_err="Incorrect 'JobType.outputFiles' parameter. " \
-                    "Allowed regexp: '%s'." % RX_ADDFILE.pattern)
-            validate_strlist("userfiles", param, safe, RX_USERFILE)
+                    "Allowed regexp for each filename: '%s'." % RX_ADDFILE.pattern)
+            validate_strlist("userfiles", param, safe, RX_USERFILE, custom_err="Incorrect 'Data.userInputFiles' parameter. " \
+                    "Allowed regexp for each filename: '%s'." % RX_USERFILE.pattern)
             validate_num("savelogsflag", param, safe, optional=False)
             validate_num("saveoutput", param, safe, optional=True)
             validate_num("faillimit", param, safe, optional=True)


### PR DESCRIPTION
User had some trouble with invalid input filenames [1], the default error message doesn't explain anything, this will print the regex that failed. We did the same thing for the outputFiles parameter some time ago.
[1] https://hypernews.cern.ch/HyperNews/CMS/get/computing-tools/2672.html