### PR TITLE
create symlink to nohup.out (fix #6295)

### DIFF
--- a/src/script/Deployment/Publisher/start.sh
+++ b/src/script/Deployment/Publisher/start.sh
@@ -17,7 +17,7 @@ fi
 
 source ${PUBLISHER_HOME}/env.sh
 
-rm -f ${PUBLISHER_HOME}/nohup.out
+rm -f /data/hostdisk/${SERVICE}/nohup.out
 
 check_link(){
 # function checks if symbolic links required to start service exists and if they are not broken
@@ -38,7 +38,7 @@ check_link(){
 # -/data/hostdisk/${SERVICE}/cfg/PublisherConfig.py
 # -/data/hostdisk/${SERVICE}/logs
 # -/data/hostdisk/${SERVICE}/PublisherFiles
-declare -A links=( ["PublisherConfig.py"]="/data/hostdisk/${SERVICE}/cfg/PublisherConfig.py" ["logs"]="/data/hostdisk/${SERVICE}/logs" ["/data/srv/Publisher_files"]="/data/hostdisk/${SERVICE}/PublisherFiles" )
+declare -A links=( ["PublisherConfig.py"]="/data/hostdisk/${SERVICE}/cfg/PublisherConfig.py" ["logs"]="/data/hostdisk/${SERVICE}/logs" ["/data/srv/Publisher_files"]="/data/hostdisk/${SERVICE}/PublisherFiles" ["nohup.out"]="/data/hostdisk/${SERVICE}/nohup.out")
 
 for name in "${!links[@]}";
 do

--- a/src/script/Deployment/TaskWorker/start.sh
+++ b/src/script/Deployment/TaskWorker/start.sh
@@ -5,7 +5,7 @@ unset X509_USER_CERT
 unset X509_USER_KEY
 source /data/srv/TaskManager/env.sh
 
-rm -f /data/srv/TaskManager/nohup.out
+rm -f /data/hostdisk/${SERVICE}/nohup.out
 
 check_link(){
 # function checks if symbolic links required to start service exists and if they are not broken
@@ -25,7 +25,7 @@ check_link(){
 #directories/files that should be created before starting the container (SERVICE will be set to 'TaskWorker'):
 # -/data/hostdisk/${SERVICE}/cfg/TaskWorkerConfig.py
 # -/data/hostdisk/${SERVICE}/logs
-declare -A links=( ["current/TaskWorkerConfig.py"]="/data/hostdisk/${SERVICE}/cfg/TaskWorkerConfig.py" ["logs"]="/data/hostdisk/${SERVICE}/logs")
+declare -A links=( ["current/TaskWorkerConfig.py"]="/data/hostdisk/${SERVICE}/cfg/TaskWorkerConfig.py" ["logs"]="/data/hostdisk/${SERVICE}/logs" ["nohup.out"]="/data/hostdisk/${SERVICE}/nohup.out")
 
 for name in "${!links[@]}";
 do


### PR DESCRIPTION
this change will make nohup.out available outside the container. For a given SERVICE/container, it will be stored in the following directory: 
```
[crab3@crab-preprod-tw01 Publisher_schedd]$ pwd
/data/container/Publisher_schedd
[crab3@crab-preprod-tw01 Publisher_schedd]$ ll
total 32
drwxr-xr-x. 2 crab3 zh    4096 Dec 10 15:05 cfg
drwxr-xr-x. 4 crab3 zh    4096 Jan  4 00:02 logs
-rw-------. 1 crab3 1000     0 Jan  4 10:03 nohup.out
drwxr-xr-x. 3 crab3 zh   20480 Jan  4 10:01 PublisherFiles
```