### PR TITLE
Create symlinks to new docker mount point

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM cmssw/cmsweb:20200901
+FROM cmssw/cmsweb:20201113
 MAINTAINER Daina Dirmaite daina.dirmaite@gmail.com
 
 #keep only voms-proxy basded on c++
@@ -24,8 +24,6 @@ WORKDIR ${WDIR}
 # install
 COPY --chown=${USER}:${USER} install.sh monitor.sh ./
 RUN echo "Y" > yes.repo && sh install.sh < yes.repo
-
-RUN echo '"cms" "lcg-voms2.cern.ch" "15002" "/DC=ch/DC=cern/OU=computers/CN=lcg-voms2.cern.ch" "cms" "24"' > /etc/vomses/cms-lcg-voms2.cern.ch && echo '"cms" "voms2.cern.ch" "15002" "/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch" "cms" "24"' > /etc/vomses/cms-voms2.cern.ch
 
 # run the service
 CMD sh start.sh && sh /data/monitor.sh && while true; do sleep 60;done

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -17,7 +17,6 @@ USER ${USER}
 ARG TW_VERSION
 ENV RELEASE $TW_VERSION
 ENV TW_VERSION $TW_VERSION
-ENV SERVICE provideService
 
 RUN mkdir -p /data/srv/tmp && mkdir -p /data/srv/Publisher && mkdir -p /data/srv/TaskManager
 WORKDIR ${WDIR}
@@ -26,5 +25,7 @@ WORKDIR ${WDIR}
 COPY --chown=${USER}:${USER} install.sh monitor.sh ./
 RUN echo "Y" > yes.repo && sh install.sh < yes.repo
 
+RUN echo '"cms" "lcg-voms2.cern.ch" "15002" "/DC=ch/DC=cern/OU=computers/CN=lcg-voms2.cern.ch" "cms" "24"' > /etc/vomses/cms-lcg-voms2.cern.ch && echo '"cms" "voms2.cern.ch" "15002" "/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch" "cms" "24"' > /etc/vomses/cms-voms2.cern.ch
+
 # run the service
-CMD sh /data/srv/${SERVICE}/start.sh && sh /data/monitor.sh && while true; do sleep 60;done
+CMD sh start.sh && sh /data/monitor.sh && while true; do sleep 60;done

--- a/Docker/install.sh
+++ b/Docker/install.sh
@@ -1,42 +1,35 @@
 #!/bin/bash
 
 env
-        set -x
-        echo starting
+set -x
+echo starting
 
-        touch /data/srv/condor_config
+touch /data/srv/condor_config
 
-        export RELEASE=$TW_VERSION 
+export RELEASE=$TW_VERSION 
 
-        export MYTESTAREA=/data/srv/TaskManager/$RELEASE
-        export SCRAM_ARCH=slc7_amd64_gcc630
+export MYTESTAREA=/data/srv/TaskManager/$RELEASE
+export SCRAM_ARCH=slc7_amd64_gcc630
      
-        export REPO=comp.crab3
+export REPO=comp.crab3
 
-        export verbose=true
-        echo 'Installation'
+export verbose=true
+echo 'Installation'
 
-        mkdir -p $MYTESTAREA
-        wget -O $MYTESTAREA/bootstrap.sh http://cmsrep.cern.ch/cmssw/repos/bootstrap.sh
-        sh $MYTESTAREA/bootstrap.sh -architecture $SCRAM_ARCH -path $MYTESTAREA -repository $REPO setup
+mkdir -p $MYTESTAREA
+wget -O $MYTESTAREA/bootstrap.sh http://cmsrep.cern.ch/cmssw/repos/bootstrap.sh
+sh $MYTESTAREA/bootstrap.sh -architecture $SCRAM_ARCH -path $MYTESTAREA -repository $REPO setup
 
-	cd /data/srv/TaskManager
-        $RELEASE/common/cmspkg -a $SCRAM_ARCH upgrade
-        $RELEASE/common/cmspkg -a $SCRAM_ARCH update
-        $RELEASE/common/cmspkg -a $SCRAM_ARCH install cms+crabtaskworker+$RELEASE
+cd /data/srv/TaskManager
+$RELEASE/common/cmspkg -a $SCRAM_ARCH upgrade
+$RELEASE/common/cmspkg -a $SCRAM_ARCH update
+$RELEASE/common/cmspkg -a $SCRAM_ARCH install cms+crabtaskworker+$RELEASE
 
-        cp $MYTESTAREA/$SCRAM_ARCH/cms/crabtaskworker/$RELEASE/data/script/Deployment/Publisher/{start.sh,env.sh,stop.sh} /data/srv/Publisher/
-        cp $MYTESTAREA/$SCRAM_ARCH/cms/crabtaskworker/$RELEASE/data/script/Deployment/TaskWorker/{start.sh,env.sh,stop.sh} /data/srv/TaskManager/
+cp $MYTESTAREA/$SCRAM_ARCH/cms/crabtaskworker/$RELEASE/data/script/Deployment/Publisher/{start.sh,env.sh,stop.sh} /data/srv/Publisher/
+cp $MYTESTAREA/$SCRAM_ARCH/cms/crabtaskworker/$RELEASE/data/script/Deployment/TaskWorker/{start.sh,env.sh,stop.sh} /data/srv/TaskManager/
 
-#	cd /data/srv/TaskManager
-        ln -s $RELEASE current
-	ln -s /data/srv/TaskManager/current /data/srv/Publisher/current
+ln -s $RELEASE current
+ln -s /data/srv/TaskManager/current /data/srv/Publisher/current
 
-        cd $MYTESTAREA
-        ln -s /data/srv/cfg/TaskWorkerConfig.py TaskWorkerConfig.py
-
-        cd /data/srv/Publisher
-        ln -s /data/srv/cfg/PublisherConfig.py PublisherConfig.py
-
-	set +x
+set +x
 

--- a/src/script/Deployment/Publisher/start.sh
+++ b/src/script/Deployment/Publisher/start.sh
@@ -19,6 +19,26 @@ source ${PUBLISHER_HOME}/env.sh
 
 rm -f ${PUBLISHER_HOME}/nohup.out
 
+check_link(){
+  if [ -L $1 ] ; then
+    if [ -e $1 ] ; then
+       return 0
+    else
+       unlink $1
+       return 1
+    fi
+  else
+    return 1
+  fi
+}
+
+declare -A links=( ["PublisherConfig.py"]="/data/hostdisk/${SERVICE}/cfg/PublisherConfig.py" ["logs"]="/data/hostdisk/${SERVICE}/logs" ["/data/srv/Publisher_files"]="/data/hostdisk/${SERVICE}/PublisherFiles" )
+
+for name in "${!links[@]}";
+do
+  check_link "${name}" || ln -s "${links[$name]}" "$name"
+done
+
 __strip_pythonpath(){
 # this function is used to strip the taskworker lines from $PYTHONPATH
 # in order for the debug |private calls to be able to add theirs

--- a/src/script/Deployment/Publisher/start.sh
+++ b/src/script/Deployment/Publisher/start.sh
@@ -20,6 +20,8 @@ source ${PUBLISHER_HOME}/env.sh
 rm -f ${PUBLISHER_HOME}/nohup.out
 
 check_link(){
+# function checks if symbolic links required to start service exists and if they are not broken
+
   if [ -L $1 ] ; then
     if [ -e $1 ] ; then
        return 0

--- a/src/script/Deployment/TaskWorker/start.sh
+++ b/src/script/Deployment/TaskWorker/start.sh
@@ -8,6 +8,8 @@ source /data/srv/TaskManager/env.sh
 rm -f /data/srv/TaskManager/nohup.out
 
 check_link(){
+# function checks if symbolic links required to start service exists and if they are not broken
+
   if [ -L $1 ] ; then
     if [ -e $1 ] ; then
        return 0

--- a/src/script/Deployment/TaskWorker/start.sh
+++ b/src/script/Deployment/TaskWorker/start.sh
@@ -7,6 +7,26 @@ source /data/srv/TaskManager/env.sh
 
 rm -f /data/srv/TaskManager/nohup.out
 
+check_link(){
+  if [ -L $1 ] ; then
+    if [ -e $1 ] ; then
+       return 0
+    else
+       unlink $1
+       return 1
+    fi
+  else
+    return 1
+  fi
+}
+
+declare -A links=( ["current/TaskWorkerConfig.py"]="/data/hostdisk/${SERVICE}/cfg/TaskWorkerConfig.py" ["logs"]="/data/hostdisk/${SERVICE}/logs")
+
+for name in "${!links[@]}";
+do
+  check_link "${name}" || ln -s "${links[$name]}" "$name"
+done
+
 __strip_pythonpath(){
 # this function is used to strip the taskworker lines from $PYTHONPATH
 # in order for the debug |private calls to be able to add theirs


### PR DESCRIPTION
@belforte these are the changes that will create symlinks to the new mount point `-v /data/container:/data/hostdisk/` and all needed sub-directories. In Publisher/TW `start.sh` script there is a new variable `${SERVICE}` introduced which will be used from docker run command. since we can have multiple Publisher containers running, `${SERVICE}` will specify which exactly Publisher was started (Publisher, Publisher_rucio, Publisher_asoless etc) and accordingly create links to that specific Publisher `logs, cfg, PublisherFiles `sub-directories

I also updated cmssw/cmsweb image tag to `20201113` and removed few other unnecessary things from Dockerfile.