### PR TITLE
improve TW stop.sh script output (fix #6359)

### DIFF
--- a/src/script/Deployment/TaskWorker/stop.sh
+++ b/src/script/Deployment/TaskWorker/stop.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 #  script is used to gracefully stop TW.
 #  TW is given checkTimes*timeout seconds to stop, if it is still running after
 #  this period, TW and all its slaves are killed by sending SIGKILL signal.
@@ -9,17 +8,25 @@ timeout=30 #that will give 6*30=180 seconds (3min) for the TW to finish work
 
 TaskMasterPid=$(ps exfww | grep MasterWorker | grep -v grep | head -1 | awk '{print $1}')
 kill $TaskMasterPid || exit 0
+echo "SIGTERM sent to MasterWorker pid $TaskMasterPid"
 
 for (( i=0; i<$checkTimes; ++i)); do
-  sleep $timeout
+  aliveSlaves=`pgrep -P $TaskMasterPid | tr '\n' ' '`
 
-  if ps -p $TaskMasterPid >/dev/null; then
-    echo "Process $TaskMasterPid is still running."
+  if [ -n "$aliveSlaves" ]; then
+    echo "($aliveSlaves) slave(s) are still running, sleeping for $timeout seconds. ($((i+1)) of $checkTimes try)"
+    sleep $timeout
   else
-    echo "Process $TaskMasterPid has shut down successfully"
-    exit 0
+    echo "Slaves gracefully stopped after $((i * timeout)) seconds."
+    break
   fi
 done
 
-echo "Could not stop process $TaskMasterPid gracefully. Sending SIGKILL."
-pkill -9 -f TaskWorker
+runningProcesses=`pgrep -f TaskWorker | tr '\n' ' '`
+if [ -n "$runningProcesses" ]; then
+  echo -e "After max allowed time ($((checkTimes * timeout)) seconds) following TW processes are still running: $runningProcesses \nSending SIGKILL to stop it."
+  pkill -9 -f TaskWorker
+  echo "Running TW processes: `pgrep -f TaskWorker | tr '\n' ' '`"
+else
+  echo "TaskWorker master has shutdown successfully."
+fi


### PR DESCRIPTION
two possible scenarios:
1. TW stopped gracefully:
```
[crab3@crab-preprod-tw02 TaskManager]$ ./test.sh
SIGTERM sent to MasterWorker pid 27416
(27419 27420 ) slave(s) are still running, sleeping for 30 seconds. (1 of 6 try)
(27419 27420 ) slave(s) are still running, sleeping for 30 seconds. (2 of 6 try)
(27419 27420 ) slave(s) are still running, sleeping for 30 seconds. (3 of 6 try)
(27419 27420 ) slave(s) are still running, sleeping for 30 seconds. (4 of 6 try)
(27419 27420 ) slave(s) are still running, sleeping for 30 seconds. (5 of 6 try)
TaskWorker slaves gracefully stopped after 150 seconds.
TaskWorker master has shutdown successfully.
```
2. SIGKILL has to be sent:
```
[crab3@crab-preprod-tw02 TaskManager]$ ./test.sh
SIGTERM sent to MasterWorker pid 27291
(27295 ) slave(s) are still running, sleeping for 30 seconds. (1 of 6 try)
(27295 ) slave(s) are still running, sleeping for 30 seconds. (2 of 6 try)
(27295 ) slave(s) are still running, sleeping for 30 seconds. (3 of 6 try)
(27295 ) slave(s) are still running, sleeping for 30 seconds. (4 of 6 try)
(27295 ) slave(s) are still running, sleeping for 30 seconds. (5 of 6 try)
(27295 ) slave(s) are still running, sleeping for 30 seconds. (6 of 6 try)
After max allowed time (180 seconds) following TW processes are still running: 27291 27295
Sending SIGKILL to stop it.
Running TW processes:
```