### PR TITLE
cache_status.py refactoring, cmdline args

### DIFF
--- a/scripts/task_process/cache_status.py
+++ b/scripts/task_process/cache_status.py
@@ -10,14 +10,13 @@ import sys
 import classad
 import glob
 import copy
+import fcntl
 from shutil import move
 # Need to import HTCondorUtils from a parent directory, not easy when the files are not in python packages.
 # Solution by ajay, SO: http://stackoverflow.com/questions/11536764
 # /attempted-relative-import-in-non-package-even-with-init-py/27876800#comment28841658_19190695
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import HTCondorUtils
-
-logging.basicConfig(filename='task_process/cache_status.log', level=logging.DEBUG)
 
 NODE_DEFAULTS = {
     'Retries': 0,
@@ -32,9 +31,6 @@ NODE_DEFAULTS = {
     'WallDurations': [],
     'JobIds': []
 }
-
-STATUS_CACHE_FILE = "task_process/status_cache.txt"
-FJR_PARSE_RES_FILE = "task_process/fjr_parse_results.txt"
 
 #
 # insertCpu, parseJobLog, parsNodeStateV2 and parseErrorReport
@@ -244,91 +240,136 @@ def parseNodeStateV2(fp, nodes):
             # observed; STATUS_ERROR is terminal.
             info['State'] = 'failed'
 
-# --- New code ----
+class InvalidConfigException(Exception):
+    pass
 
-def storeNodesInfoInFile():
-    # Open cache file and get the location until which the jobs_log was parsed last time
-    try:
-        if os.path.exists(STATUS_CACHE_FILE) and os.stat(STATUS_CACHE_FILE).st_size > 0:
-            logging.debug("cache file found, opening and reading")
-            nodesStorage = open(STATUS_CACHE_FILE, "r")
+class StatusCacher:
+    """
+    Parses logs in the spool dir and updates the status_cache.txt file.
 
-            jobLogCheckpoint = int(nodesStorage.readline())
-            fjrParseResCheckpoint = int(nodesStorage.readline())
-            nodes = ast.literal_eval(nodesStorage.readline())
-            nodeMap = ast.literal_eval(nodesStorage.readline())
-            nodesStorage.close()
+    Can be initialized with different log file locations for debugging purposes
+    by passing an override configuration dict to the init method.
+    """
+
+    cfgDict = {
+        "statusCacheFile": "task_process/status_cache.txt",
+        "fjrParseResFile": "task_process/fjr_parse_results.txt",
+        "jobLogFile": "job_log",
+        "loggingFile": "task_process/cache_status.log"
+        }
+
+    def __init__(self, **kwargs):
+        # Check if kwargs contains override settings and apply them to the cfgDict
+        for key in kwargs:
+            if key in self.cfgDict:
+                self.cfgDict[key] = kwargs[key]
+            else:
+                raise InvalidConfigException()
+        # Assign cfgDict contents as class attributes
+        for key in self.cfgDict:
+            setattr(self, key, self.cfgDict[key])
+
+        logging.basicConfig(filename=self.loggingFile, level=logging.DEBUG)
+
+    def readPreviousInfo(self):
+        """
+        Open cache file and get the location until which the jobs_log was parsed last time
+        """
+
+        previousInfoDict = {
+            "jobLogCheckpoint": 0,
+            "fjrParseResCheckpoint": 0,
+            "nodes": {},
+            "nodeMap": {}
+            }
+
+        try:
+            if os.path.exists(self.statusCacheFile) and os.stat(self.statusCacheFile).st_size > 0:
+                logging.debug("Cache file found, opening and reading")
+
+                with open(self.statusCacheFile, "r") as nodesStorage:
+                    previousInfoDict["jobLogCheckpoint"] = int(nodesStorage.readline())
+                    previousInfoDict["fjrParseResCheckpoint"] = int(nodesStorage.readline())
+                    previousInfoDict["nodes"] = ast.literal_eval(nodesStorage.readline())
+                    previousInfoDict["nodeMap"] = ast.literal_eval(nodesStorage.readline())
+            else:
+                logging.debug("Cache file not found, will start from scratch")
+        except Exception:
+            logging.exception("error during status_cache handling")
+
+        return previousInfoDict
+
+    def readNewInfo(self, infoDict):
+        """
+        Parses the logs from a certain checkpoint and updates infoDict accordingly.
+        """
+        with open(self.jobLogFile, "r") as jobsLog:
+            jobsLog.seek(infoDict["jobLogCheckpoint"])
+            parseJobLog(jobsLog, infoDict["nodes"], infoDict["nodeMap"])
+            infoDict["jobLogCheckpoint"] = jobsLog.tell()
+
+        for fn in glob.glob("node_state*"):
+            with open(fn, 'r') as nodeState:
+                parseNodeStateV2(nodeState, infoDict["nodes"])
+
+        try:
+            errorSummary, infoDict["fjrParseResCheckpoint"] = self.summarizeFjrParseResults(
+                infoDict["fjrParseResCheckpoint"])
+            if errorSummary and infoDict["fjrParseResCheckpoint"]:
+                parseErrorReport(errorSummary, infoDict["nodes"])
+        except IOError:
+            logging.exception("Problem during error_summary file handling")
+
+    def storeNodesInfoInFile(self, infoDict):
+        """
+        Writes the contents of infoDict to file.
+        """
+
+        with open(self.statusCacheFile, "w") as cacheFile:
+            # Acquire blocking lock on the file
+            fcntl.flock(cacheFile.fileno(), fcntl.LOCK_EX)
+            cacheFile.write(str(infoDict["jobLogCheckpoint"]) + "\n")
+            cacheFile.write(str(infoDict["fjrParseResCheckpoint"]) + "\n")
+            cacheFile.write(str(infoDict["nodes"]) + "\n")
+            cacheFile.write(str(infoDict["nodeMap"]) + "\n")
+
+    def summarizeFjrParseResults(self, checkpoint):
+        '''
+        Reads the fjr_parse_results file line by line. The file likely contains multiple
+        errors for the same jobId coming from different retries, we only care about
+        the last error for each jobId. Since each postjob writes this information
+        sequentially (job retry #2 will be written after job retry #1), overwrite
+        whatever information there was before for each jobId.
+
+        Return the updated error dictionary and also the location until which the
+        fjr_parse_results file was read so that we can store it and
+        don't have t re-read the same information next time the cache_status.py runs.
+        '''
+
+        if os.path.exists(self.fjrParseResFile):
+            with open(self.fjrParseResFile, "r") as f:
+                f.seek(checkpoint)
+                content = f.readlines()
+                newCheckpoint = f.tell()
+
+            errDict = {}
+            for line in content:
+                fjrResult = ast.literal_eval(line)
+                jobId = fjrResult.keys()[0]
+                errDict[jobId] = fjrResult[jobId]
+            return errDict, newCheckpoint
         else:
-            logging.debug("cache file not found, creating")
-            jobLogCheckpoint = 0
-            fjrParseResCheckpoint = 0
-            nodes = {}
-            nodeMap = {}
-    except Exception:
-        logging.exception("error during status_cache handling")
-    jobsLog = open("job_log", "r")
+            return None, 0
 
-    jobsLog.seek(jobLogCheckpoint)
-
-    parseJobLog(jobsLog, nodes, nodeMap)
-    newJobLogCheckpoint = jobsLog.tell()
-    jobsLog.close()
-
-    for fn in glob.glob("node_state*"):
-        with open(fn, 'r') as nodeState:
-            parseNodeStateV2(nodeState, nodes)
-
-    try:
-        errorSummary, newFjrParseResCheckpoint = summarizeFjrParseResults(fjrParseResCheckpoint)
-        if errorSummary and newFjrParseResCheckpoint:
-            parseErrorReport(errorSummary, nodes)
-    except IOError:
-        logging.exception("error during error_summary file handling")
-
-    # First write the new cache file under a temporary name, so that other processes
-    # don't get an incomplete result. Then replace the old one with the new one.
-    tempFilename = (STATUS_CACHE_FILE + ".%s") % os.getpid()
-
-    nodesStorage = open(tempFilename, "w")
-    nodesStorage.write(str(newJobLogCheckpoint) + "\n")
-    nodesStorage.write(str(newFjrParseResCheckpoint) + "\n")
-    nodesStorage.write(str(nodes) + "\n")
-    nodesStorage.write(str(nodeMap) + "\n")
-    nodesStorage.close()
-
-    move(tempFilename, STATUS_CACHE_FILE)
-
-def summarizeFjrParseResults(checkpoint):
-    '''
-    Reads the fjr_parse_results file line by line. The file likely contains multiple
-    errors for the same jobId coming from different retries, we only care about
-    the last error for each jobId. Since each postjob writes this information
-    sequentially (job retry #2 will be written after job retry #1), overwrite
-    whatever information there was before for each jobId.
-
-    Return the updated error dictionary and also the location until which the
-    fjr_parse_results file was read so that we can store it and
-    don't have t re-read the same information next time the cache_status.py runs.
-    '''
-
-    if os.path.exists(FJR_PARSE_RES_FILE):
-        with open(FJR_PARSE_RES_FILE, "r") as f:
-            f.seek(checkpoint)
-            content = f.readlines()
-            newCheckpoint = f.tell()
-
-        errDict = {}
-        for line in content:
-            fjrResult = ast.literal_eval(line)
-            jobId = fjrResult.keys()[0]
-            errDict[jobId] = fjrResult[jobId]
-        return errDict, newCheckpoint
-    else:
-        return None, 0
+    def run(self):
+        infoDict = self.readPreviousInfo()
+        self.readNewInfo(infoDict)
+        self.storeNodesInfoInFile(infoDict)
 
 def main():
     try:
-        storeNodesInfoInFile()
+        cacher = StatusCacher()
+        cacher.run()
     except Exception:
         logging.exception("error during main loop")
 


### PR DESCRIPTION
I have restructured my code into more intuitive methods and made it better overall, IMHO. I didn't touch the code that does the log file parsing.

I also added support for command line arguments which make debugging slightly easier.
All of the arguments are optional, and if any of them are specified, the file location in the script will be overridden. It is used like this:
`python task_process/cache_status.py -c status_cache.txt --loggingFile log.log -f task_process/fjr_parse_results.txt --jobLog job_log` 

In production, the script will continue running without any arguments, in which case the defaults will used.
