### PR TITLE
Fix TestWorker to allow running in debug mode again

### DIFF
--- a/src/python/TaskWorker/TestWorker.py
+++ b/src/python/TaskWorker/TestWorker.py
@@ -27,8 +27,8 @@ class TestWorker(object):
 
     def injectWorks(self, works):
         if works:
-            func, task, _, _ = works[0]
-            func(self.resthost, self.resturi, self.config, task, 0)
+            func, task, _, args = works[0]
+            func(self.resthost, self.resturi, self.config, task, 0, args)
 
     def checkFinished(self):
         return []


### PR DESCRIPTION
Somehow, I needed the argument for the work to be set properly.