### PR TITLE
Provide separate EstimatedWallTime.

### DIFF
--- a/src/python/TaskWorker/Actions/PreJob.py
+++ b/src/python/TaskWorker/Actions/PreJob.py
@@ -333,7 +333,8 @@ class PreJob:
         self.resubmit_info[outkey]['CRAB_ResubmitList_in_taskad'] = CRAB_ResubmitList_in_taskad
         ## Add the resubmission parameters to the Job.<job_id>.submit content.
         if maxjobruntime is not None:
-            new_submit_text += '+MaxWallTimeMins = %s\n' % (str(maxjobruntime))
+            new_submit_text += '+EstimatedWallTimeMins = %s\n' % str(maxjobruntime)
+            new_submit_text += '+MaxWallTimeMins = (JobStatus=?=1) ? EstimatedWallTimeMins : %s\n' % str(maxjobruntime)
         if maxmemory is not None:
             new_submit_text += '+RequestMemory = %s\n' % (str(maxmemory))
         if numcores is not None:


### PR DESCRIPTION
MaxWallTimeMins is used for two different things in CRAB:
- Provide an estimate of runtime to HTCondor in order to help match jobs to a running pilot.
- As a limit when the schedd will kill a running job that goes over its runtime limits.

This tweak allows us to set separate values for each use case.  Both values default to the same thing, but there's an opportunity to adjust the estimated wall time in the future.