### PR TITLE
Fix publishname for Rucio

### DIFF
--- a/scripts/task_process/RUCIO_Transfers.py
+++ b/scripts/task_process/RUCIO_Transfers.py
@@ -223,7 +223,7 @@ def algorithm():
     try:
         with open("task_process/transfers.txt") as _list:
             doc = json.loads(_list.readlines()[0])
-            publishname = doc['publishname']
+            publishname = doc['publishname'].replace('-00000000000000000000000000000000', '/rucio/USER')
         monitor_manager(user, publishname)
     except Exception:
         logging.exception('Monitor proccess failed.')


### PR DESCRIPTION
Due to using publication false with RUCIO output files. Right now, when publication is false the publishname is the name of the task provided by the user + '-00000000000000000000000000000000'

I'm trying to keep a Dataset name in the form of usal DBS datasets,