### PR TITLE
Use rucio for lfn2pfn in TaskWorker

### DIFF
--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -300,56 +300,6 @@ def removeDummyFile(filename, logger):
     except Exception:
         logger.info('Warning: Failed to delete file %s' % filename)
 
-"""
-def getPFN(proxy, lfnsaddprefix, filename, sitename, logger):
-    from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
-
-    phedex = PhEDEx({"cert": proxy, "key": proxy, "logger": logger})
-    lfnsadd = os.path.join(lfnsaddprefix, filename)
-    try:
-        pfndict = phedex.getPFN(nodes=[sitename], lfns=[lfnsadd])
-        pfn = pfndict[(sitename, lfnsadd)]
-        if not pfn:
-            logger.info('Error: Failed to get PFN from the site. Please check the site status')
-            return False
-    except HTTPException as errormsg:
-        logger.info('Error: Failed to contact PhEDEx or wrong PhEDEx node name is used')
-        logger.info('Result: %s\nStatus :%s\nURL :%s' % (errormsg.result, errormsg.status, errormsg.url))
-        raise HTTPException(errormsg)
-    return pfn
-"""
-"""
-def getPFN(proxy, lfnsaddprefix, filename, sitename, logger):
-    from WMCore.Services.Rucio.Rucio import Rucio
-    rucio_config_dict = {
-        "phedexCompatible": True,
-        "auth_type": "x509", "ca_cert": self.config.Services.Rucio_caPath,
-        "logger": logger,
-        "creds": {"client_cert": proxy, "client_key": proxy}
-    }
-
-    logger.info("Initializing Rucio client")
-    # WMCore is awfully verbose
-    try:
-        with tempSetLogLevel(logger=logger, level=logging.ERROR):
-            self.rucioClient = Rucio(  # pylint: disable=W0201
-                self.config.Services.Rucio_account,
-                hostUrl=self.config.Services.Rucio_host,
-                authUrl=self.config.Services.Rucio_authUrl,
-                configDict=rucio_config_dict
-            )
-        self.rucioClient.whoAmI()
-    except HTTPException as errormsg:
-        logger.info('Error: Failed to contact Rucio')
-        logger.info('Result: %s\nStatus :%s\nURL :%s' % (errormsg.result, errormsg.status, errormsg.url))
-        raise HTTPException(errormsg)
-
-    lfn = os.path.join(lfnsaddprefix, filename)
-    pfn = self.rucioClient.getPFN(sitename, lfn)
-
-    return pfn
-"""
-
 def executeCommand(command):
     """ Execute passed bash command. There is no check for command success or failure. Who`s calling
         this command, has to check exitcode, out and err

--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -300,7 +300,7 @@ def removeDummyFile(filename, logger):
     except Exception:
         logger.info('Warning: Failed to delete file %s' % filename)
 
-
+"""
 def getPFN(proxy, lfnsaddprefix, filename, sitename, logger):
     from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
 
@@ -317,7 +317,38 @@ def getPFN(proxy, lfnsaddprefix, filename, sitename, logger):
         logger.info('Result: %s\nStatus :%s\nURL :%s' % (errormsg.result, errormsg.status, errormsg.url))
         raise HTTPException(errormsg)
     return pfn
+"""
+"""
+def getPFN(proxy, lfnsaddprefix, filename, sitename, logger):
+    from WMCore.Services.Rucio.Rucio import Rucio
+    rucio_config_dict = {
+        "phedexCompatible": True,
+        "auth_type": "x509", "ca_cert": self.config.Services.Rucio_caPath,
+        "logger": logger,
+        "creds": {"client_cert": proxy, "client_key": proxy}
+    }
 
+    logger.info("Initializing Rucio client")
+    # WMCore is awfully verbose
+    try:
+        with tempSetLogLevel(logger=logger, level=logging.ERROR):
+            self.rucioClient = Rucio(  # pylint: disable=W0201
+                self.config.Services.Rucio_account,
+                hostUrl=self.config.Services.Rucio_host,
+                authUrl=self.config.Services.Rucio_authUrl,
+                configDict=rucio_config_dict
+            )
+        self.rucioClient.whoAmI()
+    except HTTPException as errormsg:
+        logger.info('Error: Failed to contact Rucio')
+        logger.info('Result: %s\nStatus :%s\nURL :%s' % (errormsg.result, errormsg.status, errormsg.url))
+        raise HTTPException(errormsg)
+
+    lfn = os.path.join(lfnsaddprefix, filename)
+    pfn = self.rucioClient.getPFN(sitename, lfn)
+
+    return pfn
+"""
 
 def executeCommand(command):
     """ Execute passed bash command. There is no check for command success or failure. Who`s calling

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -27,7 +27,6 @@ from ServerUtilities import insertJobIdSid, MAX_DISK_SPACE, MAX_IDLE_JOBS, MAX_P
 from CMSGroupMapper import get_egroup_users
 
 import WMCore.WMSpec.WMTask
-import WMCore.Services.PhEDEx.PhEDEx as PhEDEx
 from WMCore.Services.CRIC.CRIC import CRIC
 
 import classad
@@ -396,7 +395,7 @@ class DagmanCreator(TaskAction.TaskAction):
             rucioClient.whoAmI()
         except HTTPException as errormsg:
             self.logger.info('Error: Failed to contact Rucio')
-            self.logger.info('Result: %s\nStatus :%s\nURL :%s' % (errormsg.result, errormsg.status, errormsg.url))
+            self.logger.info('Result: %s\nStatus :%s\nURL :%s', errormsg.result, errormsg.status, errormsg.url)
             raise HTTPException(errormsg)
 
         pfnDict = rucioClient.getPFN(dest_site, dest_dir)

--- a/src/python/TaskWorker/Actions/StageoutCheck.py
+++ b/src/python/TaskWorker/Actions/StageoutCheck.py
@@ -47,7 +47,7 @@ class StageoutCheck(TaskAction):
             rucioClient.whoAmI()
         except HTTPException as errormsg:
             self.logger.info('Error: Failed to contact Rucio')
-            self.logger.info('Result: %s\nStatus :%s\nURL :%s' % (errormsg.result, errormsg.status, errormsg.url))
+            self.logger.info('Result: %s\nStatus :%s\nURL :%s', errormsg.result, errormsg.status, errormsg.url)
             raise HTTPException(errormsg)
 
         lfn = os.path.join(lfnsaddprefix, filename)


### PR DESCRIPTION
removes all calls to PhEDEx from TaskWorker. Only the ones from task_process scripts are left