### PR TITLE
Increase RenewRemoteProxies polling time to 2 days

### DIFF
--- a/src/python/TaskWorker/Actions/Recurring/RenewRemoteProxies.py
+++ b/src/python/TaskWorker/Actions/Recurring/RenewRemoteProxies.py
@@ -15,7 +15,7 @@ from RESTInteractions import HTTPRequests
 from TaskWorker.Actions.Recurring.BaseRecurringAction import BaseRecurringAction
 
 class RenewRemoteProxies(BaseRecurringAction):
-    pollingTime = 360 #minutes
+    pollingTime = 2880 #minutes
 
     def _execute(self, resthost, resturi, config, task):
         renewer = CRAB3ProxyRenewer(config, resthost, resturi.replace("workflowdb", "info"), self.logger)


### PR DESCRIPTION
Forgot to make a PR for this earlier, so far 2 days seems to have worked fine.