### PR TITLE
set max_time_in_queue for FTS back to 6h.

### DIFF
--- a/scripts/task_process/FTS_Transfers.py
+++ b/scripts/task_process/FTS_Transfers.py
@@ -279,9 +279,9 @@ class submit_thread(threading.Thread):
                            bring_online=None,
                            source_spacetoken=None,
                            spacetoken=None,
-                           # max time for job in the fts queue in seconds.
-                           # Usually, it should take O(s) for healthy situations
-                           max_time_in_queue=600,
+                           # max time for job in the fts queue in hours.
+                           # Usually, it should take O(m) for healthy situations
+                           max_time_in_queue=6,
                            retry=3,
                            # seconds after which the transfer is retried
                            # reduced under FTS suggestion w.r.t. the 3hrs of asov1


### PR DESCRIPTION
 See https://cern.service-now.com/service-portal?id=ticket&table=incident&n=INC2775059 and https://github.com/dmwm/CRABServer/issues/6572#issuecomment-828488868