### PR TITLE
Fix resubmission with automatic splitting

### DIFF
--- a/scripts/AdjustSites.py
+++ b/scripts/AdjustSites.py
@@ -148,6 +148,7 @@ def adjustMaxRetries(adjustJobIds, ad):
     (or for all jobs if jobIds = True). Incrementing the maximum allowed number of
     retries is a necessary condition for a job to be resubmitted.
     """
+    printLog("Adjusting retries for job ids: {0}".format(adjustJobIds))
     if not adjustJobIds:
         return
     if not os.path.exists("RunJobs.dag"):
@@ -168,7 +169,7 @@ def adjustMaxRetries(adjustJobIds, ad):
     ## Search for the RETRY directives in the DAG file for the job ids passed in the
     ## resubmitJobIds argument and change the maximum retries to the current retry
     ## count + CRAB_NumAutomJobRetries.
-    retry_re = re.compile(r'RETRY Job(\d+(?:\d+)?) (\d+) ')
+    retry_re = re.compile(r'RETRY Job(\d+(?:-\d+)?) (\d+) ')
     output = ""
     adjustAll = (adjustJobIds == True)
     numAutomJobRetries = int(ad.get('CRAB_NumAutomJobRetries', 2))

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -60,7 +60,7 @@ ABORT-DAG-ON Job{count} 3
 """
 
 SUBDAG_FRAGMENT = """
-SUBDAG EXTERNAL Job{count}SubJobs RunJobs{count}.subdag
+SUBDAG EXTERNAL Job{count}SubJobs RunJobs{count}.subdag NOOP
 SCRIPT DEFER 4 300 PRE Job{count}SubJobs dag_bootstrap.sh PREDAG {stage} {completion} {count}
 """
 

--- a/src/python/TaskWorker/Actions/DagmanSubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanSubmitter.py
@@ -464,6 +464,7 @@ class DagmanSubmitter(TaskAction.TaskAction):
         dagAd["LeaveJobInQueue"] = classad.ExprTree("true")
         dagAd["PeriodicHold"] = classad.ExprTree("time() > CRAB_TaskEndTime")
         dagAd["TransferOutput"] = info['outputFilesString']
+        dagAd["OnExitHold"] = classad.ExprTree("(ExitCode =!= UNDEFINED && ExitCode != 0)")
         dagAd["OnExitRemove"] = classad.ExprTree("( ExitSignal =?= 11 || (ExitCode =!= UNDEFINED && ExitCode >=0 && ExitCode <= 2))")
         dagAd["OtherJobRemoveRequirements"] = classad.ExprTree("DAGManJobId =?= ClusterId")
         dagAd["RemoveKillSig"] = "SIGUSR1"
@@ -483,7 +484,6 @@ class DagmanSubmitter(TaskAction.TaskAction):
                 fd.write('+{0} = {1}\n'.format(k, value))
 
         dagAd["TaskType"] = "ROOT"
-        dagAd["OnExitHold"] = classad.ExprTree("(ExitCode =!= UNDEFINED && ExitCode != 0)")
         dagAd["Out"] = str(os.path.join(info['scratch'], "request.out"))
         dagAd["Err"] = str(os.path.join(info['scratch'], "request.err"))
         dagAd["Cmd"] = cmd

--- a/src/python/TaskWorker/Actions/PreDAG.py
+++ b/src/python/TaskWorker/Actions/PreDAG.py
@@ -100,7 +100,7 @@ class PreDAG(object):
                     self.failedJobs.append(jobnr)
                 completedCount += 1
                 yield jobnr
-        self.logger.info("found {0} completed jobs".format(completedCount))
+        self.logger.info("found %s completed jobs", completedCount)
 
     def execute(self, *args):
         """Excecute executeInternal in locked mode
@@ -153,7 +153,7 @@ class PreDAG(object):
 
         self.readProcessedJobs()
         unprocessed = completed - self.processedJobs
-        self.logger.info("jobs remaining to process: {0}".format(", ".join(sorted(unprocessed))))
+        self.logger.info("jobs remaining to process: %s", ", ".join(sorted(unprocessed)))
 
         # The TaskWorker saves some files that now we are gonna read
         with open('datadiscovery.pkl', 'rb') as fd:
@@ -175,7 +175,7 @@ class PreDAG(object):
                 sumEventsThr += float(fd.read())
                 count += 1
         eventsThr = sumEventsThr / count
-        self.logger.info("average throughput for {1} jobs: {0}".format(eventsThr, count))
+        self.logger.info("average throughput for %s jobs: %s", count, eventsThr)
         runtime = task['tm_split_args'].get('seconds_per_job', -1)
         if self.stage == "processing":
             # Build in a 33% error margin in the runtime to not create too
@@ -219,9 +219,9 @@ class PreDAG(object):
 #            self.set_dashboard_state('FAILED')
             return 1
         try:
-            creator = DagmanCreator(config, server=None, resturi='')
             parent = self.prefix if self.stage == 'tail' else None
-            _, _, subdags = creator.createSubdag(split_result.result, task=task, parent=parent, stage=self.stage)
+            creator = DagmanCreator(config, server=None, resturi='')
+            creator.createSubdag(split_result.result, task=task, parent=parent, stage=self.stage)
             self.submitSubdag('RunJobs{0}.subdag'.format(self.prefix), getattr(config.TaskWorker, 'maxPost', 20), self.stage)
         except TaskWorkerException as e:
             retmsg = "DAG creation failed with:\n{0}".format(e)
@@ -285,7 +285,7 @@ class PreDAG(object):
         #Now we turn lumis it into something like:
         #lumis=['1, 33, 35, 35, 37, 47, 49, 75, 77, 130, 133, 136','1,45,50,80']
         #which is the format expected by buildLumiMask in the splitting algorithm
-        lumis = [",".join(map(str, reduce(lambda x, y:x + y, missing_compact[run]))) for run in runs]
+        lumis = [",".join(str(l) for l in reduce(lambda x, y:x + y, missing_compact[run])) for run in runs]
 
         task['tm_split_args']['runs'] = runs
         task['tm_split_args']['lumis'] = lumis


### PR DESCRIPTION
When using the external SubDAG line of DAGMan, HTCondor actively removes
remaining jobs in the queue when aborting a DAG due to failed nodes. This
includes tail SubDAGs and makes resubmission impossible. Make the DAGs
independent by submitting them when we previously created a submission file
only, and switch the DAG nodes to NOOP.