### PR TITLE
update install.sh script fix dmwm#6430

### DIFF
--- a/Docker/install.sh
+++ b/Docker/install.sh
@@ -24,7 +24,7 @@ sh $MYTESTAREA/bootstrap.sh -architecture $SCRAM_ARCH -path $MYTESTAREA -reposit
 cd /data/srv/TaskManager
 $RELEASE/common/cmspkg -a $SCRAM_ARCH upgrade
 $RELEASE/common/cmspkg -a $SCRAM_ARCH update
-$RELEASE/common/cmspkg -a $SCRAM_ARCH install cms+crabtaskworker+$RELEASE || echo "Incorrect tag was given as an input. Please double check if $TW_VERSION RPMs are available in $REPO." && exit 1
+$RELEASE/common/cmspkg -a $SCRAM_ARCH install cms+crabtaskworker+$RELEASE || echo "Installation failed. Please check log lines above for details" && exit 1
 
 cp $MYTESTAREA/$SCRAM_ARCH/cms/crabtaskworker/$RELEASE/data/script/Deployment/Publisher/{start.sh,env.sh,stop.sh,} /data/srv/Publisher/
 cp $MYTESTAREA/$SCRAM_ARCH/cms/crabtaskworker/$RELEASE/data/script/Deployment/TaskWorker/{start.sh,env.sh,stop.sh,updateTMRuntime.sh} /data/srv/TaskManager/

--- a/Docker/install.sh
+++ b/Docker/install.sh
@@ -23,7 +23,7 @@ sh $MYTESTAREA/bootstrap.sh -architecture $SCRAM_ARCH -path $MYTESTAREA -reposit
 cd /data/srv/TaskManager
 $RELEASE/common/cmspkg -a $SCRAM_ARCH upgrade
 $RELEASE/common/cmspkg -a $SCRAM_ARCH update
-$RELEASE/common/cmspkg -a $SCRAM_ARCH install cms+crabtaskworker+$RELEASE
+$RELEASE/common/cmspkg -a $SCRAM_ARCH install cms+crabtaskworker+$RELEASE || echo "Incorrect tag was given as an input. Please double check if $TW_VERSION RPMs are available in $REPO." && exit 1
 
 cp $MYTESTAREA/$SCRAM_ARCH/cms/crabtaskworker/$RELEASE/data/script/Deployment/Publisher/{start.sh,env.sh,stop.sh,} /data/srv/Publisher/
 cp $MYTESTAREA/$SCRAM_ARCH/cms/crabtaskworker/$RELEASE/data/script/Deployment/TaskWorker/{start.sh,env.sh,stop.sh,updateTMRuntime.sh} /data/srv/TaskManager/


### PR DESCRIPTION
this change will catch error and exit when incorrect tag (i.e. non existing tag in given comp repo) is given as an input to docker build command, e.g.:
trying to use `TW_VERSION=3.3.2004.TEST`
```
....installation log....
+ 3.3.2004.TEST/common/cmspkg -a slc7_amd64_gcc630 install cms+crabtaskworker+3.3.2004.TEST
Reading Package Lists...
error: unknown package: cms+crabtaskworker+3.3.2004.TEST
+ echo 'Incorrect tag was given as an input. Please double check if 3.3.2004.TEST RPMs are available in comp.crab3.'
+ exit 1
Incorrect tag was given as input. Please double check if 3.3.2004.TEST RPMs are available in comp.crab3.
The command '/bin/sh -c echo "Y" > yes.repo && sh install.sh < yes.repo' returned a non-zero code: 1
[ddirmait@ddivm2 Docker]$
```
