### PR TITLE
abort dag_bootstrap if task already runs (fix #6151)

### DIFF
--- a/scripts/AdjustSites.py
+++ b/scripts/AdjustSites.py
@@ -372,11 +372,11 @@ def checkTaskInfo(ad):
 
     scheddName = os.environ['schedd_name']
 
-    printLog("Task status on DB: %s, clusterID on DB: %s, scheddy name on DB: %s; \nclusterID on condor ads: %s, scheddy name on condor ads: %s "
+    printLog('Task status on DB: %s, clusterID on DB: %s, schedd name on DB: %s; \nclusterID on condor ads: %s, schedd name on condor ads: %s '
         % (taskStatusOnDB, clusteridOnDB, scheddOnDB, clusterIdOnSchedd, scheddName))
 
     if not (taskStatusOnDB == 'SUBMITTED' and scheddOnDB == scheddName and clusteridOnDB == str(clusterIdOnSchedd)):
-        printLog('Exiting AdjustSites because task already runs or is not submitted.')
+        printLog('Exiting AdjustSites because this dagman does not match task information in TASKS DB')
         sys.exit(3)
 
 

--- a/scripts/AdjustSites.py
+++ b/scripts/AdjustSites.py
@@ -20,7 +20,7 @@ from datetime import datetime
 from httplib import HTTPException
 
 from RESTInteractions import HTTPRequests
-from ServerUtilities import getProxiedWebDir
+from ServerUtilities import getProxiedWebDir, getColumn
 
 
 def printLog(msg):
@@ -343,6 +343,43 @@ def setupLog():
     os.close(logfd)
 
 
+def checkTaskInfo(ad):
+    """
+    Function checks that given task is registered in the database with status SUBMITTED and with the
+    same clusterId and schedd name in the database as in the condor ads where it is currently running.
+    In case above condition is not met, script immediately terminates
+    """
+
+    task = ad['CRAB_ReqName']
+    host = ad['CRAB_RestHost']
+    uri = ad['CRAB_RestURInoAPI'] + '/task'
+    cert = ad['X509UserProxy']
+    clusterIdOnSchedd = ad['ClusterId']
+    data = {'subresource': 'search', 'workflow': task}
+
+    try:
+        server = HTTPRequests(host, cert, cert, retry=3)
+        dictresult, _, _ = server.get(uri, data=data)
+    except HTTPException as hte:
+        printLog(traceback.format_exc())
+        printLog(hte.headers)
+        printLog(hte.result)
+        sys.exit(2)
+
+    taskStatusOnDB = getColumn(dictresult, 'tm_task_status')
+    clusteridOnDB = getColumn(dictresult, 'clusterid')
+    scheddOnDB = getColumn(dictresult, 'tm_schedd')
+
+    scheddName = os.environ['schedd_name']
+
+    printLog("Task status on DB: %s, clusterID on DB: %s, scheddy name on DB: %s; \nclusterID on condor ads: %s, scheddy name on condor ads: %s "
+        % (taskStatusOnDB, clusteridOnDB, scheddOnDB, clusterIdOnSchedd, scheddName))
+
+    if not (taskStatusOnDB == 'SUBMITTED' and scheddOnDB == scheddName and clusteridOnDB == str(clusterIdOnSchedd)):
+        printLog('Exiting AdjustSites because task already runs or is not submitted.')
+        sys.exit(3)
+
+
 def main():
     """
     Need a doc string here.
@@ -359,6 +396,7 @@ def main():
         ad = classad.parseOne(fd)
     printLog("Parsed ad: %s" % ad)
 
+    checkTaskInfo(ad)
     makeWebDir(ad)
 
     printLog("Webdir has been set up. Uploading the webdir URL to the REST")

--- a/scripts/dag_bootstrap_startup.sh
+++ b/scripts/dag_bootstrap_startup.sh
@@ -155,12 +155,21 @@ fi
 
 # Recalculate the black / whitelist
 if [ -e AdjustSites.py ]; then
+    export schedd_name=`condor_config_val schedd_name`
     echo "Execute AdjustSites.py ..."
     python AdjustSites.py
     ret=$?
     if [ $ret -eq 1 ]; then
         echo "Error: AdjustSites.py failed to update the webdir." >&2
         condor_qedit $CONDOR_ID DagmanHoldReason "'AdjustSites.py failed to update the webdir.'"
+        exit 1
+    elif [ $ret -eq 2 ]; then
+        echo "Error: Cannot get data from REST Interface" >&2
+        condor_qedit $CONDOR_ID DagmanHoldReason "'Cannot get data from REST Interface.'"
+        exit 1   
+    elif [ $ret -eq 3 ]; then
+        echo "Error: task already runs or is not submitted yet." >&2
+        condor_qedit $CONDOR_ID DagmanHoldReason "'Task already runs or is not submitted yet.'"
         exit 1
     fi
 else

--- a/scripts/dag_bootstrap_startup.sh
+++ b/scripts/dag_bootstrap_startup.sh
@@ -168,8 +168,8 @@ if [ -e AdjustSites.py ]; then
         condor_qedit $CONDOR_ID DagmanHoldReason "'Cannot get data from REST Interface.'"
         exit 1   
     elif [ $ret -eq 3 ]; then
-        echo "Error: task already runs or is not submitted yet." >&2
-        condor_qedit $CONDOR_ID DagmanHoldReason "'Task already runs or is not submitted yet.'"
+        echo "Error: this dagman does not match task information in TASKS DB" >&2
+        condor_qedit $CONDOR_ID DagmanHoldReason "'This dagman does not match task information in TASKS DB'"
         exit 1
     fi
 else


### PR DESCRIPTION
using `crab-preprod-tw02` and `vocms059` I tested following cases:

1. AdjustSites.py tries to run when task is not submitted 
2. AdjustSites.py tries to run when task is submitted but clusterId on DB is different compared to what is condor ads
3. AdjustSites.py tries to run when task is submitted but schedd on DB is equal to`None`

in all above cases script terminates