### PR TITLE
add option to use gocurl for s3 operations (fix #6685)

### DIFF
--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -785,7 +785,7 @@ def uploadToS3ViaPSU (filepath=None, preSignedUrlFields=None, logger=None):
     """
     uploads a file to s3.cern.ch usign PreSigned URLs obtained e.g. from a call to
     crabserver RESTCache API /crabserver/prod/cache?subresource=upload
-    based on env.variable 'commandToUse' value, implementation can use plain curl
+    based on env.variable 'CRAB_useGoCurl' presence, implementation can use plain curl
     or gocurl to execute upload to S3 command
     :param filepath: string : the full path to a file to upload
     :param preSignedUrlFields: dictionary: a dictionary with the needed fields as
@@ -813,13 +813,10 @@ def uploadToS3ViaPSU (filepath=None, preSignedUrlFields=None, logger=None):
 
     userAgent = 'CRAB'
     uploadCommand = ''
-    
-    # This variable is used to set how upload to S3 command should be executed.
-    # If variable is set to 'useGOCurl' (i.e. export commandToUse=useGOCurl), then goCurl 
-    # is used for upload command execution: https://github.com/vkuznet/gocurl
-    commandToUse = os.getenv('commandToUse')
 
-    if commandToUse == 'useGOCurl':
+    # CRAB_useGoCurl env. variable is used to define how upload to S3 command should be executed.
+    # If variable is set, then goCurl is used for command execution: https://github.com/vkuznet/gocurl
+    if os.getenv('CRAB_useGoCurl'):
         uploadCommand += '/afs/cern.ch/user/v/valya/public/gocurl -verbose 2 -method POST'
         uploadCommand += ' -header "User-Agent:%s"' % userAgent
         uploadCommand += ' -form "key=%s"' % key
@@ -845,7 +842,6 @@ def uploadToS3ViaPSU (filepath=None, preSignedUrlFields=None, logger=None):
         uploadCommand += ' -F "file=@%s"' % filepath
         uploadCommand += ' "%s"' % url
 
-
     logger.debug('Will execute:\n%s', uploadCommand)
     uploadProcess = subprocess.Popen(uploadCommand, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     stdout, stderr = uploadProcess.communicate()
@@ -861,7 +857,7 @@ def downloadFromS3ViaPSU(filepath=None, preSignedUrl=None, logger=None):
     More generic than the name implies:
     downloads a file usign PreSigned URLs obtained e.g. from a call to
     crabserver RESTCache API /crabserver/prod/cache?subresource=download
-    based on env.variable 'commandToUse' value, implementation can use wget
+    based on env.variable 'CRAB_useGoCurl' presence, implementation can use wget
     or gocurl to execute download from S3 command
     :param filepath: string : the full path to the file to be created
         if the file exists already, it will be silently overwritten
@@ -874,14 +870,12 @@ def downloadFromS3ViaPSU(filepath=None, preSignedUrl=None, logger=None):
         raise Exception("mandatory filepath argument missing")
     if not preSignedUrl :
         raise Exception("mandatory preSignedUrl argument missing")
-        
-    # This variable is used to set how download from S3 command should be executed.
-    # If variable is set to 'useGOCurl' (i.e. export commandToUse=useGOCurl), then goCurl 
-    # is used for download command execution: https://github.com/vkuznet/gocurl
-    commandToUse = os.getenv('commandToUse')               
 
     downloadCommand = ''
-    if commandToUse == 'useGOCurl':
+
+    # CRAB_useGoCurl env. variable is used to define how download from S3 command should be executed.
+    # If variable is set, then goCurl is used for command execution: https://github.com/vkuznet/gocurl
+    if os.getenv('CRAB_useGoCurl'):
         downloadCommand += '/afs/cern.ch/user/v/valya/public/gocurl -verbose 2 -method GET'
         downloadCommand += ' -out "%s"' % filepath
         downloadCommand += ' -url "%s"' % preSignedUrl


### PR DESCRIPTION
changes allows to test gocurl for s3 operations. In order to use it set `export commandToUse=useGOCurl` before running crab commands.

However, behavior of gocurl is not fully understood yet: once in a while it fails to upload file to s3 with below error:
```
DEBUG 2021-07-15 09:12:26.757 UTC:       Will execute:
/afs/cern.ch/user/v/valya/public/gocurl -verbose 2 -method POST -header "User-Agent:CRAB" -form "key=ddirmait/sandboxes/9a353571f2604e79242c83b2ec6f30c7c57fb9
3f94cf377ebfcbc12eae666dee.tar.gz" -form "AWSAccessKeyId=ab00fcc889f248c495d2875f15a3badb" -form "policy=eyJjb25kaXRpb25zIjogW3siYnVja2V0IjogImNyYWJjYWNoZV9wc
mVwcm9kIn0sIHsia2V5IjogImRkaXJtYWl0L3NhbmRib3hlcy85YTM1MzU3MWYyNjA0ZTc5MjQyYzgzYjJlYzZmMzBjN2M1N2ZiOTNmOTRjZjM3N2ViZmNiYzEyZWFlNjY2ZGVlLnRhci5neiJ9XSwgImV4cGl
yYXRpb24iOiAiMjAyMS0wNy0xNVQxMDoxMjoyNloifQ==" -form "signature=Z5s1fHaYT06jBKj7331yMWZ8gxw=" -form "file=@/afs/cern.ch/user/d/ddirmait/crab_tasks/crab_projec
ts/crab_20210715_111222/inputs/debugFiles.tgz" -url "https://s3.cern.ch/crabcache_preprod"
DEBUG 2021-07-15 09:12:27.760 UTC:       exitcode: 0
stdout: <?xml version="1.0" encoding="UTF-8"?><Error><Code>InvalidArgument</Code><Message>Key not specified</Message><BucketName>crabcache_preprod</BucketName
><RequestId>tx000000000000001b751fb-0060effbfb-1e049857-default</RequestId><HostId>1e049857-default-default</HostId></Error>

stderr: 2021/07/15 11:12:27 main.go:98: HTTP headers
2021/07/15 11:12:27 main.go:100: User-Agent CRAB
2021/07/15 11:12:27 main.go:114: HTTP form pairs
2021/07/15 11:12:27 main.go:116: User-Agent CRAB
```

also, exit code of the command is 0, so error in not catched by the code.