### PR TITLE
Do not perform the HTCondor query in the PreJob

### DIFF
--- a/scripts/AdjustSites.py
+++ b/scripts/AdjustSites.py
@@ -292,21 +292,14 @@ def saveProxiedWebdir(ad):
     if proxied_webDir: # Prefer the proxied webDir to the non-proxied one
         ad[webDir_adName] = str(proxied_webDir)
 
-    #This condor_edit is required because in the REST interface we look for the webdir if the DB upload failed (or in general if we use the "old logic")
-    #See https://github.com/dmwm/CRABServer/blob/3.3.1507.rc8/src/python/CRABInterface/HTCondorDataWorkflow.py#L398
-    dagJobId = '%d.%d' % (ad['ClusterId'], ad['ProcId'])
-    try:
-        htcondor.Schedd().edit([dagJobId], webDir_adName, '{0}'.format(ad.lookup(webDir_adName)))
-    except RuntimeError as reerror:
-        printLog(str(reerror))
-
-    # We need to use a file to communicate this to the prejob. I tried things like:
-    #    htcondor.Schedd().edit([dagJobId], 'CRAB_UserWebDirPrx', ad.lookup('CRAB_UserWebDir'))
-    # but the prejob read the classads from the file, not querying the schedd.and we can't update
-    # the classad file since it's owned by user condor
     if ad[webDir_adName]:
-        with open("proxied_webdir", "w") as fd:
-            fd.write(ad[webDir_adName])
+        # This condor_edit is required because in the REST interface we look for the webdir if the DB upload failed (or in general if we use the "old logic")
+        # See https://github.com/dmwm/CRABServer/blob/3.3.1507.rc8/src/python/CRABInterface/HTCondorDataWorkflow.py#L398
+        dagJobId = '%d.%d' % (ad['ClusterId'], ad['ProcId'])
+        try:
+            htcondor.Schedd().edit([dagJobId], webDir_adName, '{0}'.format(ad.lookup(webDir_adName)))
+        except RuntimeError as reerror:
+            printLog(str(reerror))
     else:
         printLog("Cannot get proxied webdir from the server. Maybe the schedd does not have one in the REST configuration?")
         return 1

--- a/scripts/AdjustSites.py
+++ b/scripts/AdjustSites.py
@@ -300,6 +300,12 @@ def saveProxiedWebdir(ad):
             htcondor.Schedd().edit([dagJobId], webDir_adName, '{0}'.format(ad.lookup(webDir_adName)))
         except RuntimeError as reerror:
             printLog(str(reerror))
+
+        # We need to use a file to communicate this to the prejob. I tried to read the corresponding ClassAd from the preJob like:
+        # htcondor.Schedd().xquery(requirements="ClusterId == %d && ProcId == %d" % (self.task_ad['ClusterId'], self.task_ad['ProcId']), projection=[webDir_adName]).next().get(webDir_adName)
+        # but it is too heavy of an operation.
+        with open("webdir", "w") as fd:
+            fd.write(ad[webDir_adName])
     else:
         printLog("Cannot get proxied webdir from the server. Maybe the schedd does not have one in the REST configuration?")
         return 1

--- a/scripts/AdjustSites.py
+++ b/scripts/AdjustSites.py
@@ -272,12 +272,11 @@ def updateWebDir(ad):
 
 def saveProxiedWebdir(ad):
     """ The function queries the REST interface to get the proxied webdir and sets
-        a classad so that we report this to the dashboard instead of the regular URL
+        a classad so that we report this to the dashboard instead of the regular URL.
 
-        The proxied_url (if exist) is written to a file named proxied_webdir so that
-        prejobs can read it and report to dashboard. If the url does not exist
-        (i.e.: schedd not at CERN), the file is not written and we report the usual
-        webdir
+        The webdir (if exists) is written to a file named 'webdir' so that
+        prejobs can read it and report to dashboard. If the proxied URL does not exist
+        (i.e.: schedd not at CERN), we report the usual webdir.
 
         See https://github.com/dmwm/CRABServer/issues/4883
     """
@@ -349,7 +348,7 @@ def main():
     printLog("Starting AdjustSites with _CONDOR_JOB_AD=%s" % os.environ['_CONDOR_JOB_AD'])
 
     with open(os.environ['_CONDOR_JOB_AD']) as fd:
-        ad = classad.parseOld(fd)
+        ad = classad.parseOne(fd)
     printLog("Parsed ad: %s" % ad)
 
     makeWebDir(ad)
@@ -419,7 +418,7 @@ def main():
     if 'CRAB_SiteAdUpdate' in ad:
         newSiteAd = ad['CRAB_SiteAdUpdate']
         with open("site.ad") as fd:
-            siteAd = classad.parse(fd)
+            siteAd = classad.parseOne(fd)
         siteAd.update(newSiteAd)
         with open("site.ad", "w") as fd:
             fd.write(str(siteAd))

--- a/scripts/dag_bootstrap_startup.sh
+++ b/scripts/dag_bootstrap_startup.sh
@@ -70,7 +70,13 @@ if [ $(cat $_CONDOR_JOB_AD | wc -l) -lt 3 ]; then
     fi
 fi
 
-#MAX_POST is set in TaskWorker configuration.
+# MAX_IDLE and MAX_POST are set in TaskWorker configuration and ServerUtilities.py.
+MAX_IDLE=1000
+MAX_IDLE_TMP=`grep '^CRAB_MaxIdle =' $_CONDOR_JOB_AD | tr -d '"' | awk '{print $NF;}'`
+if [ "X$MAX_IDLE_TMP" != "X" ]; then
+    MAX_IDLE=$MAX_IDLE_TMP
+fi
+
 MAX_POST=20
 MAX_POST_TMP=`grep '^CRAB_MaxPost =' $_CONDOR_JOB_AD | tr -d '"' | awk '{print $NF;}'`
 if [ "X$MAX_POST_TMP" != "X" ]; then
@@ -226,7 +232,7 @@ EOF
     # This is also done in the PostJob to submit subdags for tail-catching
     # and automated splitting.  Values below will also have to be changed
     # there in (createSubdagSubmission)!
-    exec nice -n 19 condor_dagman -f -l . -Lockfile $PWD/$1.lock -DoRecov -AutoRescue 0 -MaxPre 20 -MaxIdle 1000 -MaxPost $MAX_POST -Dag $PWD/$1 -Dagman `which condor_dagman` -CsdVersion "$CONDOR_VERSION" -debug 4 -verbose
+    exec nice -n 19 condor_dagman -f -l . -Lockfile $PWD/$1.lock -DoRecov -AutoRescue 0 -MaxPre 20 -MaxIdle $MAX_IDLE -MaxPost $MAX_POST -Dag $PWD/$1 -Dagman `which condor_dagman` -CsdVersion "$CONDOR_VERSION" -debug 4 -verbose
     EXIT_STATUS=$?
     echo "condor_dagman terminated with EXIT_STATUS=${EXIT_STATUS} at `date`"
 fi

--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -34,6 +34,9 @@ MAX_WALLTIME = 21*60*60 + 30*60
 MAX_MEMORY = 2*1024
 MAX_DISK_SPACE = 20000000 # Disk usage is not used from .job.ad as CRAB3 is not seeting it. 20GB is max.
 
+MAX_IDLE_JOBS = 1000
+MAX_POST_JOBS = 20
+
 ## Parameter used to set the LeaveJobInQueue and the PeriodicRemoveclassads.
 ## It's also used during resubmissions since we don't allow a resubmission during the last week
 ## Before changing this value keep in mind that old running DAGs have the old value in the CRAB_TaskSubmitTime

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -23,7 +23,7 @@ import TaskWorker.WorkerExceptions
 import TaskWorker.DataObjects.Result
 import TaskWorker.Actions.TaskAction as TaskAction
 from TaskWorker.WorkerExceptions import TaskWorkerException
-from ServerUtilities import insertJobIdSid, MAX_DISK_SPACE
+from ServerUtilities import insertJobIdSid, MAX_DISK_SPACE, MAX_IDLE_JOBS, MAX_POST_JOBS
 from CMSGroupMapper import get_egroup_users
 
 import WMCore.WMSpec.WMTask
@@ -1045,11 +1045,19 @@ class DagmanCreator(TaskAction.TaskAction):
             fd.write(dag)
 
         info["jobcount"] = len(dagSpecs)
-        maxpost = getattr(self.config.TaskWorker, 'maxPost', 20)
+
+        maxidle = getattr(self.config.TaskWorker, 'maxIdle', MAX_IDLE_JOBS)
+        if maxidle == -1:
+            maxidle = info['jobcount']
+        elif maxidle == 0:
+            maxidle = int(max(MAX_IDLE_JOBS, info['jobcount']*.1))
+        info['maxidle'] = maxidle
+
+        maxpost = getattr(self.config.TaskWorker, 'maxPost', MAX_POST_JOBS)
         if maxpost == -1:
             maxpost = info['jobcount']
         elif maxpost == 0:
-            maxpost = int(max(20, info['jobcount']*.1))
+            maxpost = int(max(MAX_POST_JOBS, info['jobcount']*.1))
         info['maxpost'] = maxpost
 
         if info.get('faillimit') == None:

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -136,7 +136,7 @@ WhenToTransferOutput = ON_EXIT_OR_EVICT
 +SpoolOnEvict = false
 
 # Keep job in the queue upon completion long enough for the postJob to run, allowing the monitoring script to fetch the postJob status and job exit-code updated by the postJob
-LeaveJobInQueue = true
+LeaveJobInQueue = ifThenElse((JobStatus=?=4 || JobStatus=?=3) && (time() - EnteredCurrentStatus < 30 * 60*60), true, false)
 
 universe = vanilla
 Executable = gWMS-CMSRunAnalysis.sh

--- a/src/python/TaskWorker/Actions/DagmanSubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanSubmitter.py
@@ -88,6 +88,7 @@ SUBMIT_INFO = [ \
     ('CRAB_ASODB', 'tm_asodb'),
     ('CRAB_FailedNodeLimit', 'faillimit'),
     ('CRAB_DashboardTaskType', 'taskType'),
+    ('CRAB_MaxIdle', 'maxidle'),
     ('CRAB_MaxPost', 'maxpost')]
 
 

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -2653,14 +2653,14 @@ class PostJob():
         while counter < limit:
             try:
                 counter += 1
-                msg = "attempt %d out of %d" % (counter, limit)
+                msg = "attempt %d out of %d without Schedd.edits" % (counter, limit)
                 self.logger.info("       -----> Started %s -----", msg)
                 with self.schedd.transaction():
-                    for param in params:
-                        self.schedd.edit([self.dag_jobid], param, str(params[param]))
-                    self.schedd.edit([self.dag_jobid], 'CRAB_PostJobLastUpdate', str(time.time()))
-                    # Once state ClassAds have been updated, let HTCondor remove the job from the queue
-                    self.schedd.edit([self.dag_jobid], "LeaveJobInQueue", classad.ExprTree("false"))
+                    #for param in params:
+                    #    self.schedd.edit([self.dag_jobid], param, str(params[param]))
+                    #self.schedd.edit([self.dag_jobid], 'CRAB_PostJobLastUpdate', str(time.time()))
+                    ## Once state ClassAds have been updated, let HTCondor remove the job from the queue
+                    #self.schedd.edit([self.dag_jobid], "LeaveJobInQueue", classad.ExprTree("false"))
                     self.logger.info("       -----> Finished %s -----", msg)
                     self.logger.info("====== Finished to update ClassAds.")
                     break

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -2641,7 +2641,7 @@ class PostJob():
         if os.environ.get('TEST_POSTJOB_NO_STATUS_UPDATE', False):
             self.schedd.edit([self.dag_jobid], "LeaveJobInQueue", classad.ExprTree("false"))
             return
-        self.logger.info("====== Starting to update classAds.")
+        self.logger.info("====== Starting to update ClassAds.")
         msg = "status: %s." % (state)
         params = {'CRAB_PostJobStatus': '"{0}"'.format(state)}
         self.monitoringExitCode(params, exitCode)
@@ -2651,16 +2651,20 @@ class PostJob():
         limit = 5
         counter = 0
         while counter < limit:
-            counter += 1
-            self.logger.info("       -----> Started attempt %d out of %d -----", counter, limit)
-            with self.schedd.transaction():
-                for param in params:
-                    self.schedd.edit([self.dag_jobid], param, str(params[param]))
-                self.schedd.edit([self.dag_jobid], 'CRAB_PostJobLastUpdate', str(time.time()))
-                # Once state classAds have been updated, let HTCondor remove the job from the queue
-                self.schedd.edit([self.dag_jobid], "LeaveJobInQueue", classad.ExprTree("false"))
-                self.logger.info("====== Finished to update classAds.")
-                break
+            try:
+                counter += 1
+                self.logger.info("       -----> Started attempt %d out of %d -----", counter, limit)
+                with self.schedd.transaction():
+                    for param in params:
+                        self.schedd.edit([self.dag_jobid], param, str(params[param]))
+                    self.schedd.edit([self.dag_jobid], 'CRAB_PostJobLastUpdate', str(time.time()))
+                    # Once state ClassAds have been updated, let HTCondor remove the job from the queue
+                    self.schedd.edit([self.dag_jobid], "LeaveJobInQueue", classad.ExprTree("false"))
+                    self.logger.info("====== Finished to update ClassAds.")
+                    break
+            except Exception:
+                self.logger.exception()
+
             if counter != limit:
                 self.logger.warning("       -----> Failed to set ClassAds -----")
                 maxSleep = 2*counter -1

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -2840,7 +2840,7 @@ class PostJob():
             archiveDoc = createArchiverDoc(job)
             archiveDoc['task'] = self.reqname
             archiveDoc["meta_data"]['crab_id'] = self.job_id
-            archiveDoc["meta_data"]['crab_exit_code'] = self.job_report['exitCode']
+            archiveDoc["meta_data"]['crab_exit_code'] = self.job_report.get('exitCode', -1)
             archiveDoc["steps"].append(
                 {
                     "errors": [

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -2653,14 +2653,14 @@ class PostJob():
         while counter < limit:
             try:
                 counter += 1
-                msg = "attempt %d out of %d without Schedd.edits" % (counter, limit)
+                msg = "attempt %d out of %d with only one Schedd.edit" % (counter, limit)
                 self.logger.info("       -----> Started %s -----", msg)
                 with self.schedd.transaction(htcondor.TransactionFlags.NonDurable):
                     #for param in params:
                     #    self.schedd.edit([self.dag_jobid], param, str(params[param]))
                     #self.schedd.edit([self.dag_jobid], 'CRAB_PostJobLastUpdate', str(time.time()))
-                    ## Once state ClassAds have been updated, let HTCondor remove the job from the queue
-                    #self.schedd.edit([self.dag_jobid], "LeaveJobInQueue", classad.ExprTree("false"))
+                    # Once state ClassAds have been updated, let HTCondor remove the job from the queue
+                    self.schedd.edit([self.dag_jobid], "LeaveJobInQueue", classad.ExprTree("false"))
                     self.logger.info("       -----> Finished %s -----", msg)
                     self.logger.info("====== Finished to update ClassAds.")
                     break

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -2649,11 +2649,12 @@ class PostJob():
         self.logger.info(msg)
         with HTCondorUtils.AuthenticatedSubprocess(os.environ['X509_USER_PROXY'], logger=self.logger) as (parent, rpipe):
             if not parent:
-                for param in params:
-                    self.schedd.edit([self.dag_jobid], param, str(params[param]))
-                self.schedd.edit([self.dag_jobid], 'CRAB_PostJobLastUpdate', str(time.time()))
-                # Once state classAds have been updated, let HTCondor remove the job from the queue
-                self.schedd.edit([self.dag_jobid], "LeaveJobInQueue", classad.ExprTree("false"))
+                with self.schedd.transaction():
+                    for param in params:
+                        self.schedd.edit([self.dag_jobid], param, str(params[param]))
+                    self.schedd.edit([self.dag_jobid], 'CRAB_PostJobLastUpdate', str(time.time()))
+                    # Once state classAds have been updated, let HTCondor remove the job from the queue
+                    self.schedd.edit([self.dag_jobid], "LeaveJobInQueue", classad.ExprTree("false"))
                 self.logger.info("====== Finished to update classAds.")
 
     ## = = = = = PostJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -2655,7 +2655,7 @@ class PostJob():
                 counter += 1
                 msg = "attempt %d out of %d without Schedd.edits" % (counter, limit)
                 self.logger.info("       -----> Started %s -----", msg)
-                with self.schedd.transaction():
+                with self.schedd.transaction(htcondor.TransactionFlags.NonDurable):
                     #for param in params:
                     #    self.schedd.edit([self.dag_jobid], param, str(params[param]))
                     #self.schedd.edit([self.dag_jobid], 'CRAB_PostJobLastUpdate', str(time.time()))

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -1079,9 +1079,10 @@ class ASOServerJob(object):
         Killing actual FTS transfers (if possible) is left to ASO.
         """
         if doc_ids_reasons is None:
+            doc_ids_reasons = {}
             for doc_info in self.docs_in_transfer:
                 doc_id = doc_info['doc_id']
-                doc_ids_reasons = dict(doc_id = None)
+                doc_ids_reasons[doc_id] = None
         if not doc_ids_reasons:
             msg = "There are no ASO transfers to cancel."
             self.logger.info(msg)

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -2638,6 +2638,10 @@ class PostJob():
         """
         Update PostJobStatus and job exit-code among the job ClassAds for the monitoring script to update the Grafana dashboard.
         """
+        if not os.path.exists('/etc/editClassAds'):
+            self.logger.info("====== Will not edit the job ClassAds.")
+            return
+
         if os.environ.get('TEST_POSTJOB_NO_STATUS_UPDATE', False):
             self.schedd.edit([self.dag_jobid], "LeaveJobInQueue", classad.ExprTree("false"))
             return

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -83,7 +83,6 @@ from shutil import move
 from httplib import HTTPException
 
 import DashboardAPI
-import HTCondorUtils
 import WMCore.Database.CMSCouch as CMSCouch
 from WMCore.DataStructs.LumiList import LumiList
 from WMCore.Services.WMArchive.DataMap import createArchiverDoc
@@ -2647,15 +2646,13 @@ class PostJob():
         self.monitoringExitCode(params, exitCode)
         msg += " ClassAds values to set are: %s" % (str(params))
         self.logger.info(msg)
-        with HTCondorUtils.AuthenticatedSubprocess(os.environ['X509_USER_PROXY'], logger=self.logger) as (parent, rpipe):
-            if not parent:
-                with self.schedd.transaction():
-                    for param in params:
-                        self.schedd.edit([self.dag_jobid], param, str(params[param]))
-                    self.schedd.edit([self.dag_jobid], 'CRAB_PostJobLastUpdate', str(time.time()))
-                    # Once state classAds have been updated, let HTCondor remove the job from the queue
-                    self.schedd.edit([self.dag_jobid], "LeaveJobInQueue", classad.ExprTree("false"))
-                self.logger.info("====== Finished to update classAds.")
+        with self.schedd.transaction():
+            for param in params:
+                self.schedd.edit([self.dag_jobid], param, str(params[param]))
+            self.schedd.edit([self.dag_jobid], 'CRAB_PostJobLastUpdate', str(time.time()))
+            # Once state classAds have been updated, let HTCondor remove the job from the queue
+            self.schedd.edit([self.dag_jobid], "LeaveJobInQueue", classad.ExprTree("false"))
+        self.logger.info("====== Finished to update classAds.")
 
     ## = = = = = PostJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -1081,7 +1081,7 @@ class ASOServerJob(object):
         if doc_ids_reasons is None:
             for doc_info in self.docs_in_transfer:
                 doc_id = doc_info['doc_id']
-                doc_ids_reasons[doc_id] = None
+                doc_ids_reasons = dict(doc_id = None)
         if not doc_ids_reasons:
             msg = "There are no ASO transfers to cancel."
             self.logger.info(msg)

--- a/src/python/TaskWorker/Actions/PreJob.py
+++ b/src/python/TaskWorker/Actions/PreJob.py
@@ -551,9 +551,9 @@ class PreJob:
         ## Load the task ad.
         self.get_task_ad()
 
-        webDir_ClassAd = 'CRAB_WebDirURL'
+        webDir_ClassAd = 'CRAB_WebDirURL' # this ClassAd is not present in the os.environ['_CONDOR_JOB_AD'] file parsed in the get_task_ad() above, being created afterwards by AdjustSites.py, so we need to query the DAG job now:
         try:
-            self.userWebDirPrx = htcondor.Schedd().xquery(requirements="ClusterId == %d && ProcId == %d" % (self.task_ad['ClusterId'], self.task_ad['ProcId']), projection=[webDir_ClassAd]).next().get(webDir_ClassAd)
+            self.userWebDirPrx = htcondor.Schedd().xquery(requirements="ClusterId == %d && ProcId == %d" % (self.task_ad['ClusterId'], self.task_ad['ProcId']), projection=[webDir_ClassAd]).next().get(webDir_ClassAd) # Given we are querying the DAG job, we may extend this query and remove the file parsing above. 
         except:
             msg = "Exception executing the pre-job:"
             msg += "\n'%s' ClassAd not found in job %d.%d" % (webDir_ClassAd, self.task_ad['ClusterId'], self.task_ad['ProcId'])

--- a/src/python/TaskWorker/Actions/PreJob.py
+++ b/src/python/TaskWorker/Actions/PreJob.py
@@ -551,13 +551,12 @@ class PreJob:
         ## Load the task ad.
         self.get_task_ad()
 
-        webDir_ClassAd = 'CRAB_WebDirURL' # this ClassAd is not present in the os.environ['_CONDOR_JOB_AD'] file parsed in the get_task_ad() above, being created afterwards by AdjustSites.py, so we need to query the DAG job now:
         try:
-            self.userWebDirPrx = htcondor.Schedd().xquery(requirements="ClusterId == %d && ProcId == %d" % (self.task_ad['ClusterId'], self.task_ad['ProcId']), projection=[webDir_ClassAd]).next().get(webDir_ClassAd) # Given we are querying the DAG job, we may extend this query and remove the file parsing above. 
-        except:
-            msg = "Exception executing the pre-job:"
-            msg += "\n'%s' ClassAd not found in job %d.%d" % (webDir_ClassAd, self.task_ad['ClusterId'], self.task_ad['ProcId'])
-            self.logger.exception(msg)
+            with open('webdir') as fd:
+                self.userWebDirPrx = fd.read()
+        except IOError as e:
+            self.logger.error("'I/O error(%s): %s', when looking for the 'webdir' file. Might be normal"
+                              " if the schedd does not have a proxiedurl in the REST external config.", e.errno, e.strerror)
 
         try:
             self.get_resubmit_info()


### PR DESCRIPTION
[This query](https://github.com/dmwm/CRABServer/commit/48b3700c0f0feaf273f1ae766e53da61edcf0b6c#diff-2e11afb3c1930106c068af4dfb513115R556) is too heavy when executed by many PreJobs on the schedd.
Going back to communicating the webDir through a file. 