### PR TITLE
use native Rucio client and port TapeRecall to Rucio

### DIFF
--- a/src/python/RucioUtils.py
+++ b/src/python/RucioUtils.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from __future__ import division
+
 from TaskWorker.WorkerExceptions import TaskWorkerException
 
 def getNativeRucioClient(config=None, logger=None):

--- a/src/python/RucioUtils.py
+++ b/src/python/RucioUtils.py
@@ -1,0 +1,60 @@
+from TaskWorker.WorkerExceptions import TaskWorkerException
+
+def getNativeRucioClient(config=None, logger=None):
+    """
+    instantiates a Rucio python Client for use in CRAB TaskWorker
+    :param config: a TaskWorker configuration object in which
+                    at least the variables used below are defined
+    :param logger: a valid logger instance
+    :return: a Rucio Client object
+    """
+    logger.info("Initializing native Rucio client")
+    from rucio.client import Client
+
+    nativeClient = Client(
+        rucio_host=config.Services.Rucio_host,
+        auth_host=config.Services.Rucio_authUrl,
+        ca_cert=config.Services.Rucio_caPath,
+        account=config.Services.Rucio_account,
+        creds={"client_cert": config.TaskWorker.cmscert, "client_key": config.TaskWorker.cmskey},
+        auth_type='x509'
+    )
+    ret = nativeClient.ping()
+    logger.info("Rucio server v.%s contacted", ret['version'])
+    ret = nativeClient.whoami()
+    logger.info("Rucio client initialized for %s in status %s", ret['account'], ret['status'])
+
+    return nativeClient
+
+def getWritePFN(rucioClient=None, siteName='', lfn='', logger=None):
+    """
+    convert a single LFN into a PFN which can be used for Writing via Rucio
+    Rucio supports the possibility that at some point in the future sites may
+    require different protocols or hosts for read or write operations
+    :param rucioClient: Rucio python client, e.g. the object returned by getNativeRucioClient above
+    :param siteName: e.g. 'T2_CH_CERN'
+    :param lfn: a CMS-style LFN
+    :param logger: a valid logger instance
+    :return: a CMS-style PFN
+    """
+
+    # add a scope to turn LFN into Rucio DID syntax
+    did = 'cms:' + lfn
+    try:
+        didDict = rucioClient.lfns2pfns(siteName, [did], operation='write')
+    except Exception as ex:
+        logger.warning('Rucio lfn2pfn resolution for Write failed with:\n%s', ex)
+        logger.warning("Will try with operation='read'")
+        try:
+            didDict = rucioClient.lfns2pfns(siteName, [did], operation='read')
+        except Exception as ex:
+            msg = 'lfn2pfn resolution with Rucio failed for site: %s  LFN: %s' % (siteName, lfn)
+            msg += ' with exception :\n%s' % str(ex)
+            raise TaskWorkerException(msg)
+
+    # lfns2pfns returns a dictionary with did as key and pfn as value:
+    #  https://rucio.readthedocs.io/en/latest/api/rse.html
+    # {u'cms:/store/user/rucio': u'gsiftp://eoscmsftp.cern.ch:2811/eos/cms/store/user/rucio'}
+    pfn = didDict[did]
+
+    return pfn

--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -19,7 +19,9 @@ class DBSDataDiscovery(DataDiscovery):
     """Performing the data discovery through CMS DBS service.
     """
 
-    def __init__(self, config, server='', resturi='', procnum=-1, rucioClient=None):
+    # disable pylint warning in next line since they refer to conflict with the main()
+    # at the bottom of this file which is only used for testing
+    def __init__(self, config, server='', resturi='', procnum=-1, rucioClient=None): # pylint: disable=redefined-outer-name
         DataDiscovery.__init__(self, config, server, resturi, procnum)
         self.rucioClient = rucioClient
 
@@ -106,14 +108,14 @@ class DBSDataDiscovery(DataDiscovery):
             containerDid = {'scope':myScope, 'name':containerName}
             self.logger.info("Create RUcio container %s", containerName)
             try:
-                response = self.rucioClient.add_container(myScope, containerName)
+                self.rucioClient.add_container(myScope, containerName)
             except DataIdentifierAlreadyExists:
                 self.logger.debug("Container name already exists in Rucio. Keep going")
             except Exception as ex:
                 msg += "Rucio exception creating container: %s" %  (str(ex))
                 raise TaskWorkerException(msg)
             try:
-                response = self.rucioClient.attach_dids(myScope, containerName, dids)
+                self.rucioClient.attach_dids(myScope, containerName, dids)
             except DuplicateContent:
                 self.logger.debug("Some dids are already in this container. Keep going")
             except Exception as ex:
@@ -207,7 +209,7 @@ class DBSDataDiscovery(DataDiscovery):
         if system == 'Dynamo':
             raise NotImplementedError
             # keep following old, unused, unreachable code around for a bit as reference, to be removed once all works
-            ddmServer = self.config.TaskWorker.DDMServer
+            ddmServer = self.config.TaskWorker.DDMServer # pylint: disable=unreachable
             ddmRequest = None
             try:
                 ddmRequest = blocksRequest(blockList, ddmServer, self.config.TaskWorker.cmscert,

--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -12,9 +12,8 @@ from WMCore.Services.DBS.DBSErrors import DBSReaderError
 from TaskWorker.WorkerExceptions import TaskWorkerException, TapeDatasetException
 from TaskWorker.Actions.DataDiscovery import DataDiscovery
 from TaskWorker.Actions.DDMRequests import blocksRequest
-from ServerUtilities import tempSetLogLevel
 
-from rucio.common.exception import (DuplicateRule, DataIdentifierAlreadyExists, DuplicateContent, RuleNotFound)
+from rucio.common.exception import (DuplicateRule, DataIdentifierAlreadyExists, DuplicateContent)
 
 class DBSDataDiscovery(DataDiscovery):
     """Performing the data discovery through CMS DBS service.

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -14,14 +14,12 @@ import tarfile
 import hashlib
 import tempfile
 from ast import literal_eval
-from httplib import HTTPException
 
 from ServerUtilities import getLock
 from ServerUtilities import TASKLIFETIME
 
 import TaskWorker.WorkerExceptions
 import TaskWorker.DataObjects.Result
-#import TaskWorker.Actions.TaskAction as TaskAction
 from TaskWorker.Actions.TaskAction import TaskAction
 from TaskWorker.WorkerExceptions import TaskWorkerException
 from ServerUtilities import insertJobIdSid, MAX_DISK_SPACE, MAX_IDLE_JOBS, MAX_POST_JOBS

--- a/src/python/TaskWorker/Actions/StageoutCheck.py
+++ b/src/python/TaskWorker/Actions/StageoutCheck.py
@@ -1,15 +1,11 @@
 import os
 import re
-from httplib import HTTPException
 
 from TaskWorker.Actions.TaskAction import TaskAction
 from TaskWorker.WorkerExceptions import TaskWorkerException
-
 from ServerUtilities import isFailurePermanent
 from ServerUtilities import getCheckWriteCommand, createDummyFile
 from ServerUtilities import removeDummyFile, executeCommand
-from ServerUtilities import tempSetLogLevel
-
 from RucioUtils import getWritePFN
 
 class StageoutCheck(TaskAction):


### PR DESCRIPTION
This PR introduces several changes:
* use native Rucio Client everywhere, not WMCore one
* use same instance of rucioClient for all actions on a Task
* introduce RucioUtils.py and move there getPFN
* use Rucio for placing tape recall requests (to be tested)
* code for tapeRecall is preliminary waiting for decision from Rucio team
   on account, RSE, scope etc. for the requests, currently using  T3_IT_Trieste
