### PR TITLE
[docker] add mapellidario remotes to dev repos

### DIFF
--- a/Docker/addGH.sh
+++ b/Docker/addGH.sh
@@ -22,11 +22,13 @@ cd CRABServer
 git checkout $CRABServerTag
 git remote add stefano https://github.com/belforte/CRABServer.git
 git remote add daina https://github.com/ddaina/CRABServer.git
+git remote add mapellidario https://github.com/mapellidario/CRABServer.git
 cd ..
 cd WMCore
 git checkout $WMCoreTag
 git remote add stefano https://github.com/belforte/WMCore.git
 git remote add daina https://github.com/ddaina/WMCore.git
+git remote add mapellidario https://github.com/mapellidario/WMCore.git
 
 # 4. create .gitconfig
 cat > ~/.gitconfig << EOF


### PR DESCRIPTION
Adding my remotes to the docker image developer repos.

I choose `mapellidario` instead of `dario` so that we can get tab completion on the remote name just by writing the first letter instead of at the third (`daina` and `dario` differ only at the third character). Hope this is not a problem! :)