### PR TITLE
Completes the planned CRABCache functionalities

### DIFF
--- a/scripts/Utils/TestRest.ipynb
+++ b/scripts/Utils/TestRest.ipynb
@@ -1,0 +1,260 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 122,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/afs/cern.ch/work/b/belforte/CRAB3/CRABServer/scripts/Utils'"
+      ]
+     },
+     "execution_count": 122,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from __future__ import division\n",
+    "from __future__ import print_function\n",
+    "import json\n",
+    "import os\n",
+    "import time\n",
+    "import subprocess\n",
+    "import argparse\n",
+    "import logging\n",
+    "import sys\n",
+    "import urllib\n",
+    "\n",
+    "from RESTInteractions import HTTPRequests\n",
+    "from httplib import HTTPException\n",
+    "from ServerUtilities import encodeRequest\n",
+    "\n",
+    "os.getcwd()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Proxy: /tmp/x509up_u8516\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
+    "logger = logging.getLogger('Logger')\n",
+    "\n",
+    "proxy = os.environ['X509_USER_PROXY']\n",
+    "print(\"Proxy: %s\" % proxy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'retry': 0, 'content_type': 'application/x-www-form-urlencoded', 'cert': '/tmp/x509up_u8516', 'host': 'cmsweb-testbed.cern.ch:8443', 'version': 'development', 'accept_type': 'text/html', 'key': '/tmp/x509up_u8516', 'userAgent': 'CRABtestSB', 'conn': <WMCore.Services.pycurl_manager.RequestHandler object at 0x7f379f1e4c50>, 'verbose': False}\n"
+     ]
+    }
+   ],
+   "source": [
+    "hostname = 'cmsweb-testbed'\n",
+    "instance = 'preprod'\n",
+    "host = hostname + '.cern.ch:8443'\n",
+    "uriNoApi = '/crabserver/' + instance + '/'\n",
+    "server = HTTPRequests(host, proxy, proxy, userAgent='CRABtestSB')\n",
+    "print(server)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "uri: /crabserver/preprod//info\n",
+      "({u'result': [{u'crabserver': u'Welcome', u'version': u'development'}], u'desc': {u'columns': [u'null']}}, 200, 'OK')\n"
+     ]
+    }
+   ],
+   "source": [
+    "api = '/info'\n",
+    "uri = uriNoApi + api\n",
+    "print(\"uri: %s\"% uri)\n",
+    "res = server.get(uri)\n",
+    "print(res)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 103,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "({u'result': []}, 200, 'OK')\n"
+     ]
+    }
+   ],
+   "source": [
+    "# test upload WebDir\n",
+    "api = 'task'\n",
+    "uri = uriNoApi + api\n",
+    "subresource = 'addwebdir'\n",
+    "data = {'subresource': subresource}\n",
+    "data['workflow'] = '210318_133054:belforte_crab_20210318_143048'\n",
+    "data['webdirurl'] = 'http://vocms059.cern.ch/mon/cms1627/210318_133054:belforte_crab_20210318_143048'\n",
+    "res = server.post(uri, data=urllib.urlencode(data))\n",
+    "print(res)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 104,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# input file metadata from PostJob log\n",
+    "ifm=[('outlfn', u'/store/mc/HC/GenericTTbar/AODSIM/CMSSW_9_2_6_91X_mcRun1_realistic_v2-v2/00000/8ADD04E5-1776-E711-A1BA-FA163E6741E0.root_1'), ('outdatasetname', '/FakeDataset/fakefile-FakePublish-5b6a581e4ddd41b130711a045d5fecb9/USER'), ('globalTag', 'None'), ('outsize', '0'), ('checksumcksum', '0'), ('checksumadler32', '0'), ('jobid', '1'), ('outtmplfn', '/store/temp/user/belforte.be1f4dc5be8664cbd145bf008f5399adf42b086f/GenericTTbar/Stefano-Test-210317/210318_171955/0000'), ('appver', 'CMSSW_10_6_12'), ('outtype', 'POOLIN'), ('checksummd5', '0'), ('publishdataname', 'Stefano-Test-210317-00000000000000000000000000000000'), ('events', 300), ('taskname', '210318_171955:belforte_crab_20210318_181949'), ('acquisitionera', 'null'), ('outtmplocation', u'T2_IT_Bari'), ('outlocation', 'T2_CH_CERN'), ('directstageout', 0), ('outfileruns', '1'), ('outfilelumis', '1920')]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 112,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# corresponding urlencoded data form PostJob log\n",
+    "PJdata='outlfn=%2Fstore%2Fmc%2FHC%2FGenericTTbar%2FAODSIM%2FCMSSW_9_2_6_91X_mcRun1_realistic_v2-v2%2F00000%2F8ADD04E5-1776-E711-A1BA-FA163E6741E0.rootS_1&outdatasetname=%2FFakeDataset%2Ffakefile-FakePublish-5b6a581e4ddd41b130711a045d5fecb9%2FUSER&globalTag=None&outsize=0&checksumcksum=0&checksumadler32=0&jobid=1&outtmplfn=%2Fstore%2Ftemp%2Fuser%2Fbelforte.be1f4dc5be8664cbd145bf008f5399adf42b086f%2FGenericTTbar%2FStefano-Test-210317%2F210318_171955%2F0000&appver=CMSSW_10_6_12&outtype=POOLIN&checksummd5=0&publishdataname=Stefano-Test-210317-00000000000000000000000000000000&events=300&taskname=210318_171955%3Abelforte_crab_20210318_181949&acquisitionera=null&outtmplocation=T2_IT_Bari&outlocation=T2_CH_CERN&directstageout=0&outfileruns=1&outfilelumis=1920'\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 113,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "outlfn=/store/mc/HC/GenericTTbar/AODSIM/CMSSW_9_2_6_91X_mcRun1_realistic_v2-v2/00000/8ADD04E5-1776-E711-A1BA-FA163E6741E0.rootS_1&outdatasetname=/FakeDataset/fakefile-FakePublish-5b6a581e4ddd41b130711a045d5fecb9/USER&globalTag=None&outsize=0&checksumcksum=0&checksumadler32=0&jobid=1&outtmplfn=/store/temp/user/belforte.be1f4dc5be8664cbd145bf008f5399adf42b086f/GenericTTbar/Stefano-Test-210317/210318_171955/0000&appver=CMSSW_10_6_12&outtype=POOLIN&checksummd5=0&publishdataname=Stefano-Test-210317-00000000000000000000000000000000&events=300&taskname=210318_171955:belforte_crab_20210318_181949&acquisitionera=null&outtmplocation=T2_IT_Bari&outlocation=T2_CH_CERN&directstageout=0&outfileruns=1&outfilelumis=1920\n"
+     ]
+    }
+   ],
+   "source": [
+    "# unquoted data\n",
+    "uPJdata=urllib.unquote_plus(PJdata)\n",
+    "print(uPJdata)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 114,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'acquisitionera': ['null'],\n",
+      " 'appver': ['CMSSW_10_6_12'],\n",
+      " 'checksumadler32': ['0'],\n",
+      " 'checksumcksum': ['0'],\n",
+      " 'checksummd5': ['0'],\n",
+      " 'directstageout': ['0'],\n",
+      " 'events': ['300'],\n",
+      " 'globalTag': ['None'],\n",
+      " 'jobid': ['1'],\n",
+      " 'outdatasetname': ['/FakeDataset/fakefile-FakePublish-5b6a581e4ddd41b130711a045d5fecb9/USER'],\n",
+      " 'outfilelumis': ['1920'],\n",
+      " 'outfileruns': ['1'],\n",
+      " 'outlfn': ['/store/mc/HC/GenericTTbar/AODSIM/CMSSW_9_2_6_91X_mcRun1_realistic_v2-v2/00000/8ADD04E5-1776-E711-A1BA-FA163E6741E0.rootS_1'],\n",
+      " 'outlocation': ['T2_CH_CERN'],\n",
+      " 'outsize': ['0'],\n",
+      " 'outtmplfn': ['/store/temp/user/belforte.be1f4dc5be8664cbd145bf008f5399adf42b086f/GenericTTbar/Stefano-Test-210317/210318_171955/0000'],\n",
+      " 'outtmplocation': ['T2_IT_Bari'],\n",
+      " 'outtype': ['POOLIN'],\n",
+      " 'publishdataname': ['Stefano-Test-210317-00000000000000000000000000000000'],\n",
+      " 'taskname': ['210318_171955:belforte_crab_20210318_181949']}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# decoded (parsed) data\n",
+    "import urlparse\n",
+    "import pprint\n",
+    "pPJdata=urlparse.parse_qs(PJdata)\n",
+    "pprint.pprint(pPJdata)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 117,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "({u'result': [], u'desc': {u'columns': [u'fmd_lfn']}}, 200, 'OK')\n"
+     ]
+    }
+   ],
+   "source": [
+    "#test upload file metadata\n",
+    "# note that it this file is alredy in DB it will simply update it, changing the SQL query automatically\n",
+    "# to make sure to test an INSERT must use a new filename every time.\n",
+    "api = 'filemetadata'\n",
+    "uri = uriNoApi + api\n",
+    "res = server.put(uri, PJdata)\n",
+    "print(res)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.14+"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/python/CRABInterface/RESTCache.py
+++ b/src/python/CRABInterface/RESTCache.py
@@ -170,7 +170,7 @@ class RESTCache(RESTEntity):
             return fileNames
 
         if subresource == 'used':
-            # return spare used by username, in MBytes (rounded to integer)
+            # return space used by username, in MBytes (rounded to integer)
             if not username:
                 raise MissingParameter('username is missing')
             paginator = self.s3_client.get_paginator('list_objects_v2')
@@ -184,5 +184,6 @@ class RESTCache(RESTEntity):
             for page in page_iterator:
                 for item in page['Contents']:
                     usedBytes += item['Size']
-            usedMBytes = usedBytes / 1024 / 1024
-            return usedMBytes
+            usedMBytes = usedBytes // 1024 // 1024
+            # WMCore REST wants to return lists
+            return [usedMBytes]

--- a/src/python/CRABInterface/RESTCache.py
+++ b/src/python/CRABInterface/RESTCache.py
@@ -68,7 +68,7 @@ class RESTCache(RESTEntity):
             validate_str('object', param, safe, RX_CACHE_OBJECT, optional=False)
             validate_str('taskname', param, safe, RX_TASKNAME, optional=True)
             validate_str('username', param, safe, RX_USERNAME, optional=True)
-            validate_str('cachename',param, safe, RX_CACHENAME, optional=True)
+            validate_str('cachename', param, safe, RX_CACHENAME, optional=True)
 
     @restcall
     def get(self, subresource, object, taskname, username, cachename):  # pylint: disable=redefined-builtin

--- a/src/python/CRABInterface/RESTCache.py
+++ b/src/python/CRABInterface/RESTCache.py
@@ -58,6 +58,7 @@ class RESTCache(RESTEntity):
         endpoint = 'https://s3.cern.ch'
         self.s3_client = boto3.client('s3', endpoint_url=endpoint, aws_access_key_id=access_key,
                                       aws_secret_access_key=secret_key, verify=False)
+        # TODO need a way to identify if I am instance prod/preprod/dev and set proper bucket
         self.s3_bucket = 'bucket1'
 
     def validate(self, apiobj, method, api, param, safe):
@@ -65,7 +66,7 @@ class RESTCache(RESTEntity):
         authz_login_valid()
         if method in ['GET']:
             validate_str('subresource', param, safe, RX_SUBRES_CACHE, optional=False)
-            validate_str('object', param, safe, RX_CACHE_OBJECT, optional=False)
+            validate_str('object', param, safe, RX_CACHE_OBJECT, optional=True)
             validate_str('taskname', param, safe, RX_TASKNAME, optional=True)
             validate_str('username', param, safe, RX_USERNAME, optional=True)
             validate_str('cachename', param, safe, RX_CACHENAME, optional=True)

--- a/src/python/CRABInterface/RESTCache.py
+++ b/src/python/CRABInterface/RESTCache.py
@@ -65,13 +65,13 @@ class RESTCache(RESTEntity):
         authz_login_valid()
         if method in ['GET']:
             validate_str('subresource', param, safe, RX_SUBRES_CACHE, optional=False)
-            validate_str('object', param, safe, RX_CACHE_OBJECT, optional=True)
+            validate_str('object', param, safe, RX_CACHE_OBJECT, optional=False)
             validate_str('taskname', param, safe, RX_TASKNAME, optional=True)
             validate_str('username', param, safe, RX_USERNAME, optional=True)
             validate_str('cachename',param, safe, RX_CACHENAME, optional=True)
 
     @restcall
-    def get(self, subresource, object, taskname, username):  # pylint: disable=redefined-builtin
+    def get(self, subresource, object, taskname, username, cachename):  # pylint: disable=redefined-builtin
         """
            :arg str subresource: the specific information to be accessed;
         """

--- a/src/python/CRABInterface/RESTCache.py
+++ b/src/python/CRABInterface/RESTCache.py
@@ -30,13 +30,13 @@ class RESTCache(RESTEntity):
     GET: /crabserver/prod/cache?subresource=retrieve&object=clientlog&taskname=<task>
 
     These retun information about usage
-    GET: /crabserver/prod/cache?subresource=list&username=<username>
+    GET: /crabserver/prod/cache?subresource=list&username=<username>&object=<object>
     GET: /crabserver/prod/cache?subresource=used&username=<username>
 
     AUTHORIZATION
-    users will only be able to get an upload PS URL for their tasks
-    retieve of sandbox will be restricted to owners
-    retrieve of logs and debut files will be free
+    users will only be able to get an upload PreSigned URL for their tasks
+    retrieve of sandbox will be restricted to owners
+    retrieve of logs and debug files will be free
     CRAB operators will have full access
     """
 
@@ -45,12 +45,12 @@ class RESTCache(RESTEntity):
         self.logger = logging.getLogger("CRABLogger:RESTCache")
 
         # TODO: read these from secret file
-        access_key="5d4270f1e022442783646c34cf552d55"
-        secret_key="310e1af0fe7a43f1a2477fb77e3a5101"
+        access_key = "5d4270f1e022442783646c34cf552d55"
+        secret_key = "310e1af0fe7a43f1a2477fb77e3a5101"
         # TODO take this from rest config json file ? worry about transition from old to new !
         endpoint = 'https://s3.cern.ch'
         self.s3_client = boto3.client('s3', endpoint_url=endpoint, aws_access_key_id=access_key,
-                                 aws_secret_access_key=secret_key, verify=False)
+                                      aws_secret_access_key=secret_key, verify=False)
         self.s3_bucket = 'bucket1'
 
     def validate(self, apiobj, method, api, param, safe):
@@ -64,11 +64,13 @@ class RESTCache(RESTEntity):
 
     @restcall
     def get(self, subresource, object, taskname, username):  # pylint: disable=redefined-builtin
-        """Retrieves the server information, like delegateDN, filecacheurls ...
-           :arg str subresource: the specific server information to be accessed;
+        """
+           :arg str subresource: the specific information to be accessed;
         """
 
         if subresource == 'upload':
+            # returns a dictionary with the information to upload a file with a POST
+            # via a "PreSigned URL"
             if not object:
                 raise MissingParameter("object to upload is missing")
             if not taskname:
@@ -76,7 +78,7 @@ class RESTCache(RESTEntity):
             ownerName = getUsernameFromTaskname(taskname)
             # TODO add code here to check that username has authorization
             objectPath = ownerName + '/' + taskname + '/' + object
-            expiration = 3600
+            expiration = 3600  # 1 hour is good for testing
             try:
                 response = self.s3_client.generate_presigned_post(
                     self.s3_bucket, objectPath, ExpiresIn=expiration)
@@ -93,6 +95,7 @@ class RESTCache(RESTEntity):
             return [preSignedUrl['url'], preSignedUrl['fields']]
 
         if subresource == 'retrieve':
+            # downloads a file from S3 to /tmp and serves it to the client
             if not object:
                 raise MissingParameter("object to upload is missing")
             if not taskname:
@@ -121,14 +124,45 @@ class RESTCache(RESTEntity):
             return txt
 
         if subresource == 'list':
+            # list all files (aka objects, aka keys in S3 lingo) for a given usermame
+            # if arg object is present, returns only the file names for that object
             if not username:
                 raise MissingParameter('username is missing')
-            response = self.s3_client.list_objects(Bucket=self.s3_bucket)
-            fullList = [object['Key'] for object in response['Contents']]
-            return fullList
+            # In S3 we always need to retrieve all keys even if some filtering/compression
+            # will be applied before reporting, since there is a limit of 1K key per call,
+            # multiple calls will be needed, S3 paginators make that easy
+            # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/paginators.html
+            # We use S3 prefix to limit retrieved list to a user, since in our buckets
+            # file keys always have the form <username>/... see:
+            # https://github.com/dmwm/CRABServer/wiki/CRABCache-replacement-with-S3#bucket-organization  and
+            # https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html
+            #
+            fileNames = []
+            paginator = self.s3_client.get_paginator('list_objects_v2')
+            operation_parameters = {'Bucket': self.s3_bucket,
+                                    'Prefix': username}
+            page_iterator = paginator.paginate(**operation_parameters)
+            for page in page_iterator:
+                namesInPage = [item['Key'].lstrip(username+'/') for item in page['Contents']]
+                fileNames += namesInPage
+            if object:
+                filteredFileNames = [f for f in fileNames if object in f]
+                fileNames = filteredFileNames
+            return fileNames
 
         if subresource == 'used':
+            # return spare used by username, in MBytes (rounded to integer)
             if not username:
                 raise MissingParameter('username is missing')
-            usedSpace = '218 MBytes'
-            return usedSpace
+            paginator = self.s3_client.get_paginator('list_objects_v2')
+            operation_parameters = {'Bucket': self.s3_bucket,
+                                    'Prefix': username}
+            page_iterator = paginator.paginate(**operation_parameters)
+            # S3 records object size in bytes, see:
+            # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.list_objects_v2
+            usedBytes = 0
+            for page in page_iterator:
+                for item in page['Contents']:
+                    usedBytes += item['Size']
+            usedMBytes = usedBytes / 1024 / 1024
+            return usedMBytes

--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -593,7 +593,7 @@ class tempSetLogLevel():
         self.logger.setLevel(self.previousLogLevel)
 
 def uploadToS3 (restServer=None, instance='prod', filepath=None, object=None,  # pylint: disable=redefined-builtin
-                taskname=None, bucket='CRABCache', logger=None):
+                taskname=None, cachename=None, bucket='CRABCache', logger=None):
     """
     one call to make a 2-step operation:
     obtains a preSignedUrl from crabserver RESTCache and use it to upload a file
@@ -602,6 +602,7 @@ def uploadToS3 (restServer=None, instance='prod', filepath=None, object=None,  #
     :param filepath: string : the full path of the file to upload
     :param object: string : the kind of object to upload: clientlog|twlog|sandbox|debugfiles
     :param taskname: string : the task this object belongs to
+    :param cachename: string : when uploading sandbox taskname is not used but cachename is needed
     :param bucket: string : the name of the bucket in s3.cern.ch where to upload
     :return: nothing. Raises an exception in case of error
     """
@@ -611,7 +612,8 @@ def uploadToS3 (restServer=None, instance='prod', filepath=None, object=None,  #
     uri = uriNoApi + api
     dataDict = {'subresource':'upload',
                 'object':object,
-                'taskname':taskname}
+                'taskname':taskname,
+                'cachename':cachename}
     data = encodeRequest(dataDict)
     try:
         # calls to restServer alway return a 3-ple ({'result':'string'}, HTTPcode, HTTPreason)

--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -1,6 +1,8 @@
 """
 This contains some utility methods to share between the server and the client, or by the server components themself
 """
+# this is a weird and unclear message from pylint, better to ignore it
+# pylint: disable=W0715
 
 from __future__ import print_function
 from __future__ import division


### PR DESCRIPTION
now has working implementation also of `list` and `used` and proper "directory" for sandboxes as per
https://github.com/dmwm/CRABServer/wiki/CRABCache-replacement-with-S3

Main missing item is how to define which bucket name to use in presence of e.g. `CRABCacheProd`, `CRABCachePre`, `CRABCacheDev` ones. Automated or delegate to client ?

