### PR TITLE
Fix fallout from disentangling DAGs.

### DIFF
--- a/scripts/dag_bootstrap_startup.sh
+++ b/scripts/dag_bootstrap_startup.sh
@@ -139,6 +139,7 @@ mkdir -p finished_jobs
 CONDOR_VERSION=`condor_version | head -n 1`
 PROC_ID=`grep '^ProcId =' $_CONDOR_JOB_AD | tr -d '"' | awk '{print $NF;}'`
 CLUSTER_ID=`grep '^ClusterId =' $_CONDOR_JOB_AD | tr -d '"' | awk '{print $NF;}'`
+REQUEST_NAME=`grep '^CRAB_ReqName =' $_CONDOR_JOB_AD | tr -d '"' | awk '{print $NF;}'`
 export CONDOR_ID="${CLUSTER_ID}.${PROC_ID}"
 ls -lah
 if [ "X" == "X$X509_USER_PROXY" ] || [ ! -e $X509_USER_PROXY ]; then
@@ -162,7 +163,7 @@ else
 cat > task_process/daemon.jdl << EOF
 Universe      = local
 Executable    = task_process/task_proc_wrapper.sh
-Arguments     = $CLUSTER_ID
+Arguments     = $REQUEST_NAME
 Log           = task_process/daemon.PC.log
 Output        = task_process/daemon.out.\$(Cluster).\$(Process)
 Error         = task_process/daemon.err.\$(Cluster).\$(Process)

--- a/scripts/task_process/task_proc_wrapper.sh
+++ b/scripts/task_process/task_proc_wrapper.sh
@@ -10,19 +10,35 @@ function check_exit {
     # If that passes, checks if the dag has been in a final state for long enough (currently 24h)
     # It will echo 1 if TP can exit, otherwise 0
 
-    # TP will only exit if the dag is not in a temporary state ( not idle(1) and not running(2) ), if at least one condor_q
-    # was performed (DAG_STATUS is not "init") and if the last perfomed condor_q was successfull (DAG_STATUS is not empty)
-    if [[ "$DAG_STATUS" != "1" && "$DAG_STATUS" != "2" && "$DAG_STATUS" != "init" && "$DAG_STATUS" ]]; then
-        # If the dag is in a final state, check the age of ENTERED_CUR_STATUS.
-        echo $(( ( $(date +"%s") - $ENTERED_CUR_STATUS ) > 24 * 3600))
+    # TP will only exit if the dag is not in a temporary state ( not
+    # idle(1) and not running(2) ), if at least one condor_q was performed
+    # (DAG_INFO is not "init") and if the last perfomed condor_q was
+    # successfull (DAG_INFO is not empty)
+    if [[ "$DAG_INFO" == "init" || ! "$DAG_INFO" ]]; then
+        echo 0
         return
     fi
-    # Cannot exit yet
-    echo 0
+
+    # Make sure that all DAGs have exited; Count the ones that are still
+    # running or are in the current state for less than 24 hours.
+    NOT_DONE=0
+    echo "$DAG_INFO"|while read CLUSTER_ID DAG_STATUS ENTERED_CUR_STATUS; do
+        if [[ "$DAG_STATUS" == "1" || "$DAG_STATUS" == "2" || $(( ($(date +"%s") - $ENTERED_CUR_STATUS) < 24 * 3600 )) ]]; then
+            NOT_DONE=$(( $NOT_DONE + 1 ))
+        fi
+    done
+    echo $(( $NOT_DONE == 0 ))
+}
+
+function dag_status {
+    [[ "$DAG_INFO" == "init" || ! "$DAG_INFO" ]] && return
+    echo "$DAG_INFO"|while read CLUSTER_ID DAG_STATUS ENTERED_CUR_STATUS; do
+        echo "Dag status code for $CLUSTER_ID: $DAG_STATUS Entered current status date: $(date -d @$ENTERED_CUR_STATUS '+%Y/%m/%d %H:%M:%S %Z')"
+    done
 }
 
 function perform_condorq {
-    read DAG_STATUS ENTERED_CUR_STATUS <<< `condor_q $CLUSTER_ID -af JobStatus EnteredCurrentStatus`
+    DAG_INFO=$(condor_q -constr 'CRAB_ReqName =?= "'$REQUEST_NAME'" && TaskType =!= "Job"' -af ClusterId JobStatus EnteredCurrentStatus)
     TIME_OF_LAST_QUERY=$(date +"%s")
     echo "Query done on $(date '+%Y/%m/%d %H:%M:%S %Z')"
 }
@@ -38,9 +54,9 @@ echo "Starting a new task_process, creating task_process_running file"
 
 HOURS_BETWEEN_QUERIES=24
 
-# Cluster ID is passed from the dagman_bootstrap_startup.sh and points to the main dag
-CLUSTER_ID=$1
-echo "CLUSTER_ID: $CLUSTER_ID"
+# The request name is passed from the dagman_bootstrap_startup.sh and points to the main dag
+REQUEST_NAME=$1
+echo "REQUEST_NAME: $REQUEST_NAME"
 
 # Sleeping until files in the spool dir are created. TODO - make this smarter
 sleep 60s
@@ -48,9 +64,9 @@ TIME_OF_LAST_QUERY=$(date +"%s")
 
 # Loop will exit when condor_q does not return 1 (idle) or 2 (running), meaning that the dag reached a final state
 # and no more changes should happen to the status.
-# For the initial query period, set DAG_STATUS to something other than empty. Since querying condor immediatly after
+# For the initial query period, set DAG_INFO to something other than empty. Since querying condor immediatly after
 # submission is most likely pointless and relatively expensive, the script will run normally and perform the query later.
-DAG_STATUS="init"
+DAG_INFO="init"
 
 echo "Starting task daemon wrapper"
 while true
@@ -75,25 +91,26 @@ do
         perform_condorq
     fi
 
-    # Once the dag's status changes from 1 (idle) or 2 (running) to something else,
+    # Once the dags' status changes from 1 (idle) or 2 (running) to something else,
     # (normally) no further updates are expected to the log files and the task_process can exit.
     # However, in the case that a crab kill command is issued, Task Worker performs two operations:
     # 1) Hold the DAG with condor_hold,
     # 2) Remove all of the jobs with condor_rm.
     # If a task is large, it will take some time for all of the jobs to be removed. If during this time
-    # we run condor_q, see that the DAG is held and decide to exit immediately, some jobs may still be
+    # we run condor_q, see that the DAGs are held and decide to exit immediately, some jobs may still be
     # in the process of getting removed and their status may not be updated before the wrapper exits. To get around this,
-    # we won't exit until the dag has spent at least 24 hours in it's latest state (EnteredCurrentStatus classad).
+    # we won't exit until every dag has spent at least 24 hours in it's latest state (EnteredCurrentStatus classad).
     # This should give enough time for any changes to be propagated to the log files that we parse in the caching script.
     # This method is better than a simple sleep because of the possibility of resubmission.
     #
-    # Note that here we also ignore an empty DAG_STATUS result because it could be a temporary problem with condor_q
+    # Note that here we also ignore an empty DAG_INFO result because it could be a temporary problem with condor_q
     # simply returning empty. If the dag isn't actually in the queue anymore, the check for an existing caching script
     # at the start of the loop should catch that and exit.
-    echo "Dag status code: $DAG_STATUS Entered current status date: $(date -d @$ENTERED_CUR_STATUS '+%Y/%m/%d %H:%M:%S %Z')"
+    dag_status
+
     if [ "$(check_exit)" == "1" ]; then
         # Before we really decide to exit, we should run condor_q once more
-        # to get the latest info about DAG_STATUS and ENTERED_CUR_STATUS. Even though check_exit may pass successfully,
+        # to get the latest info about the DAGs. Even though check_exit may pass successfully,
         # because we do condor_q only every 24h (and also wait for 24 hours after ENTERED_CUR_STATUS),
         # the information used in check_exit could be out of date - the task may have been resubmitted
         # after our last condor_q, for example.
@@ -109,6 +126,7 @@ do
 
             exit 0
         fi
-        echo "Cannot exit yet! DAG_STATUS: $DAG_STATUS ENTERED_CUR_STATUS: $ENTERED_CUR_STATUS"
+        echo "Cannot exit yet!"
+        dag_status
     fi
 done

--- a/src/python/TaskWorker/Actions/DagmanKiller.py
+++ b/src/python/TaskWorker/Actions/DagmanKiller.py
@@ -92,10 +92,10 @@ class DagmanKiller(TaskAction):
 
     def killAll(self, jobConst):
 
-        # We need to keep ROOT DAG in hold until periodic remove kicks in.
+        # We need to keep ROOT, PROCESSING, and TAIL DAGs in hold until periodic remove kicks in.
         # See DagmanSubmitter.py#L390 (dagAd["PeriodicRemove"])
         # This is needed in case user wants to resubmit.
-        rootConst = "TaskType =?= \"ROOT\" && CRAB_ReqName =?= %s" % HTCondorUtils.quote(self.workflow)
+        rootConst = "TaskType =!= \"Job\" && CRAB_ReqName =?= %s" % HTCondorUtils.quote(self.workflow)
 
         # Holding DAG job does not mean that it will remove all jobs
         # and this must be done separately


### PR DESCRIPTION
1. Pass the CRAB RequestName to the task_process for monitoring
2. Have task_process monitor all DAGs matching the RequestName
3. Kill not just the ROOT DAG, but all DAGs matching the RequestName