### PR TITLE
no point in keeping trying adding >10 Warnings

### DIFF
--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -1,7 +1,7 @@
 # WMCore dependecies here
 from WMCore.REST.Server import RESTEntity, restcall
 from WMCore.REST.Validation import validate_str, validate_strlist, validate_num
-from WMCore.REST.Error import InvalidParameter, ExecutionError
+from WMCore.REST.Error import InvalidParameter, ExecutionError, NotAcceptable
 
 from CRABInterface.Utils import conn_handler
 from CRABInterface.Utils import getDBinstance
@@ -236,7 +236,7 @@ class RESTTask(RESTEntity):
             self.logger.info("Warning message already present in the task database. Will not add it again.")
             return []
         if len(warnings)>10:
-            raise ExecutionError("You cannot add more than 10 warnings to a task")
+            raise NotAcceptable("You cannot add more than 10 warnings to a task")
         warnings.append(warning)
 
         self.api.modify(self.Task.SetWarnings_sql, warnings=[str(warnings)], workflow=[workflow])

--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -93,7 +93,7 @@ class RESTTask(RESTEntity):
             #TODO move the function in ServerUtils and use it when required (e.g.: mysql LONGTEXT does not need read())
             try:
                 return str(col)
-            except Exception as ex:
+            except Exception as ex:  # pylint: disable=unused-variable
                 return col.read()
         return [getval(col) for col in row]
 

--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -1,13 +1,13 @@
 # WMCore dependecies here
 from WMCore.REST.Server import RESTEntity, restcall
-from WMCore.REST.Validation import validate_str, validate_strlist, validate_num
+from WMCore.REST.Validation import validate_str, validate_strlist
 from WMCore.REST.Error import InvalidParameter, ExecutionError, NotAcceptable
 
 from CRABInterface.Utils import conn_handler
 from CRABInterface.Utils import getDBinstance
 from CRABInterface.RESTExtensions import authz_login_valid, authz_owner_match
 from CRABInterface.Regexps import RX_SUBRES_TASK, RX_TASKNAME, RX_STATUS, RX_USERNAME, RX_TEXT_FAIL,\
-    RX_RUNS, RX_OUT_DATASET, RX_URL, RX_OUT_DATASET, RX_SCHEDD_NAME, RX_RUCIORULE
+    RX_RUNS, RX_OUT_DATASET, RX_URL, RX_SCHEDD_NAME, RX_RUCIORULE
 
 # external dependecies here
 import re
@@ -93,7 +93,7 @@ class RESTTask(RESTEntity):
             #TODO move the function in ServerUtils and use it when required (e.g.: mysql LONGTEXT does not need read())
             try:
                 return str(col)
-            except:
+            except Exception as ex:
                 return col.read()
         return [getval(col) for col in row]
 


### PR DESCRIPTION
raising a NotAcceptable error instead of ExecutionError witll return HTTP code 406 instead of 500
see
https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/REST/Error.py
so that the call will not be retried, see
https://github.com/dmwm/CRABServer/blob/7fda2da6131393a17d4d723355f2f9fee5766557/src/python/RESTInteractions.py#L26-L38