### PR TITLE
Explicitly disable all transfers for splitting pilots

### DIFF
--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -2392,6 +2392,9 @@ class PostJob():
         else:
             ## If CRAB_ASOTimeout was not defined in the job ad, use a default of 6 hours.
             self.retry_timeout = 6 * 3600
+        if self.stage == 'probe':
+            self.transfer_outputs = 0
+            self.transfer_logs = 0
         return 0
 
     ## = = = = = PostJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =


### PR DESCRIPTION
Not tested yet, I'm fixing my VM right now. Should solve problems observed by Oscar.