### PR TITLE
Adjust column type for total units.

### DIFF
--- a/etc/updateOracle.sql
+++ b/etc/updateOracle.sql
@@ -106,3 +106,9 @@ ALTER TABLE filetransfersdb RENAME COLUMN tm_jobid_varchar TO tm_jobid;
 
 --Add the column to be used for the filetrasfersdb partitioning
 ALTER TABLE filetransfersdb ADD tm_creation_time TIMESTAMP;
+
+--Change number of totalUnits to allow fractions
+ALTER TABLE tasks ADD tm_totalunits_fraction NUMBER(38,6);
+UPDATE tasks SET tm_totalunits_fraction = tm_totalunits;
+ALTER TABLE tasks DROP COLUMN tm_totalunits;
+ALTER TABLE tasks RENAME COLUMN tm_totalunits_fraction TO tm_totalunits;


### PR DESCRIPTION
Fixes #5633. Use NUMBER(38,6), giving an integer precision of 32 digits and
a fractional precision of 6 digits.

@belforte @todor-ivanov @hernand this is the update to the database required to make fractional `totalUnits` work.

Tested with `totalUnits = 0.01`:

* [Automatic splitting](http://dashb-cms-job.cern.ch/dashboard/templates/task-analysis/#user=matze&refresh=0&table=Jobs&p=1&records=25&activemenu=2&status=&site=&tid=180208_094258%3Amatze_crab_0115_automatic_fraction_01): processed 1528420 events out of 152720952: 1.0008 percent of the dataset
* [EventAwareLumiBased splitting](http://dashb-cms-job.cern.ch/dashboard/templates/task-analysis/#user=matze&refresh=0&table=Jobs&p=1&records=25&activemenu=2&status=&site=&tid=180208_094658%3Amatze_crab_0115_eventawarelumibased_fraction_01): processed 1528420 events out of 152720952: 1.0008 percent of the dataset
* [FileBased splitting](http://dashb-cms-job.cern.ch/dashboard/templates/task-analysis/#user=matze&refresh=0&table=Jobs&p=1&records=25&activemenu=2&status=&site=&tid=180208_095311%3Amatze_crab_0115_filebased_fraction_01): processed 25 files out of 2519: 0.9925 percent of the dataset
* [LumiBased splitting](http://dashb-cms-job.cern.ch/dashboard/templates/task-analysis/#user=matze&refresh=0&table=Jobs&p=1&records=25&activemenu=2&status=&site=&tid=180208_095429%3Amatze_crab_0115_lumibased_fraction_01): processed 10703 lumis out of 1070337: 1.0000 percent of the dataset