### PR TITLE
Make kills final with automatic splitting.

### DIFF
--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -290,6 +290,7 @@ class DataWorkflow(object):
             return [{'result': retmsg}]
 
         task_status = row.task_status
+        task_splitting = row.split_algo
 
         resubmitWhat = "publications" if publication else "jobs"
         self.logger.info("About to resubmit %s for workflow: %s.", resubmitWhat, workflow)
@@ -309,6 +310,10 @@ class DataWorkflow(object):
         ## If the task status is not an allowed one, fail the resubmission.
         if task_status not in allowedTaskStates:
             msg = "You cannot resubmit %s if the task is in status %s." % (resubmitWhat, task_status)
+            raise ExecutionError(msg)
+
+        if task_status == 'KILLED' and task_splitting == 'Automatic':
+            msg = "You cannot resubmit {0} if the task is in status {1} and uses automatic splitting.".format(resubmitWhat, task_status)
             raise ExecutionError(msg)
 
         if task_status != 'SUBMITFAILED':

--- a/src/python/Databases/TaskDB/Oracle/Task/Task.py
+++ b/src/python/Databases/TaskDB/Oracle/Task/Task.py
@@ -7,11 +7,11 @@ class Task(object):
     """
     #ID
     ID_tuple = namedtuple("ID", ["taskname", "panda_jobset_id", "task_status", "task_command", "user_role", "user_group", \
-             "task_failure", "split_args", "panda_resubmitted_jobs", "save_logs", "username", \
+             "task_failure", "split_algo", "split_args", "panda_resubmitted_jobs", "save_logs", "username", \
              "user_dn", "arguments", "input_dataset", "dbs_url", "task_warnings", "publication", "user_webdir", \
              "asourl", "asodb", "output_dataset", "collector", "schedd", "dry_run", "clusterid", "start_time"])
     ID_sql = "SELECT tm_taskname, panda_jobset_id, tm_task_status, tm_task_command, tm_user_role, tm_user_group, \
-             tm_task_failure, tm_split_args, panda_resubmitted_jobs, tm_save_logs, tm_username, \
+             tm_task_failure, tm_split_algo, tm_split_args, panda_resubmitted_jobs, tm_save_logs, tm_username, \
              tm_user_dn, tm_arguments, tm_input_dataset, tm_dbs_url, tm_task_warnings, tm_publication, tm_user_webdir, tm_asourl, \
              tm_asodb, tm_output_dataset, tm_collector, tm_schedd, tm_dry_run, clusterid, tm_start_time \
              FROM tasks WHERE tm_taskname=:taskname"

--- a/src/python/TaskWorker/Actions/DagmanKiller.py
+++ b/src/python/TaskWorker/Actions/DagmanKiller.py
@@ -95,7 +95,7 @@ class DagmanKiller(TaskAction):
         # We need to keep ROOT, PROCESSING, and TAIL DAGs in hold until periodic remove kicks in.
         # See DagmanSubmitter.py#L390 (dagAd["PeriodicRemove"])
         # This is needed in case user wants to resubmit.
-        rootConst = "TaskType =!= \"Job\" && CRAB_ReqName =?= %s" % HTCondorUtils.quote(self.workflow)
+        rootConst = 'stringListMember(TaskType, "ROOT PROCESSING TAIL", " ") && CRAB_ReqName =?= %s' % HTCondorUtils.quote(self.workflow)
 
         # Holding DAG job does not mean that it will remove all jobs
         # and this must be done separately


### PR DESCRIPTION
Also avoid killing the task_process at the same time as the DAGs, to have a
status update after the kill that reflects it properly.

Fixes #5635.

@belforte a first check if a resubmit is allowed can also be done on the client side… but the server is already contacted to download the status, so I'm not sure if I should change the client for this at all.