### PR TITLE
ignore commands in config.TaskWorker.rejectedCommands. Fix #6767

### DIFF
--- a/src/script/Deployment/TaskWorker/TaskWorkerConfig.py
+++ b/src/script/Deployment/TaskWorker/TaskWorkerConfig.py
@@ -106,6 +106,7 @@ config.TaskWorker.minAutomaticRuntimeMins = 60
 
 config.TaskWorker.highPrioEgroups = ['cms-crab-HighPrioUsers']
 config.TaskWorker.bannedUsernames = ['mickeymouse','donaldduck']
+config.TaskWorker.rejectedCommands = ['NONE', 'NOPE']  # commands are upper case e.g. 'SUBMIT'
 
 # Setting the list of users for the highprio accounting group
 # not usually needed since the list if automatically populated from e-group


### PR DESCRIPTION
This is a PR for py2only branch that we run in production.
Aim is to allow CRAB draining for Oracle upgrade

also log warning for user, also for previously implemented config.TaskWorker.bannedUsernames

NOTE: also added rejectedCommands to TW config [erb](https://gitlab.cern.ch/ai/it-puppet-hostgroup-vocmsglidein/-/blob/master/code/templates/crab/crabtaskworker/TaskWorkerConfig.py.erb) template in Puppet via https://gitlab.cern.ch/ai/it-puppet-hostgroup-vocmsglidein/-/commit/9384479b9a2cc0617a4b70552a047874610d86c3
