### PR TITLE
Disable direct stageout for Rucio + better exception management

### DIFF
--- a/scripts/cmscp.py
+++ b/scripts/cmscp.py
@@ -908,12 +908,8 @@ def main():
     dest_final_dir = G_JOB_AD['CRAB_OutLFNDir']
     dest_files = split_re.split(G_JOB_AD['CRAB_Destination'])
     dest_site = G_JOB_AD['CRAB_AsyncDest']
-    # Disable direct stageout for RUCIO
-    if dest_final_dir.startswith('/store/user/rucio/'):
-        stageout_policy = ['local']
-    else:
-        stageout_policy = split_re.split(G_JOB_AD['CRAB_StageoutPolicy'])
-        print("Stageout policy: %s" % (", ".join(stageout_policy)))
+    stageout_policy = split_re.split(G_JOB_AD['CRAB_StageoutPolicy'])
+    print("Stageout policy: %s" % (", ".join(stageout_policy)))
 
     ##--------------------------------------------------------------------------
     ## Finish PARSE JOB AD

--- a/scripts/cmscp.py
+++ b/scripts/cmscp.py
@@ -904,12 +904,17 @@ def main():
             update_exit_info(exit_info, 80000, msg, True)
             return exit_info
     ## Retrieve the above attributes from the job ad.
-    stageout_policy = split_re.split(G_JOB_AD['CRAB_StageoutPolicy'])
-    print("Stageout policy: %s" % (", ".join(stageout_policy)))
     dest_temp_dir = G_JOB_AD['CRAB_OutTempLFNDir']
     dest_final_dir = G_JOB_AD['CRAB_OutLFNDir']
     dest_files = split_re.split(G_JOB_AD['CRAB_Destination'])
     dest_site = G_JOB_AD['CRAB_AsyncDest']
+    # Disable direct stageout for RUCIO
+    if dest_final_dir.startswith('/store/user/rucio/'):
+        stageout_policy = ['local']
+    else:
+        stageout_policy = split_re.split(G_JOB_AD['CRAB_StageoutPolicy'])
+        print("Stageout policy: %s" % (", ".join(stageout_policy)))
+
     ##--------------------------------------------------------------------------
     ## Finish PARSE JOB AD
     ##--------------------------------------------------------------------------

--- a/scripts/cmscp.py
+++ b/scripts/cmscp.py
@@ -310,7 +310,7 @@ def add_output_file_to_job_report(file_name, key = 'addoutput'):
     output_file_info['pfn'] = file_name
     try:
         file_size = os.stat(file_name).st_size
-    except:
+    except Exception:
         msg = "WARNING: Unable to add output file size to job report."
         print(msg)
     else:
@@ -681,12 +681,11 @@ def clean_stageout_area(local_stageout_mgr, direct_stageout_impl, policy, \
                     print("       <----- Stageout implementation log finish")
                     msg = "File successfully removed."
                     print(msg)
-                except:
+                except Exception:
                     print("       <----- Stageout implementation log finish")
                     msg  = "WARNING: Failed to remove file"
                     msg += " (maybe the file was not transferred)."
                     print(msg)
-                    pass
         else:
             msg = "There are no %sfiles to remove in the permanent storage at %s."
             msg = msg % ('other ' if found_log and keep_log else '', dest_site)
@@ -1496,7 +1495,7 @@ if __name__ == '__main__':
     JOB_STGOUT_WRAPPER_EXIT_INFO = {}
     try:
         JOB_STGOUT_WRAPPER_EXIT_INFO = main()
-    except:
+    except Exception:
         MSG  = "ERROR: Unhandled exception."
         MSG += "\n%s" % (traceback.format_exc())
         print(MSG)
@@ -1535,7 +1534,7 @@ if __name__ == '__main__':
                 MSG += " Will report failure to Dashboard."
                 print(MSG)
                 DashboardAPI.reportFailureToDashboard(CMSCP_EXIT_CODE, G_JOB_AD)
-            except:
+            except Exception:
                 MSG  = "ERROR: Unhandled exception when reporting failure to dashboard."
                 MSG += "\n%s" % (traceback.format_exc())
                 print(MSG)

--- a/scripts/task_process/CMSRucio.py
+++ b/scripts/task_process/CMSRucio.py
@@ -13,7 +13,6 @@ from subprocess import PIPE, Popen
 import requests
 from requests.exceptions import ReadTimeout
 
-import rucio.rse.rsemanager as rsemgr
 from rucio.client.client import Client
 from rucio.common.exception import (DataIdentifierAlreadyExists, FileAlreadyExists, RucioException,
                                     AccessDenied)
@@ -260,9 +259,9 @@ class CMSRucio(object):
             print(" Dry run only.  Not deleting replicas.")
             return
 
-        logging.debug('%s: %s' % (rse, [{'scope': self.scope,
+        logging.debug('%s: %s', rse, [{'scope': self.scope,
                                                       'name': filemd['name'],
-                                                     } for filemd in replicas]))
+                                                     } for filemd in replicas])
         try:
             self.cli.delete_replicas(rse=rse, files=[{'scope': self.scope,
                                                       'name': filemd['name'],

--- a/scripts/task_process/CMSRucio.py
+++ b/scripts/task_process/CMSRucio.py
@@ -209,7 +209,7 @@ class CMSRucio(object):
             print(' Dry run only. Not registering files.')
             return
         if checksums:
-            replicas = [{'scope': self.scope, 'pfn': pfn,'name': lfn, 'bytes': size, 'adler32': checksum, 'state': 'A'} for lfn, pfn, size, checksum in zip(lfns, pfns, sizes, checksums)]
+            replicas = [{'scope': self.scope, 'name': lfn, 'bytes': size, 'adler32': checksum, 'state': 'A'} for lfn, size, checksum in zip(lfns, sizes, checksums)]
         else:
             replicas = [{'scope': self.scope, 'name': lfn, 'bytes': size, 'state': 'A'} for lfn, size in zip(lfns, sizes)]
         print(replicas)

--- a/scripts/task_process/CMSRucio.py
+++ b/scripts/task_process/CMSRucio.py
@@ -215,16 +215,16 @@ class CMSRucio(object):
         print(replicas)
         # TODO: check if did already exists and choose between the following 2
         try:
-
             self.cli.add_replicas(rse=rse, files=replicas)
-        except Exception:
-            pass
+        except Exception as ex:
+            logging.exception("Failed to add replicas")
+            raise ex
 
         try:
-
             self.cli.update_replicas_states(rse=rse, files=replicas)
-        except Exception:
-            pass
+        except Exception as ex:
+            logging.exception("Failed to update states")
+            raise ex
 
 
     def register_temp_replicas(self, rse, lfns, pfns, sizes, checksums):

--- a/scripts/task_process/task_proc_wrapper.sh
+++ b/scripts/task_process/task_proc_wrapper.sh
@@ -20,7 +20,7 @@ function manage_transfers {
     if [[ -f task_process/transfers.txt ]]; then
         DEST_LFN=`python -c 'import sys, json; print json.loads( open("task_process/transfers.txt").readlines()[0] )["destination_lfn"]' `
 
-        if [[ $DEST_LFN =~ ^/store/test/rucio/* ]]; then
+        if [[ $DEST_LFN =~ ^/store/user/rucio/* ]]; then
         export PYTHONPATH=$PYTHONPATH:/cvmfs/cms.cern.ch/rucio/current/lib/python2.7/site-packages
         timeout 15m python task_process/RUCIO_Transfers.py
         else

--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -164,7 +164,10 @@ def truncateError(msg):
 def checkOutLFN(lfn, username):
     """ Check if the lfn provided contains the username or is /store/local/ or /store/local/
     """
-    if lfn.startswith('/store/user/'):
+    if lfn.startswith('/store/user/rucio/'):
+        if lfn.split('/')[4] != username:
+            return False 
+    elif lfn.startswith('/store/user/'):
         if lfn.split('/')[3] != username:
             return False
     elif lfn.startswith('/store/test/rucio/user/'):
@@ -172,9 +175,6 @@ def checkOutLFN(lfn, username):
             return False
     elif lfn.startswith('/store/test/rucio/int/user/'):
         if lfn.split('/')[6] != username:
-            return False
-    elif lfn.startswith('/store/rucio/user/'):
-        if lfn.split('/')[4] != username:
             return False
     elif lfn.startswith('/store/group/') or lfn.startswith('/store/local/'):
         if lfn.split('/')[3] == '':

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -741,7 +741,7 @@ class DagmanCreator(TaskAction.TaskAction):
 
         # disable direct stageout for rucio tasks
         if kwargs['task']['tm_output_lfn'].startswith('/store/user/rucio'):
-            kwargs['task']['stageoutpolicy'] = "remote"
+            kwargs['task']['stageoutpolicy'] = "local"
         elif hasattr(self.config.TaskWorker, 'stageoutPolicy'):
             kwargs['task']['stageoutpolicy'] = ",".join(self.config.TaskWorker.stageoutPolicy)
         else:

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -739,7 +739,10 @@ class DagmanCreator(TaskAction.TaskAction):
         dagSpecs = []
         subdags = []
 
-        if hasattr(self.config.TaskWorker, 'stageoutPolicy'):
+        # disable direct stageout for rucio tasks
+        if kwargs['task']['tm_output_lfn'].startswith('/store/user/rucio'):
+            kwargs['task']['stageoutpolicy'] = "remote"
+        elif hasattr(self.config.TaskWorker, 'stageoutPolicy'):
             kwargs['task']['stageoutpolicy'] = ",".join(self.config.TaskWorker.stageoutPolicy)
         else:
             kwargs['task']['stageoutpolicy'] = "local,remote"

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -396,7 +396,9 @@ class ASOServerJob(object):
                         ##           failure is permanent or not.
                         reasons, app, severity = doc['transfer_failure_reason'], 'aso', None
                         if reasons:
-                            reasons += " [...CUT...] Full log at https://fts3.cern.ch:8449/fts3/ftsmon/#/job/%s" % doc['fts_id']
+                            # Do not add this if FTS jobID is not available
+                            if doc['fts_id']:
+                                reasons += " [...CUT...] Full log at https://fts3.cern.ch:8449/fts3/ftsmon/#/job/%s" % doc['fts_id']
                         if app:
                             msg += "\n-----> %s log start -----" % str(app).upper()
                         msg += "\n%s" % reasons

--- a/src/python/TransferInterface/MonitorTransfers.py
+++ b/src/python/TransferInterface/MonitorTransfers.py
@@ -164,10 +164,10 @@ def monitor(user, taskname, log):
                 crabInj.delete_replicas(source, to_delete)
             mark_failed([id_map[x[0]] for x in list_failed], [x[1] for x in list_failed], oracleDB)
     except ReplicaNotFound:
-            try:
-                mark_failed([id_map[x[0]] for x in list_failed], [x[1] for x in list_failed], oracleDB)
-            except Exception:
-                log.exception("Failed to update status for failed files")
+        try:
+            mark_failed([id_map[x[0]] for x in list_failed], [x[1] for x in list_failed], oracleDB)
+        except Exception:
+            log.exception("Failed to update status for failed files")
     except Exception:
         log.exception("Failed to update status for failed files")
 
@@ -184,10 +184,10 @@ def monitor(user, taskname, log):
                 crabInj.delete_replicas(source, to_delete)
             mark_failed([id_map[x[0]] for x in list_stuck], [x[1] for x in list_stuck], oracleDB)
     except ReplicaNotFound:
-            try:
-                mark_failed([id_map[x[0]] for x in list_failed], [x[1] for x in list_failed], oracleDB)
-            except Exception:
-                log.exception("Failed to update status for failed files")
+        try:
+            mark_failed([id_map[x[0]] for x in list_failed], [x[1] for x in list_failed], oracleDB)
+        except Exception:
+            log.exception("Failed to update status for failed files")
     except Exception:
         log.exception("Failed to update status for stuck rule")
 

--- a/src/python/TransferInterface/MonitorTransfers.py
+++ b/src/python/TransferInterface/MonitorTransfers.py
@@ -100,6 +100,11 @@ def monitor(user, taskname, log):
     for file_ in locks_generator:
         log.debug("LOCK %s", file_)
         filename = file_['name']
+        if filename not in id_map:
+            # This is needed because in Rucio we allow user to publish 2 different tasks
+            # within the same Rucio dataset
+            log.info("Skipping file from previous tasks: %s", filename)
+            continue
         status = file_['state']
         log.info("state %s", status)
         sitename = file_['rse']

--- a/src/python/TransferInterface/MonitorTransfers.py
+++ b/src/python/TransferInterface/MonitorTransfers.py
@@ -4,7 +4,7 @@ import json
 from rucio.common.exception import ReplicaNotFound
 from RESTInteractions import HTTPRequests
 from ServerUtilities import encodeRequest
-from TransferInterface import chunks, mark_failed, mark_transferred, CRABDataInjector
+from TransferInterface import mark_failed, mark_transferred, CRABDataInjector
 
 
 def monitor(user, taskname, log):

--- a/src/python/TransferInterface/RegisterFiles.py
+++ b/src/python/TransferInterface/RegisterFiles.py
@@ -243,9 +243,22 @@ class submit_thread(threading.Thread):
                     self.log.debug("Registered direct files: {0}".format(dest_lfns))
                     self.threadLock.release()
                     return
-                except Exception:
+                except Exception as ex:
                     self.log.exception("Failed to register direct files.")
                     self.threadLock.release()
+                    try:
+                        ids =  [x[self.job_col.index('ids')] for x in self.job]
+                        fileDoc = dict()
+                        fileDoc['asoworker'] = 'rucio'
+                        fileDoc['subresource'] = 'updateTransfers'
+                        fileDoc['list_of_ids'] = ids 
+                        fileDoc['list_of_transfer_state'] = ["FAILED" for _ in ids]
+                        fileDoc['list_of_failure_reason'] = [str(ex) for _ in ids]
+                        fileDoc['list_of_retry_value'] = [0 for _ in ids]
+
+                        self.toUpdate.append(fileDoc)
+                    except Exception as ex:
+                        self.log.exception("Failed to mark failed files")
                     return
 
             # Otherwise register files staged in temporary area
@@ -266,7 +279,6 @@ class submit_thread(threading.Thread):
                 fileDoc['list_of_failure_reason'] = [str(ex) for _ in ids]
                 fileDoc['list_of_retry_value'] = [0 for _ in ids]
 
-                self.log.info("Marking failed %s files" % (len(fileDoc['list_of_ids'])))
                 self.toUpdate.append(fileDoc)
             except Exception as ex:
                 self.log.exception("Failed to mark failed files")


### PR DESCRIPTION
- disable direct stageout:
  - with rucio managing all the transfers --> users not allowed to other replicas anywhere other than temp RSE
- manage Rucio failures --> propagating failure to transferdb
- use the definitive rucio user namespace: /store/user/rucio/<username>
