### PR TITLE
Add api for getting some task classads with condor_q

### DIFF
--- a/src/python/CRABInterface/DataUserWorkflow.py
+++ b/src/python/CRABInterface/DataUserWorkflow.py
@@ -85,6 +85,14 @@ class DataUserWorkflow(object):
            :return: a generator of output file info lists - site, lfn, ... for each file"""
         return self.workflow.output2(workflow, howmany, jobids)
 
+    def taskads(self, workflow):
+        """Calls the getRootTasks method to query condor and return a list of predefined attributes.
+
+           :arg str workflow: a workflow name
+           :return: a dict of attributes returned by the getRootTasks method
+        """
+        return self.workflow.taskads(workflow)
+
     def submit(self, *args, **kwargs):
         """Perform the workflow injection
 

--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -689,6 +689,8 @@ class RESTUserWorkflow(RESTEntity):
                 result = self.userworkflowmgr.report2(workflow, userdn=userdn, usedbs=shortformat)
             elif subresource == 'publicationstatus':
                 result = self.userworkflowmgr.publicationStatus(workflow, asourl, asodb, username)
+            elif subresource == 'taskads':
+                result = self.userworkflowmgr.taskads(workflow)
             # if here means that no valid subresource has been requested
             # flow should never pass through here since validation restrict this
             else:

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -70,7 +70,7 @@ RX_CLUSTERID = re.compile(r"^[0-9.]+$")
 RX_CERT = re.compile(r'^[-]{5}BEGIN CERTIFICATE[-]{5}[\w\W]+[-]{5}END CERTIFICATE[-]{5}\n$')
 
 #subresourced of DataUserWorkflow (/workflow) resource
-RX_SUBRESTAT = re.compile(r"^errors|report|logs|data|logs2|data2|resubmit|resubmit2|proceed|publicationstatus$")
+RX_SUBRESTAT = re.compile(r"^errors|report|logs|data|logs2|data2|resubmit|resubmit2|proceed|publicationstatus|taskads$")
 
 #subresources of the ServerInfo (/info) and Task (/task) resources
 RX_SUBRES_SI = re.compile(r"^delegatedn|backendurls|version|bannedoutdest|scheddaddress|ignlocalityblacklist|$")


### PR DESCRIPTION
This would be called by the client in status2 when there is no webdir found in the database for a task. In that case, the DagmanHoldReason should be displayed to the user.

Status2 should already have the collector and schedd parameters needed for this query, getting them from the DB is simpler (maybe we want to avoid unnecessary DB queries?). Also not sure what classads exactly this should return. I could simply return the hold reason, but having things like JobStatus, ExitCode etc. may be useful for other things and shouldn't increase the load on the schedd, though this isn't difficult to modify in any case.