### PR TITLE
Tell WMCore to not override PSet threads

### DIFF
--- a/scripts/TweakPSet.py
+++ b/scripts/TweakPSet.py
@@ -92,7 +92,7 @@ class SetupCMSSWPsetCore(SetupCMSSWPset):
     """
     def __init__(self, location, inputFiles, runAndLumis, agentNumber, lfnBase, outputMods, firstEvent=0, lastEvent=-1, firstLumi=None,\
                     firstRun=None, seeding=None, lheInputFiles=False, oneEventMode=False, eventsPerLumi=None, maxRuntime=None):
-        ScriptInterface.__init__(self)
+        SetupCMSSWPset.__init__(self, crabPSet=True)
         self.stepSpace = ConfigSection()
         self.stepSpace.location = location
         self.step = StepConfiguration(lfnBase, outputMods)
@@ -111,7 +111,6 @@ class SetupCMSSWPsetCore(SetupCMSSWPset):
             self.step.data.application.configuration.eventsPerLumi = eventsPerLumi
         if maxRuntime:
             self.step.data.application.configuration.maxSecondsUntilRampdown = maxRuntime
-        self.step.data.application.multicore.enabled = False
         self.step.data.section_("input")
         self.job = jobDict(lheInputFiles, seeding)
         self.job["input_files"] = []


### PR DESCRIPTION
This is needed to make use of my changes in WMCore [1]. 

I have no idea why previously the `ScriptInterface.__init__()` method was being called, skipping the `__init__()` method of the parent Class `SetupCMSSWPset`, kind of awkward and strange, though many other things about this code are strange too.

Also removing `self.step.data.application.multicore.enabled` because it had become meaningless some time ago.

[1] https://github.com/dmwm/WMCore/pull/7993

