### PR TITLE
tm_publication is a string, not a boolean. Fix #5543

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -555,7 +555,7 @@ class DagmanCreator(TaskAction.TaskAction):
         dagSpecs = []
         i = startjobid
         temp_dest, dest = makeLFNPrefixes(task)
-        if task['tm_publication'] :
+        if task['tm_publication'] == 'T':
             try:
                 validateLFNs(dest,outfiles)
             except AssertionError as ex:


### PR DESCRIPTION
I've fixed some mistakes that were in Stefano's PR https://github.com/dmwm/CRABServer/pull/5544. I think this is safe to deploy in production, will do so ASAP.