### PR TITLE
pass correct project directory for immediate test fix #6657

### DIFF
--- a/test/container/testingScripts/taskSubmission.sh
+++ b/test/container/testingScripts/taskSubmission.sh
@@ -32,11 +32,12 @@ submitTasks(){
 #run immediate check on tasks submitted for Client_Configuration_Validation testing. 
 #Save results to failed_tests and successful_tests files.
 immediateCheck(){
+  project_dir="/tmp/crabTestConfig"
   for task in ${tasksToCheck};
   do
 	echo ${task}
 	test_to_execute=`echo "${task}" | grep -oP '(?<=_crab_).*(?=)'`
-	task_dir=`echo "${task}" | grep -oP '(?<=Project dir:\s).*(?=\sPlease)'`
+	task_dir=${project_dir}/crab_${test_to_execute}
 	bash -x ${test_to_execute}-testSubmit.sh ${task_dir} && \
 		echo ${test_to_execute}-testSubmit.sh ${task_dir} - $? >> /artifacts/successful_tests || \
 		echo ${test_to_execute}-testSubmit.sh ${task_dir} - $? >> /artifacts/failed_tests	

--- a/test/container/testingScripts/taskSubmission.sh
+++ b/test/container/testingScripts/taskSubmission.sh
@@ -32,19 +32,16 @@ submitTasks(){
 #run immediate check on tasks submitted for Client_Configuration_Validation testing. 
 #Save results to failed_tests and successful_tests files.
 immediateCheck(){
-  project_dir="/tmp/crabTestConfig"
   for task in ${tasksToCheck};
   do
 	echo ${task}
 	test_to_execute=`echo "${task}" | grep -oP '(?<=_crab_).*(?=)'`
-        task_dir=${project_dir}/${test_to_execute}
+	task_dir=`echo "${task}" | grep -oP '(?<=Project dir:\s).*(?=\sPlease)'`
 	bash -x ${test_to_execute}-testSubmit.sh ${task_dir} && \
-                                echo ${test_to_execute}-testSubmit.sh ${task_dir} - $? >> /artifacts/successful_tests || \
-                                echo ${test_to_execute}-testSubmit.sh ${task_dir} - $? >> /artifacts/failed_tests	
+		echo ${test_to_execute}-testSubmit.sh ${task_dir} - $? >> /artifacts/successful_tests || \
+		echo ${test_to_execute}-testSubmit.sh ${task_dir} - $? >> /artifacts/failed_tests	
   done
 }
-
-
 
 if [ "${Client_Validation_Suite}" = true ]; then
 	echo -e "Starting task submission for Client Validation testing.\n"
@@ -73,5 +70,7 @@ if [ "${Task_Submission_Status_Tracking}" = true ]; then
         submitTasks "${filesToSubmit}" "TS"
 	cd ${WORK_DIR}
 fi
+
+
 
 


### PR DESCRIPTION
fixes #6657. 

the only left test that is still failing is:

```
15:42:01 210616_134037:cmsbot_crab_sendExternalFolder
15:42:01 sendExternalFolder-testSubmit.sh /tmp/crabTestConfig/crab_sendExternalFolder
15:42:01 + workDir=/tmp/crabTestConfig/crab_sendExternalFolder
15:42:01 + lookInTaskSandboxFor '^external/' /tmp/crabTestConfig/crab_sendExternalFolder
15:42:01 + local 'file=^external/'
15:42:01 + local workDir=/tmp/crabTestConfig/crab_sendExternalFolder
15:42:01 ++ find /tmp/crabTestConfig/crab_sendExternalFolder/inputs -name '*default.tgz'
15:42:01 + tarball=/tmp/crabTestConfig/crab_sendExternalFolder/inputs/2b645042-c1f5-4bf5-852b-974be49fb404default.tgz
15:42:01 + tar tf /tmp/crabTestConfig/crab_sendExternalFolder/inputs/2b645042-c1f5-4bf5-852b-974be49fb404default.tgz
15:42:01 + grep -q '^external/'
15:42:01 + '[' 1 -ne 0 ']'
15:42:01 + exit 1
```