### PR TITLE
improve TW/publisher start scripts (fix #6418)

### DIFF
--- a/src/script/Deployment/Publisher/start.sh
+++ b/src/script/Deployment/Publisher/start.sh
@@ -1,8 +1,56 @@
 #!/bin/bash
 
+helpFunction(){
+  echo -e "\nUsage example: ./start.sh -c | -g [-d]"
+  echo -e "\t-c start current Publisher instance"
+  echo -e "\t-g start Publisher instance from GitHub repo"
+  echo -e "\t-d start Publisher in debug mode. Option can be combined with -c or -g"
+  exit 1
+  }
+
+while getopts ":dDcCgGhH" opt
+do
+    case "$opt" in
+      h|H) helpFunction ;;
+      g|G) MODE="private" ;;
+      c|C) MODE="current" ;;
+      d|D) debug=true ;;
+      * ) echo "Unimplemented option: -$OPTARG"; helpFunction ;;
+    esac
+done
+
+if ! [ -v MODE ]; then
+  echo "Please set how you want to start Publisher (add -c or -g option)." && helpFunction
+fi
+
 unset X509_USER_PROXY
 unset X509_USER_CERT
 unset X509_USER_KEY
+
+rm -f nohup.out
+
+# if GH repositories location is not already defined, set a default
+if ! [ -v GHrepoDir ]
+then
+  GHrepoDir='/data/hostdisk/repos'
+fi
+
+__strip_pythonpath(){
+  # this function is used to strip the taskworker lines from $PYTHONPATH
+  # in order for the debug |private calls to be able to add theirs
+
+  local strip_reg=".*crabtaskworker.*"
+  local ppath_init=${PYTHONPATH//:/: }
+  local ppath_stripped=""
+
+  for i in $ppath_init
+  do
+      [[ $i =~ $strip_reg ]] || ppath_stripped="${ppath_stripped}${i}"
+  done
+  # echo -e "before strip: \n$ppath_init" |sed -e 's/\:/\:\n/g'
+  # echo -e "after strip: \n$ppath_stripped" |sed -e 's/\:/\:\n/g'
+  export PYTHONPATH=$ppath_stripped
+}
 
 # if PUBLISHER_HOME is already defined, use it
 if [ -v PUBLISHER_HOME ]
@@ -16,85 +64,25 @@ else
 fi
 
 source ${PUBLISHER_HOME}/env.sh
+ln -s /data/hostdisk/${SERVICE}/nohup.out nohup.out
 
-rm -f /data/hostdisk/${SERVICE}/nohup.out
-
-check_link(){
-# function checks if symbolic links required to start service exists and if they are not broken
-
-  if [ -L $1 ] ; then
-    if [ -e $1 ] ; then
-       return 0
-    else
-       unlink $1
-       return 1
-    fi
-  else
-    return 1
-  fi
-}
-
-#directories/files that should be created before starting the container, (SERVICE is type of Publisher started, e.g.Publisher_rucio):
-# -/data/hostdisk/${SERVICE}/cfg/PublisherConfig.py
-# -/data/hostdisk/${SERVICE}/logs
-# -/data/hostdisk/${SERVICE}/PublisherFiles
-declare -A links=( ["PublisherConfig.py"]="/data/hostdisk/${SERVICE}/cfg/PublisherConfig.py" ["logs"]="/data/hostdisk/${SERVICE}/logs" ["/data/srv/Publisher_files"]="/data/hostdisk/${SERVICE}/PublisherFiles" ["nohup.out"]="/data/hostdisk/${SERVICE}/nohup.out")
-
-for name in "${!links[@]}";
-do
-  check_link "${name}" || ln -s "${links[$name]}" "$name"
-done
-
-# if GH repositories location is not already defined, set a default
-if ! [ -v GHrepoDir ]
-then
-  GHrepoDir='/data/hostdisk/repos'
-fi
-
-__strip_pythonpath(){
-# this function is used to strip the taskworker lines from $PYTHONPATH
-# in order for the debug |private calls to be able to add theirs
-
-local strip_reg=".*crabtaskworker.*"
-local ppath_init=${PYTHONPATH//:/: }
-local ppath_stripped=""
-
-for i in $ppath_init
-do
-    [[ $i =~ $strip_reg ]] || ppath_stripped="${ppath_stripped}${i}"
-done
-# echo -e "before strip: \n$ppath_init" |sed -e 's/\:/\:\n/g'
-# echo -e "after strip: \n$ppath_stripped" |sed -e 's/\:/\:\n/g'
-export PYTHONPATH=$ppath_stripped
-}
-
-case $1 in
-  debug)
-    # use private instance from ${GHrepoDir} in pdb mode via SequentialWorker
-    __strip_pythonpath
-    export PYTHONPATH=${GHrepoDir}/CRABServer/src/python:${GHrepoDir}/WMCore/src/python:$PYTHONPATH
-    python -m pdb ${GHrepoDir}/CRABServer/src/python/Publisher/SequentialPublisher.py --config $PUBLISHER_HOME/PublisherConfig.py --debug
-	;;
+case $MODE in
   private)
-    # run private instance from ${GHrepoDir}
+    # private mode: run private instance from ${GHrepoDir}
     __strip_pythonpath
     export PYTHONPATH=${GHrepoDir}/CRABServer/src/python:${GHrepoDir}/WMCore/src/python:$PYTHONPATH
-    nohup python ${GHrepoDir}/CRABServer/src/python/Publisher/PublisherMaster.py --config $PUBLISHER_HOME/PublisherConfig.py &
-	;;
-  test)
-    # use current instance in pdb mode  via SequentialWorker
-    python $PUBLISHER_ROOT/lib/python2.7/site-packages/Publisher/SequentialPublisher.py --config $PUBLISHER_HOME/PublisherConfig.py --debug
+    if [ "$debug" = true ]; then
+      python -m pdb ${GHrepoDir}/CRABServer/src/python/Publisher/SequentialPublisher.py --config $PUBLISHER_HOME/PublisherConfig.py --debug
+    else
+      nohup python ${GHrepoDir}/CRABServer/src/python/Publisher/PublisherMaster.py --config $PUBLISHER_HOME/PublisherConfig.py &
+    fi
   ;;
-  help)
-    echo "There are 4 ways to run start.sh:"
-    echo "  start.sh             without any argument starts current instance"
-    echo "  start.sh private     starts the instance from ${GHrepoDir}/CRABServer"
-    echo "  start.sh debug       runs private instance in debub mode. For hacking"
-    echo "  start.sh test        runs current instance in debug mode. For finding out"
-    echo "BEWARE: a misspelled argument is interpreted like no argument"
-  ;;
-  *)
-  # DEFAULT mode: run current instance
-	nohup python $PUBLISHER_ROOT/lib/python2.7/site-packages/Publisher/PublisherMaster.py --config $PUBLISHER_HOME/PublisherConfig.py &
-	;;
+  current)
+  # current mode: run current instance
+    if [ "$debug" = true ]; then
+      python $PUBLISHER_ROOT/lib/python2.7/site-packages/Publisher/SequentialPublisher.py --config $PUBLISHER_HOME/PublisherConfig.py --debug
+    else
+      nohup python $PUBLISHER_ROOT/lib/python2.7/site-packages/Publisher/PublisherMaster.py --config $PUBLISHER_HOME/PublisherConfig.py &
+    fi
 esac
+

--- a/src/script/Deployment/TaskWorker/start.sh
+++ b/src/script/Deployment/TaskWorker/start.sh
@@ -1,36 +1,34 @@
 #!/bin/bash
 
+helpFunction(){
+  echo -e "\nUsage example: ./start.sh -c | -g [-d]"
+  echo -e "\t-c start current TW instance"
+  echo -e "\t-g start TW instance from GitHub repo"
+  echo -e "\t-d start TW in debug mode. Option can be combined with -c or -g"
+  exit 1
+  }
+
+while getopts ":dDcCgGhH" opt
+do
+    case "$opt" in
+      h|H) helpFunction ;;
+      g|G) MODE="private" ;;
+      c|C) MODE="current" ;;
+      d|D) debug=true ;;
+      * ) echo "Unimplemented option: -$OPTARG"; helpFunction ;;
+    esac
+done
+
+if ! [ -v MODE ]; then
+  echo "Please set how you want to start TW (add -c or -g option)." && helpFunction
+fi
+
 unset X509_USER_PROXY
 unset X509_USER_CERT
 unset X509_USER_KEY
 source /data/srv/TaskManager/env.sh
 
-rm -f /data/hostdisk/${SERVICE}/nohup.out
-
-check_link(){
-# function checks if symbolic links required to start service exists and if they are not broken
-
-  if [ -L $1 ] ; then
-    if [ -e $1 ] ; then
-       return 0
-    else
-       unlink $1
-       return 1
-    fi
-  else
-    return 1
-  fi
-}
-
-#directories/files that should be created before starting the container (SERVICE will be set to 'TaskWorker'):
-# -/data/hostdisk/${SERVICE}/cfg/TaskWorkerConfig.py
-# -/data/hostdisk/${SERVICE}/logs
-declare -A links=( ["current/TaskWorkerConfig.py"]="/data/hostdisk/${SERVICE}/cfg/TaskWorkerConfig.py" ["logs"]="/data/hostdisk/${SERVICE}/logs" ["nohup.out"]="/data/hostdisk/${SERVICE}/nohup.out")
-
-for name in "${!links[@]}";
-do
-  check_link "${name}" || ln -s "${links[$name]}" "$name"
-done
+rm -f nohup.out
 
 # if GH repositories location is not already defined, set a default
 if ! [ -v GHrepoDir ]
@@ -39,49 +37,41 @@ then
 fi
 
 __strip_pythonpath(){
-# this function is used to strip the taskworker lines from $PYTHONPATH
-# in order for the debug |private calls to be able to add theirs
+  # this function is used to strip the taskworker lines from $PYTHONPATH
+  # in order for the debug | private calls to be able to add theirs
 
-local strip_reg=".*crabtaskworker.*"
-local ppath_init=${PYTHONPATH//:/: }
-local ppath_stripped=""
+  local strip_reg=".*crabtaskworker.*"
+  local ppath_init=${PYTHONPATH//:/: }
+  local ppath_stripped=""
 
-for i in $ppath_init
-do
-    [[ $i =~ $strip_reg ]] || ppath_stripped="${ppath_stripped}${i}"
-done
-# echo -e "before strip: \n$ppath_init" |sed -e 's/\:/\:\n/g'
-# echo -e "after strip: \n$ppath_stripped" |sed -e 's/\:/\:\n/g'
-export PYTHONPATH=$ppath_stripped
+  for i in $ppath_init
+  do
+      [[ $i =~ $strip_reg ]] || ppath_stripped="${ppath_stripped}${i}"
+  done
+  # echo -e "before strip: \n$ppath_init" |sed -e 's/\:/\:\n/g'
+  # echo -e "after strip: \n$ppath_stripped" |sed -e 's/\:/\:\n/g'
+  export PYTHONPATH=$ppath_stripped
 }
 
-case $1 in
-  debug)
-    # use private instance from ${GHrepoDir} in pdb mode via SequentialWorker
-    __strip_pythonpath
-    export PYTHONPATH=${GHrepoDir}/CRABServer/src/python:${GHrepoDir}/WMCore/src/python:$PYTHONPATH
-    python -m pdb ${GHrepoDir}/CRABServer/src/python/TaskWorker/SequentialWorker.py $MYTESTAREA/TaskWorkerConfig.py --logDebug
-	;;
+ln -s /data/hostdisk/${SERVICE}/nohup.out nohup.out
+
+case $MODE in
   private)
-    # run private instance from ${GHrepoDir}
+    # private mode: run private instance from ${GHrepoDir}
     __strip_pythonpath
     export PYTHONPATH=${GHrepoDir}/CRABServer/src/python:${GHrepoDir}/WMCore/src/python:$PYTHONPATH
-    nohup python ${GHrepoDir}/CRABServer/src/python/TaskWorker/MasterWorker.py --config $MYTESTAREA/TaskWorkerConfig.py --logDebug &
-	;;
-  test)
-    # use current instance in pdb mode  via SequentialWorker
+    if [ "$debug" = true ]; then
+      python -m pdb ${GHrepoDir}/CRABServer/src/python/TaskWorker/SequentialWorker.py $MYTESTAREA/TaskWorkerConfig.py --logDebug
+    else
+      nohup python ${GHrepoDir}/CRABServer/src/python/TaskWorker/MasterWorker.py --config $MYTESTAREA/TaskWorkerConfig.py --logDebug &
+    fi
+  ;;
+  current)
+  # current mode: run current instance
+  if [ "$debug" = true ]; then
     python $MYTESTAREA/${scram_arch}/cms/crabtaskworker/*/lib/python2.7/site-packages/TaskWorker/SequentialWorker.py  $MYTESTAREA/TaskWorkerConfig.py --logDebug
-  ;;
-  help)
-    echo "There are 4 ways to run start.sh:"
-    echo "  start.sh             without any argument starts current instance"
-    echo "  start.sh private     starts the instance from ${GHrepoDir}/CRABServer"
-    echo "  start.sh debug       runs private instance in debub mode. For hacking"
-    echo "  start.sh test        runs current instance in debug mode. For finding out"
-    echo "BEWARE: a misspelled argument is interpreted like no argument"
-  ;;
-  *)
-  # DEFAULT mode: run current instance
-	nohup python $MYTESTAREA/${scram_arch}/cms/crabtaskworker/*/lib/python2.7/site-packages/TaskWorker/MasterWorker.py --config $MYTESTAREA/TaskWorkerConfig.py --logDebug &
-	;;
+  else
+    nohup python $MYTESTAREA/${scram_arch}/cms/crabtaskworker/*/lib/python2.7/site-packages/TaskWorker/MasterWorker.py --config $MYTESTAREA/TaskWorkerConfig.py --logDebug &
+  fi
 esac
+


### PR DESCRIPTION
**General usage:**
```
[crab3@crab-dev-tw01 Publisher]$ ./start.sh
Please set how you want to start Publisher (add -c or -g option).

Usage example: ./start.sh -c | -g [-d]
	-c start current Publisher instance
	-g start Publisher instance from GitHub repo
	-d start Publisher in debug mode. Option can be combined with -c or -g
```
**Start current (works with uppercase/lowercase `c`)**
```
[crab3@crab-dev-tw01 Publisher]$ ./start.sh -c
Define environment for Publisher in /data/srv/Publisher
PUBLISHER_HOME already set to /data/srv/Publisher. Will use that
[crab3@crab-dev-tw01 Publisher]$ nohup: appending output to ‘nohup.out’
```

**Start current in debug mode**
```
[crab3@crab-dev-tw01 Publisher]$ ./start.sh -c -d
Define environment for Publisher in /data/srv/Publisher
PUBLISHER_HOME already set to /data/srv/Publisher. Will use that
> /data/srv/TaskManager/v3.210218.py3/slc7_amd64_gcc630/cms/crabtaskworker/v3.210218.py3/lib/python2.7/site-packages/Publisher/SequentialPublisher.py(39)<module>()
-> master = Master(configurationFile, quiet, debug, testMode)
(Pdb)
```