### PR TITLE
HotFix for Publisher problems.

### DIFF
--- a/src/python/Publisher/PublisherMaster.py
+++ b/src/python/Publisher/PublisherMaster.py
@@ -341,6 +341,10 @@ class Master(object):
                 if int(taskname[0:4]) < 2008:
                     self.logger.info("Skipped %s. Ignore tasks created before August 2020.", taskname)
                     continue
+                username = task[0][0]
+                if username in self.config.skipUsers:
+                    self.logger.info("Skipped user %s task %s", username, taskname)
+                    continue
                 if self.TestMode:
                     self.startSlave(task)   # sequentially do one task after another
                     continue

--- a/src/python/Publisher/TaskPublish.py
+++ b/src/python/Publisher/TaskPublish.py
@@ -827,6 +827,10 @@ def publishInDBS3(config, taskname, verbose):
     failedBlocks = 0
     max_files_per_block = config.General.max_files_per_block
     #TODO here can tune max_file_per_block based on len(dbsFiles) and dbsFilesSize
+    # start with a horrible hack for identified bad use cases:
+    if '2018UL' in taskname or 'UL2018' in taskname:
+        max_files_per_block = 10
+
     dumpList = []   # keep a list of files where blocks which fail publication are dumped
     while True:
         nIter += 1

--- a/src/script/Deployment/Publisher/PublisherConfig.py
+++ b/src/script/Deployment/Publisher/PublisherConfig.py
@@ -30,6 +30,7 @@ config.General.taskFilesDir = '/data/srv/Publisher_files/'
 config.General.logsDir = '/data/srv/Publisher/logs'
 config.General.logMsgFormat = '%(asctime)s:%(levelname)s:%(module)s:%(name)s: %(message)s'
 config.General.logLevel = 'INFO'
+config.General.skipUsers = ['mickeymouse', 'donaldduck']
 
 config.section_('TaskPublisher')
 config.TaskPublisher.DBShost = 'cmsweb-prod.cern.ch'


### PR DESCRIPTION
 Introduce list of users to skip and use 10-file blocks for 2018UL datasets
Port to master the hot fix applied to py2only branch in https://github.com/dmwm/CRABServer/pull/6745