### PR TITLE
Publication flag fixes

### DIFF
--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -720,7 +720,6 @@ class ASOServerJob(object):
                            'publication_state': 'not_published',
                            'publication_retry_count': [],
                            'type': file_type,
-                           'publish': publish,
                           }
                     ## TODO: We do the following, only because that's what ASO does when a file has
                     ## been successfully transferred. But this modified LFN makes no sence when it
@@ -742,6 +741,7 @@ class ASOServerJob(object):
                 ## If after all we need to upload a new document to ASO database, let's do it.
                 if needs_commit:
                     doc.update(doc_new_info)
+                    doc['publish'] = publish
                     msg = "ASO job description: %s" % (pprint.pformat(doc))
                     self.logger.info(msg)
                     commit_result_msg = self.updateOrInsertDoc(doc)


### PR DESCRIPTION
This commit fixes a problem with publication that happens when a first
transfer fails (retry #1) and then the next retry uses direct stageout.

Since the postjob/ASO synch patch the publication flag is changed to 0
in the retry#1, but then on retry #2 is not updated anymore (used to
work because the publcation flag was not touched before)