### PR TITLE
do not print sandbox contest in job stdout

### DIFF
--- a/scripts/CMSRunAnalysis.py
+++ b/scripts/CMSRunAnalysis.py
@@ -561,7 +561,7 @@ def prepSandbox(opts):
 
 def extractUserSandbox(archiveJob, cmsswVersion):
     os.chdir(cmsswVersion)
-    print(commands.getoutput('tar xvfzm %s ' % os.path.join('..', archiveJob)))
+    print(commands.getoutput('tar xfzm %s ' % os.path.join('..', archiveJob)))
     os.chdir('..')
 
 def getProv(filename, scram):

--- a/scripts/CMSRunAnalysis.py
+++ b/scripts/CMSRunAnalysis.py
@@ -540,7 +540,7 @@ def prepSandbox(opts):
                     handleException("FAILED", EC_WGET, 'CMSRunAnalysisERROR: could not get jobO files from panda server')
                     sys.exit(EC_WGET)
                 time.sleep(30)
-        print(commands.getoutput('tar xvfzm %s' % opts.archiveJob))
+        print(commands.getoutput('tar xfzm %s' % opts.archiveJob))
     print("==== Sandbox preparation FINISHING at %s ====" % time.asctime(time.gmtime()))
 
     #move the pset in the right place


### PR DESCRIPTION
make it easier to read an debug job stdout
sandbox content is anyhow always avaiable on schedd spool directory