### PR TITLE
Add index creation to oracle create script. Fix #5550

### DIFF
--- a/src/python/Databases/FileTransfersDB/Oracle/Create.py
+++ b/src/python/Databases/FileTransfersDB/Oracle/Create.py
@@ -24,6 +24,7 @@ class Create(DBCreator):
         self.create = {}
         self.constraints = {}
         self.create['i_transfers'] = "CREATE INDEX TM_TASKNAME_IDX ON FILETRANSFERSDB (TM_TASKNAME)"
+        self.create['i_workers'] = "CREATE INDEX TM_WORKER_STATE ON FILETRANSFERSDB (TM_ASO_WORKER, TM_TRANSFER_STATE) COMPRESS 2"
         #  //
         # // Define create statements for each table
         # //


### PR DESCRIPTION
Tested on my personal devdb11 instance, the index does get created [1].

[1]
```
select index_name from user_indexes where index_name = 'TM_TASKNAME_IDX';

INDEX_NAME                   
------------------------------
TM_TASKNAME_IDX         
```