### PR TITLE
Add CRAB_ReqName to task_process attributes

### DIFF
--- a/scripts/dag_bootstrap_startup.sh
+++ b/scripts/dag_bootstrap_startup.sh
@@ -158,13 +158,15 @@ else
     if [ -f /etc/enable_task_daemon ] && [ ! -f task_process/task_process_running ];
     then
         echo "creating and executing task process daemon jdl"
+        TASKNAME=`grep '^CRAB_ReqName =' $_CONDOR_JOB_AD | awk '{print $NF;}'`
 cat > task_process/daemon.jdl << EOF
-Universe   = local
-Executable = task_process/task_proc_wrapper.sh
-Arguments  = $CLUSTER_ID
-Log        = task_process/daemon.PC.log
-Output     = task_process/daemon.out.\$(Cluster).\$(Process)
-Error      = task_process/daemon.err.\$(Cluster).\$(Process)
+Universe      = local
+Executable    = task_process/task_proc_wrapper.sh
+Arguments     = $CLUSTER_ID
+Log           = task_process/daemon.PC.log
+Output        = task_process/daemon.out.\$(Cluster).\$(Process)
+Error         = task_process/daemon.err.\$(Cluster).\$(Process)
++CRAB_ReqName = $TASKNAME
 Queue 1
 EOF
         # TODO - remove chmod


### PR DESCRIPTION
Something convenient to have when debugging problems with the task process.