### PR TITLE
Use pycurl in PhEDEx service not httlib2

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -330,7 +330,7 @@ class DagmanCreator(TaskAction.TaskAction):
 
     def __init__(self, *args, **kwargs):
         TaskAction.TaskAction.__init__(self, *args, **kwargs)
-        self.phedex = PhEDEx.PhEDEx() #TODO use config certs!
+        self.phedex = PhEDEx.PhEDEx({'pycurl': True}) #TODO use config certs!
 
 
     def buildDashboardInfo(self, task):


### PR DESCRIPTION
Because we've removed httplib2 from the taskworker tarballs [1], automatic splitting fails on the schedd with [2], which @matz-e reported. The patch initializes the WMCore Requests service to use pycurl for communication, which fixes this problem.

[1] https://github.com/dmwm/CRABServer/commit/db077fe2c6c868126e72bc9cf8eff01642ce4aa8
[2] predag.0.txt
```
Got a fatal exception: No module named httplib2
Traceback (most recent call last):
  File "/usr/lib64/python2.6/runpy.py", line 122, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib64/python2.6/runpy.py", line 34, in _run_code
    exec code in run_globals
  File "/data/srv/glidecondor/condor_local/spool/5135/0/cluster16825135.proc0.subproc0/TaskWorker/TaskManagerBootstrap.py", line 85, in <module>
    retval = bootstrap()
  File "/data/srv/glidecondor/condor_local/spool/5135/0/cluster16825135.proc0.subproc0/TaskWorker/TaskManagerBootstrap.py", line 28, in bootstrap
    return PreDAG.PreDAG().execute(*sys.argv[2:])
  File "TaskWorker/Actions/PreDAG.py", line 110, in execute
    retval = self.executeInternal(*args)
  File "TaskWorker/Actions/PreDAG.py", line 223, in executeInternal
    _, _, subdags = creator.createSubdag(split_result.result, task=task, parent=parent, stage=self.stage)
  File "TaskWorker/Actions/DagmanCreator.py", line 837, in createSubdag
    jobgroupDagSpecs, startjobid = self.makeDagSpecs(kwargs['task'], sitead, siteinfo, jobgroup, list(jgblocks)[0], availablesites, datasites, outfiles, startjobid, parent=parent, stage=stage)
  File "TaskWorker/Actions/DagmanCreator.py", line 615, in makeDagSpecs
    lastDirectPfn = self.resolvePFNs(task['tm_asyncdest'], directDest)
  File "TaskWorker/Actions/DagmanCreator.py", line 375, in resolvePFNs
    pfn_info = self.phedex.getPFN(nodes=dest_sites_, lfns=lfns)
  File "WMCore/Services/PhEDEx/PhEDEx.py", line 387, in getPFN
    data = self._getResult('lfn2pfn', args=input_dict, verb='GET')
  File "WMCore/Services/PhEDEx/PhEDEx.py", line 48, in _getResult
    f = self.refreshCache(file, callname, args, verb=verb)
  File "WMCore/Services/Service.py", line 201, in refreshCache
    self.getData(cachefile, url, inputdata, incoming_headers, encoder, decoder, verb, contentType)
  File "WMCore/Services/Service.py", line 272, in getData
    contentType = contentType)
  File "WMCore/Services/Requests.py", line 141, in makeRequest
    encoder, decoder, contentType)
  File "WMCore/Services/Requests.py", line 237, in makeRequest_httplib
    conn = self._getURLOpener()
  File "WMCore/Services/Requests.py", line 349, in _getURLOpener
    import httplib2
ImportError: No module named httplib2
```
