### PR TITLE
Add crabspec to track frequently changing crab dependencies

### DIFF
--- a/crabspec
+++ b/crabspec
@@ -1,0 +1,1 @@
+wmcver 1.3.6.crab5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,6 @@
-wmcver 1.3.6.crab5
+# Dependencies needed to run crabserver, crabcache, crabtaskworker
+# This file is used by Jenkins to create RPMs and docker image
+# Format:
+# Dependency==version          
+
+wmcver==1.3.6.crab5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+wmcver 1.3.6.crab5


### PR DESCRIPTION
This file should be used to track frequently changing crab dependencies, e.g. WMCore tag. Tag version that is specified in this file will be used by Jenkins to build crabserver/crabtaskworker/crabcache RPMs. 

.spec files that are needed to build RPMs will be still taken from cmsdist GH repository, however, WMCore version will be managed by the new file.