### PR TITLE
Fix uninitialized var in DagmanCreator. Fix #5448

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -769,8 +769,9 @@ class DagmanCreator(TaskAction.TaskAction):
             dagSpecs += jobgroupDagSpecs
 
         def getBlacklistMsg():
+            tmp = ""
             if len(global_blacklist)!=0:
-                tmp = " Global CRAB3 blacklist is %s.\n" % global_blacklist
+                tmp += " Global CRAB3 blacklist is %s.\n" % global_blacklist
             if len(siteBlacklist)!=0:
                 tmp += " User blacklist is %s.\n" % siteBlacklist
             if len(siteWhitelist)!=0:


### PR DESCRIPTION
I've reproduced the error with these config parameters [1]. With the fix, the behavior seems correct [2].

[1]
```
config.Data.inputDataset = '/TTToSemiLepton_TuneCUETP8M1_14TeV-powheg-pythia8/PhaseIIFall16DR82-PU200_90X_upgrade2023_realistic_v1_ext1-v1/GEN-SIM-RECO'
config.Data.splitting = 'FileBased'
config.Site.blacklist = ['T2_US_Vanderbilt']
```

[2]
```
2017-03-23 12:54:39,074:DEBUG:Handler,79:Traceback (most recent call last):
  File "/afs/cern.ch/user/e/erupeika/private/github/repos/CRABServer/src/python/TaskWorker/Actions/Handler.py", line 77, in executeAction
    output = work.execute(nextinput, task=self._task, tempDir=self.tempDir)
  File "/afs/cern.ch/user/e/erupeika/private/github/repos/CRABServer/src/python/TaskWorker/Actions/DagmanCreator.py", line 1073, in execute
    info, params, inputFiles, splitterResult = self.executeInternal(*args, **kw)
  File "/afs/cern.ch/user/e/erupeika/private/github/repos/CRABServer/src/python/TaskWorker/Actions/DagmanCreator.py", line 1064, in executeInternal
    info, splitterResult, subdags = self.createSubdag(*args, **kw)
  File "/afs/cern.ch/user/e/erupeika/private/github/repos/CRABServer/src/python/TaskWorker/Actions/DagmanCreator.py", line 790, in createSubdag
    raise TaskWorker.WorkerExceptions.NoAvailableSite(msg)
NoAvailableSite: The CRAB server backend refuses to send jobs to the Grid scheduler. No locations found for dataset '/TTToSemiLepton_TuneCUETP8M1_14TeV-powheg-pythia8/PhaseIIFall16DR82-PU200_90X_upgrade2023_realistic_v1_ext1-v1/GEN-SIM-RECO'. (or at least for the part of the dataset that passed the lumi-mask and/or run-range selection).
 Found 28 (out of 28) blocks present only at blacklisted sites. User blacklist is set([u'T2_US_Vanderbilt']).
```