### PR TITLE
do not pass K8s restHost to submitted jobs. Solve #6188

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanSubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanSubmitter.py
@@ -396,6 +396,9 @@ class DagmanSubmitter(TaskAction.TaskAction):
         arg = "RunJobs.dag"
 
         info['resthost'] = '"%s"' % (self.server['host'])
+        if info['resthost'] == '"cmsweb-k8s-prod.cern.ch"':
+            info['resthost'] = '"cmsweb.cern.ch"'
+            self.logger.info('resthost for Jobs changed from k8s to cmsweb.cern.ch')
         info['resturinoapi'] = '"%s"' % (self.restURInoAPI)
 
         try:


### PR DESCRIPTION
I tested in standalone mode with actual datsets, but did not test failure cases.