### PR TITLE
Removing unnecessary redraw to decrease load time of CrabServer UI TrasnferInfo significantly

### DIFF
--- a/src/script/task_info.js
+++ b/src/script/task_info.js
@@ -449,7 +449,7 @@ $(document).ready(function() {
                         if (duration) content.push(duration.toFixed(0))
                         content.push(duration)
 
-                        transtable.row.add( content ).draw()
+                        transtable.row.add( content )//.draw()
 
                     }
 


### PR DESCRIPTION
The whole table of CrabServer UI TransferInfo was being redrawn for every single item, instead of pushing data to array and drawing it once, thus increasing the load time to unreasonable amount.

The times were/are
Before: ~10k jobs took over 10 minutes
Now: ~17k jobs takes 30-60 seconds