### PR TITLE
First step in porting to python3 - code on sched

### DIFF
--- a/scripts/AdjustSites.py
+++ b/scripts/AdjustSites.py
@@ -14,10 +14,10 @@ import sys
 import time
 import glob
 import shutil
-import urllib
+from urllib.parse import urlencode
 import traceback
 from datetime import datetime
-from httplib import HTTPException
+from http.client import HTTPException
 
 import classad
 import htcondor
@@ -238,23 +238,6 @@ def makeWebDir(ad):
         os.symlink(os.path.abspath(os.path.join(".", ".job.ad")), os.path.join(path, "job_ad.txt"))
         os.symlink(os.path.abspath(os.path.join(".", "task_process/status_cache.txt")), os.path.join(path, "status_cache"))
         os.symlink(os.path.abspath(os.path.join(".", "task_process/status_cache.pkl")), os.path.join(path, "status_cache.pkl"))
-        # prepare a startup cache_info file with time info for client to have something useful to print
-        # in crab status while waiting for task_process to fill with actual jobs info. Do it in two ways
-        # new way: a pickle file for python3 compatibility
-        startInfo = {'bootstrapTime': {}}
-        startInfo['bootstrapTime']['date'] = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
-        startInfo['bootstrapTime']['fromEpoch'] = int(time.time())
-        with open(os.path.abspath(os.path.join(".", "task_process/status_cache.pkl")), 'w') as fp:
-            pickle.dump(startInfo, fp)
-        # old way: a file with multiple lines and print-like output
-        startInfo = "# Task bootstrapped at " + datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC") + "\n"
-        startInfo += "%d\n" % (int(time.time()))  # machines will like seconds from Epoch more
-        # prepare fake status_cache info to please current (v3.210127) CRAB Client
-        fakeInfo = startInfo + "{"
-        fakeInfo += "'DagStatus': {'SubDagStatus': {}, 'Timestamp': 0L, 'NodesTotal': 1L, 'SubDags': {}, 'DagStatus': 1L}"
-        fakeInfo += "}\n{}\n"
-        with open(os.path.abspath(os.path.join(".", "task_process/status_cache.txt")), 'w') as fd:
-            fd.write(fakeInfo)
         os.symlink(os.path.abspath(os.path.join(".", "prejob_logs/predag.0.txt")), os.path.join(path, "AutomaticSplitting_Log0.txt"))
         os.symlink(os.path.abspath(os.path.join(".", "prejob_logs/predag.0.txt")), os.path.join(path, "AutomaticSplitting/DagLog0.txt"))
         os.symlink(os.path.abspath(os.path.join(".", "prejob_logs/predag.1.txt")), os.path.join(path, "AutomaticSplitting/DagLog1.txt"))
@@ -266,6 +249,24 @@ def makeWebDir(ad):
     except Exception as ex: #pylint: disable=broad-except
         #Should we just catch OSError and IOError? Is that enough?
         printLog("Failed to copy/symlink files in the user web directory: %s" % str(ex))
+
+    # prepare a startup cache_info file with time info for client to have something useful to print
+    # in crab status while waiting for task_process to fill with actual jobs info. Do it in two ways
+    # new way: a pickle file for python3 compatibility
+    startInfo = {'bootstrapTime': {}}
+    startInfo['bootstrapTime']['date'] = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
+    startInfo['bootstrapTime']['fromEpoch'] = int(time.time())
+    with open(os.path.abspath(os.path.join(".", "task_process/status_cache.pkl")), 'wb') as fp:
+        pickle.dump(startInfo, fp)
+    # old way: a file with multiple lines and print-like output
+    startInfo = "# Task bootstrapped at " + datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC") + "\n"
+    startInfo += "%d\n" % (int(time.time()))  # machines will like seconds from Epoch more
+    # prepare fake status_cache info to please current (v3.210127) CRAB Client
+    fakeInfo = startInfo + "{"
+    fakeInfo += "'DagStatus': {'SubDagStatus': {}, 'Timestamp': 0L, 'NodesTotal': 1L, 'SubDags': {}, 'DagStatus': 1L}"
+    fakeInfo += "}\n{}\n"
+    with open(os.path.abspath(os.path.join(".", "task_process/status_cache.txt")), 'w') as fd:
+        fd.write(fakeInfo)
     printLog("WEB_DIR created, sym links in place and status_cache initialized")
 
     try:
@@ -287,7 +288,7 @@ def uploadWebDir(crabserver, ad):
 
     try:
         printLog("Uploading webdir %s to the REST" % data['webdirurl'])
-        crabserver.post(api='task', data=urllib.urlencode(data))
+        crabserver.post(api='task', data=urlencode(data))
         return 0
     except HTTPException as hte:
         printLog(traceback.format_exc())

--- a/scripts/CMSRunAnalysis.py
+++ b/scripts/CMSRunAnalysis.py
@@ -761,7 +761,7 @@ if __name__ == "__main__":
         try:
             oldName = 'UNKNOWN'
             newName = 'UNKNOWN'
-            for oldName, newName in literal_eval(options.outFiles).iteritems():
+            for oldName, newName in literal_eval(options.outFiles).items():
                 os.rename(oldName, newName)
         except Exception as ex:
             handleException("FAILED", EC_MoveOutErr, "Exception while moving file %s to %s." %(oldName, newName))

--- a/scripts/dag_bootstrap.sh
+++ b/scripts/dag_bootstrap.sh
@@ -13,30 +13,27 @@ set -o pipefail
 set -x
 echo "Beginning dag_bootstrap.sh (stdout)"
 echo "Beginning dag_bootstrap.sh (stderr)" 1>&2
-export PYTHONPATH=$PYTHONPATH:/cvmfs/cms.cern.ch/rucio/current/lib/python2.7/site-packages
+export PYTHONPATH=$PYTHONPATH:/cvmfs/cms.cern.ch/rucio/x86_64/slc7/py3/current/lib/python3.6/site-packages/
+export PYTHONPATH=$PYTHONPATH:/data/srv/pycurl3/7.44.1
 if [ "X$TASKWORKER_ENV" = "X" -a ! -e CRAB3.zip ]
 then
 
-	command -v python > /dev/null
+	command -v python3 > /dev/null
 	rc=$?
 	if [[ $rc != 0 ]]
 	then
-		echo "Error: Python isn't available on `hostname`." >&2
-		echo "Error: bootstrap execution requires python" >&2
+		echo "Error: Python3 isn't available on `hostname`." >&2
+		echo "Error: bootstrap execution requires python3" >&2
 		exit 1
 	else
-		echo "I found python at.."
-		echo `which python`
+		echo "I found python3 at.."
+		echo `which python3`
 	fi
 
 	if [ "x$CRAB3_VERSION" = "x" ]; then
 		TARBALL_NAME=TaskManagerRun.tar.gz
 	else
 		TARBALL_NAME=TaskManagerRun-$CRAB3_VERSION.tar.gz
-	fi
-
-	if [[ "X$CRAB_TASKMANAGER_TARBALL" == "X" ]]; then
-		CRAB_TASKMANAGER_TARBALL="http://hcc-briantest.unl.edu/$TARBALL_NAME"
 	fi
     
 	if [[ "X$CRAB_TASKMANAGER_TARBALL" != "Xlocal" ]]; then
@@ -96,7 +93,6 @@ export LD_LIBRARY_PATH=.:$LD_LIBRARY_PATH
 
 os_ver=$(source /etc/os-release;echo $VERSION_ID)
 curl_path="/cvmfs/cms.cern.ch/slc${os_ver}_amd64_gcc700/external/curl/7.59.0"
-libcurl_path="${curl_path}/lib"
 source ${curl_path}/etc/profile.d/init.sh
 
 export PYTHONUNBUFFERED=1
@@ -111,5 +107,5 @@ if [ "X$_CONDOR_JOB_AD" != "X" ]; then
   cat $_CONDOR_JOB_AD
 fi
 echo "Now running the job in `pwd`..."
-exec nice -n 19 python -m TaskWorker.TaskManagerBootstrap "$@"
+exec nice -n 19 python3 -m TaskWorker.TaskManagerBootstrap "$@"
 } 2>&1 | tee dag_bootstrap.out

--- a/scripts/dag_bootstrap_startup.sh
+++ b/scripts/dag_bootstrap_startup.sh
@@ -14,10 +14,13 @@ done
 export PATH="/usr/local/bin:/bin:/usr/bin:/usr/bin:$PATH"
 export LD_LIBRARY_PATH=.:$LD_LIBRARY_PATH
 
-os_ver=$(source /etc/os-release;echo $VERSION_ID)
-curl_path="/cvmfs/cms.cern.ch/slc${os_ver}_amd64_gcc700/external/curl/7.59.0"
-libcurl_path="${curl_path}/lib"
-source ${curl_path}/etc/profile.d/init.sh
+export PYTHONPATH=$PYTHONPATH:/data/srv/pycurl3/7.44.1
+#os_ver=$(source /etc/os-release;echo $VERSION_ID)
+#curl_path="/cvmfs/cms.cern.ch/slc${os_ver}_amd64_gcc700/external/curl/7.59.0"
+#libcurl_path="${curl_path}/lib"
+#source ${curl_path}/etc/profile.d/init.sh
+source /cvmfs/cms.cern.ch/slc7_amd64_gcc900/external/curl/7.59.0/etc/profile.d/init.sh
+
 
 srcname=$0
 env > ${srcname%.sh}.env
@@ -85,16 +88,16 @@ fi
 # Bootstrap the runtime - we want to do this before DAG is submitted
 # so all the children don't try this at once.
 if [ "X$TASKWORKER_ENV" = "X" -a ! -e CRAB3.zip ]; then
-    command -v python > /dev/null
+    command -v python3 > /dev/null
     rc=$?
     if [[ $rc != 0 ]]; then
         echo "Error: Python isn't available on `hostname`." >&2
-        echo "Error: Bootstrap execution requires python" >&2
-        condor_qedit $CONDOR_ID DagmanHoldReason "'Error: Bootstrap execution requires python.'"
+        echo "Error: Bootstrap execution requires python3" >&2
+        condor_qedit $CONDOR_ID DagmanHoldReason "'Error: Bootstrap execution requires python3.'"
         exit 1
     else
-        echo "I found python at.."
-        echo `which python`
+        echo "I found python3 at.."
+        echo `which python3`
     fi
 
     if [[ "X$CRAB_TASKMANAGER_TARBALL" == "X" ]]; then
@@ -138,7 +141,7 @@ cp $_CONDOR_JOB_AD  ./_CONDOR_JOB_AD
 if [ -e AdjustSites.py ]; then
     export schedd_name=`condor_config_val schedd_name`
     echo "Execute AdjustSites.py ..."
-    python AdjustSites.py
+    python3 AdjustSites.py
     ret=$?
     if [ $ret -eq 1 ]; then
         echo "Error: AdjustSites.py failed to update the webdir." >&2

--- a/scripts/task_process/FTS_Transfers.py
+++ b/scripts/task_process/FTS_Transfers.py
@@ -10,7 +10,7 @@ import logging
 import os
 import subprocess
 from datetime import timedelta
-from httplib import HTTPException
+from http.client import HTTPException
 
 import fts3.rest.client.easy as fts3
 

--- a/scripts/task_process/cache_status.py
+++ b/scripts/task_process/cache_status.py
@@ -196,7 +196,7 @@ def parseJobLog(fp, nodes, nodeMap):
 
 def parseErrorReport(data, nodes):
     #iterate over the jobs and set the error dict for those which are failed
-    for jobid, statedict in nodes.iteritems():
+    for jobid, statedict in nodes.items():
         if 'State' in statedict and statedict['State'] == 'failed' and jobid in data:
             # data[jobid] is a dictionary with the retry number as a key and error summary information as a value.
             # Here we want to get the error summary information, and since values() returns a list

--- a/scripts/task_process/task_proc_wrapper.sh
+++ b/scripts/task_process/task_proc_wrapper.sh
@@ -11,7 +11,7 @@ function cache_status {
 
 function cache_status_jel {
     log "Running cache_status_jel.py"
-    python task_process/cache_status_jel.py
+    python3 task_process/cache_status_jel.py
 }
 
 function manage_transfers {
@@ -101,9 +101,11 @@ TIME_OF_LAST_QUERY=$(date +"%s")
 # submission is most likely pointless and relatively expensive, the script will run normally and perform the query later.
 DAG_INFO="init"
 
+export PYTHONPATH=$PYTHONPATH:/data/srv/pycurl3/7.44.1
+
 export PYTHONPATH=`pwd`/task_process:`pwd`/CRAB3.zip:`pwd`/WMCore.zip:$PYTHONPATH
 
-export PYTHONPATH=$PYTHONPATH:/cvmfs/cms.cern.ch/rucio/current/lib/python2.7/site-packages
+export PYTHONPATH=$PYTHONPATH:/cvmfs/cms.cern.ch/rucio/x86_64/slc7/py3/current/lib/python3.6/site-packages/
 
 log "Starting task daemon wrapper"
 while true

--- a/src/python/CRABInterface/Attrib.py
+++ b/src/python/CRABInterface/Attrib.py
@@ -11,7 +11,7 @@ def attr(*args, **kwargs):
     def wrap_ob(ob):
         for name in args:
             setattr(ob, name, True)
-        for name, value in kwargs.iteritems():
+        for name, value in kwargs.items():
             setattr(ob, name, value)
         return ob
     return wrap_ob

--- a/src/python/CRABInterface/DataFileMetadata.py
+++ b/src/python/CRABInterface/DataFileMetadata.py
@@ -118,7 +118,7 @@ class DataFileMetadata(object):
         """
         self.logger.debug("Changing state of file %(outlfn)s in task %(taskname)s to %(filestate)s" % kwargs)
 
-        self.api.modify(self.FileMetaData.ChangeFileState_sql, **dict((k, [v]) for k, v in kwargs.iteritems()))
+        self.api.modify(self.FileMetaData.ChangeFileState_sql, **dict((k, [v]) for k, v in kwargs.items()))
 
     def delete(self, taskname, hours):
         """ UNUSED method that deletes record from the FILEMETADATA table

--- a/src/python/CRABInterface/HTCondorDataWorkflow.py
+++ b/src/python/CRABInterface/HTCondorDataWorkflow.py
@@ -586,7 +586,7 @@ class HTCondorDataWorkflow(DataWorkflow):
         """
         transfers = {}
         data = json.load(fp)
-        for docid, result in data['results'].iteritems():
+        for docid, result in data['results'].items():
             #Oracle has an improved structure in aso_status
             if isCouchDBURL(self.asoDBURL):
                 result = result['value']
@@ -618,7 +618,7 @@ class HTCondorDataWorkflow(DataWorkflow):
         fp.seek(0)
         data = json.load(fp)
         #iterate over the jobs and set the error dict for those which are failed
-        for jobid, statedict in nodes.iteritems():
+        for jobid, statedict in nodes.items():
             if 'State' in statedict and statedict['State'] == 'failed' and jobid in data:
                 statedict['Error'] = last(data[jobid]) #data[jobid] contains all retries. take the last one
 

--- a/src/python/HTCondorUtils.py
+++ b/src/python/HTCondorUtils.py
@@ -35,7 +35,7 @@ class OutputObj:
         self.outputMessage = outputMessage
         self.outputObj = outputObj
         self.environmentStr = ""
-        for key, val in os.environ.iteritems():
+        for key, val in os.environ.items():
             self.environmentStr += "%s=%s\n" % (key, val)
 
 

--- a/src/python/PandaServerInterface.py
+++ b/src/python/PandaServerInterface.py
@@ -103,7 +103,7 @@ class _Curl:
         # data
         strData = ''
         for key in data.keys():
-            strData += 'data="%s"\n' % urllib.urlencode({key:data[key]})
+            strData += 'data="%s"\n' % urlencode({key:data[key]})
         # write data to temporary config file
         if globalTmpDir != '':
             tmpFD, tmpName = tempfile.mkstemp(dir=globalTmpDir)
@@ -156,7 +156,7 @@ class _Curl:
         # data
         strData = ''
         for key in data.keys():
-            strData += 'data="%s"\n' % urllib.urlencode({key:data[key]})
+            strData += 'data="%s"\n' % urlencode({key:data[key]})
         # write data to temporary config file
         if globalTmpDir != '':
             tmpFD, tmpName = tempfile.mkstemp(dir=globalTmpDir)

--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -404,8 +404,7 @@ def getLock(name):
 def getHashLfn(lfn):
     """ Provide a hashed lfn from an lfn.
     """
-    return hashlib.sha224(lfn).hexdigest()
-
+    return hashlib.sha224(lfn.encode('utf-8')).hexdigest()
 
 def generateTaskName(username, requestname, timestamp=None):
     """ Generate a taskName which is saved in database

--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -3,8 +3,13 @@ import os
 import sys
 import logging
 import copy
-from httplib import HTTPException
-import urllib
+from http.client import HTTPException
+
+import sys
+if sys.version_info >= (3, 0):
+    from urllib.parse import urlencode  # pylint: disable=no-name-in-module
+if sys.version_info < (3, 0):
+    from urllib import urlencode
 
 from WMCore.DataStructs.LumiList import LumiList
 from WMCore.Services.DBS.DBSReader import DBSReader
@@ -60,7 +65,7 @@ class DBSDataDiscovery(DataDiscovery):
         # get all the RucioStorageElements (RSEs) which are of kind 'Disk'
         # locationsMap is a dictionary {block1:[locations], block2:[locations],...}
         diskLocationsMap = {}
-        for block, locations in locationsMap.iteritems():
+        for block, locations in locationsMap.items():
             # as of Sept 2020, tape RSEs ends with _Tape, go for the quick hack
             diskRSEs = [rse for rse in locations if not 'Tape' in rse]
             if  'T3_CH_CERN_OpenData' in diskRSEs:
@@ -197,7 +202,7 @@ class DBSDataDiscovery(DataDiscovery):
                          'subresource': 'addddmreqid',
                          }
             try:
-                tapeRecallStatusSet = self.crabserver.post(api='task', data=urllib.urlencode(configreq))
+                tapeRecallStatusSet = self.crabserver.post(api='task', data=urlencode(configreq))
             except HTTPException as hte:
                 self.logger.exception(hte)
                 msg = "HTTP Error while contacting the REST Interface %s:\n%s" % (

--- a/src/python/TaskWorker/Actions/DagmanKiller.py
+++ b/src/python/TaskWorker/Actions/DagmanKiller.py
@@ -1,8 +1,12 @@
 import re
 import socket
-import urllib
+import sys
+if sys.version_info >= (3, 0):
+    from urllib.parse import urlencode  # pylint: disable=no-name-in-module
+if sys.version_info < (3, 0):
+    from urllib import urlencode
 
-from httplib import HTTPException
+from http.client import HTTPException
 
 import htcondor
 
@@ -123,7 +127,7 @@ class DagmanKiller(TaskAction):
                          'workflow': kwargs['task']['tm_taskname'],
                          'status': 'KILLED'}
             self.logger.debug("Setting the task as successfully killed with %s", str(configreq))
-            self.crabserver.post(api='workflowdb', data=urllib.urlencode(configreq))
+            self.crabserver.post(api='workflowdb', data=urlencode(configreq))
         except HTTPException as hte:
             self.logger.error(hte.headers)
             msg = "The CRAB server successfully killed the task,"

--- a/src/python/TaskWorker/Actions/DagmanResubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanResubmitter.py
@@ -1,6 +1,11 @@
 import time
-import urllib
 import datetime
+
+import sys
+if sys.version_info >= (3, 0):
+    from urllib.parse import urlencode  # pylint: disable=no-name-in-module
+if sys.version_info < (3, 0):
+    from urllib import urlencode
 
 import classad
 import htcondor
@@ -16,7 +21,7 @@ from TaskWorker.Actions.DagmanSubmitter import checkMemoryWalltime
 from TaskWorker.WorkerExceptions import TaskWorkerException
 import TaskWorker.DataObjects.Result as Result
 
-from httplib import HTTPException
+from http.client import HTTPException
 
 
 class DagmanResubmitter(TaskAction):
@@ -126,7 +131,7 @@ class DagmanResubmitter(TaskAction):
                     ## all the jobs, not only the ones we want to resubmit. That's why the pre-job
                     ## is saving the values of the parameters for each job retry in text files (the
                     ## files are in the directory resubmit_info in the schedd).
-                    for adparam, taskparam in params.iteritems():
+                    for adparam, taskparam in params.items():
                         if taskparam in ad:
                             schedd.edit(rootConst, adparam, ad.lookup(taskparam))
                         elif task['resubmit_'+taskparam] != None:
@@ -138,7 +143,7 @@ class DagmanResubmitter(TaskAction):
             self.logger.debug("Resubmitting under condition overwrite = True")
             with HTCondorUtils.AuthenticatedSubprocess(proxy, logger=self.logger) as (parent, rpipe):
                 if not parent:
-                    for adparam, taskparam in params.iteritems():
+                    for adparam, taskparam in params.items():
                         if taskparam in ad:
                             if taskparam == 'jobids' and len(list(ad[taskparam])) == 0:
                                 self.logger.debug("Setting %s = True in the task ad.", adparam)
@@ -183,7 +188,7 @@ class DagmanResubmitter(TaskAction):
                          'workflow': kwargs['task']['tm_taskname'],
                          'status': 'SUBMITTED'}
             self.logger.debug("Setting the task as successfully resubmitted with %s", str(configreq))
-            self.crabserver.post(api='workflowdb', data=urllib.urlencode(configreq))
+            self.crabserver.post(api='workflowdb', data=urlencode(configreq))
         except HTTPException as hte:
             self.logger.error(hte.headers)
             msg  = "The CRAB server successfully resubmitted the task to the Grid scheduler,"

--- a/src/python/TaskWorker/Actions/DagmanSubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanSubmitter.py
@@ -8,9 +8,14 @@ import copy
 import json
 import time
 import pickle
-import urllib
 
-from httplib import HTTPException
+import sys
+if sys.version_info >= (3, 0):
+    from urllib.parse import urlencode  # pylint: disable=no-name-in-module
+if sys.version_info < (3, 0):
+    from urllib import urlencode
+
+from http.client import HTTPException
 
 import HTCondorUtils
 import CMSGroupMapper
@@ -203,7 +208,7 @@ class DagmanSubmitter(TaskAction.TaskAction):
         configreq = {'workflow':task['tm_taskname'],
                      'subresource':'updateschedd', 'scheddname':schedd}
         try:
-            self.crabserver.post(api='task', data=urllib.urlencode(configreq))
+            self.crabserver.post(api='task', data=urlencode(configreq))
         except HTTPException as hte:
             msg = "Unable to contact cmsweb and update scheduler on which task will be submitted. Error msg: %s" % hte.headers
             self.logger.warning(msg)
@@ -364,7 +369,7 @@ class DagmanSubmitter(TaskAction.TaskAction):
                      'clusterid': results[0]['ClusterId']
                     }
         self.logger.warning("Task %s already submitted to HTCondor; pushing information centrally: %s", workflow, str(configreq))
-        data = urllib.urlencode(configreq)
+        data = urlencode(configreq)
         self.crabserver.post(api='workflowdb', data=data)
 
         # Note that we don't re-send Dashboard jobs; we assume this is a rare occurrance and
@@ -455,7 +460,7 @@ class DagmanSubmitter(TaskAction.TaskAction):
                      'subresource': 'success',
                      'clusterid' : self.clusterId} #that's the condor cluster id of the dag_bootstrap.sh
         self.logger.debug("Pushing information centrally %s", configreq)
-        data = urllib.urlencode(configreq)
+        data = urlencode(configreq)
         self.crabserver.post(api='workflowdb', data=data)
 
         return Result.Result(task=kwargs['task'], result='OK')

--- a/src/python/TaskWorker/Actions/DataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DataDiscovery.py
@@ -40,7 +40,7 @@ class DataDiscovery(TaskAction):  # pylint: disable=abstract-method
             resourceCatalog = CRIC(logger=self.logger, configDict=configDict)
         # can't affort one message from CRIC per file, unless critical !
         with tempSetLogLevel(logger=self.logger, level=logging.ERROR):
-            for lfn, infos in datasetfiles.iteritems():
+            for lfn, infos in datasetfiles.items():
                 ## Skip the file if it is not in VALID state.
                 if not infos.get('ValidFile', True):
                     self.logger.warning("Skipping invalid file %s", lfn)
@@ -67,7 +67,7 @@ class DataDiscovery(TaskAction):  # pylint: disable=abstract-method
                     raise
                 wmfile['workflow'] = requestname
                 event_counter += infos['NumberOfEvents']
-                for run, lumis in infos['Lumis'].iteritems():
+                for run, lumis in infos['Lumis'].items():
                     datasetLumis.setdefault(run, []).extend(lumis)
                     wmfile.addRun(Run(run, *lumis))
                     for lumi in lumis:

--- a/src/python/TaskWorker/Actions/DryRunUploader.py
+++ b/src/python/TaskWorker/Actions/DryRunUploader.py
@@ -3,9 +3,14 @@ Upload an archive containing all files needed to run the a to the UserFileCache 
 """
 import os
 import json
-import urllib
 import tarfile
 import time
+
+import sys
+if sys.version_info >= (3, 0):
+    from urllib.parse import urlencode  # pylint: disable=no-name-in-module
+if sys.version_info < (3, 0):
+    from urllib import urlencode
 
 from WMCore.DataStructs.LumiList import LumiList
 from WMCore.Services.UserFileCache.UserFileCache import UserFileCache
@@ -79,7 +84,7 @@ class DryRunUploader(TaskAction):
                     time.sleep(5)
             update = {'workflow': kw['task']['tm_taskname'], 'subresource': 'state', 'status': 'UPLOADED'}
             self.logger.debug('Updating task status: %s', str(update))
-            self.crabserver.post(api='workflowdb', data=urllib.urlencode(update))
+            self.crabserver.post(api='workflowdb', data=urlencode(update))
 
         finally:
             os.chdir(cwd)

--- a/src/python/TaskWorker/Actions/Handler.py
+++ b/src/python/TaskWorker/Actions/Handler.py
@@ -4,7 +4,7 @@ import time
 import logging
 import tempfile
 import traceback
-from httplib import HTTPException
+from http.client import HTTPException
 
 from WMCore.Services.UserFileCache.UserFileCache import UserFileCache
 

--- a/src/python/TaskWorker/Actions/PreDAG.py
+++ b/src/python/TaskWorker/Actions/PreDAG.py
@@ -96,7 +96,7 @@ class PreDAG(object):
         stagere['processing'] = re.compile(r"^0-\d+$")
         stagere['tail'] = re.compile(r"^[1-9]\d*$")
         completedCount = 0
-        for jobnr, jobdict in self.statusCacheInfo.iteritems():
+        for jobnr, jobdict in self.statusCacheInfo.items():
             state = jobdict.get('State')
             if stagere[stage].match(jobnr) and state in ('finished', 'failed'):
                 if state == 'failed' and processFailed:

--- a/src/python/TaskWorker/Actions/Recurring/FMDCleaner.py
+++ b/src/python/TaskWorker/Actions/Recurring/FMDCleaner.py
@@ -7,7 +7,7 @@ the filemetadata delete API
 import sys
 import urllib
 import logging
-from httplib import HTTPException
+from http.client import HTTPException
 
 from RESTInteractions import CRABRest
 from TaskWorker.Actions.Recurring.BaseRecurringAction import BaseRecurringAction
@@ -19,9 +19,9 @@ class FMDCleaner(BaseRecurringAction):
         self.logger.info('Cleaning filemetadata older than 30 days..')
         ONE_MONTH = 24 * 30
         try:
-            crabserver.delete(api='filemetadata', data=urllib.urlencode({'hours': ONE_MONTH}))
+            crabserver.delete(api='filemetadata', data=urlencode({'hours': ONE_MONTH}))
 #TODO return from the server a value (e.g.: ["ok"]) to see if everything is ok
-#            result = crabserver.delete(api='filemetadata', data=urllib.urlencode({'hours': ONE_MONTH}))[0]['result'][0]
+#            result = crabserver.delete(api='filemetadata', data=urlencode({'hours': ONE_MONTH}))[0]['result'][0]
 #            self.logger.info('FMDCleaner, got %s' % result)
         except HTTPException as hte:
             self.logger.error(hte.headers)

--- a/src/python/TaskWorker/Actions/RetryJob.py
+++ b/src/python/TaskWorker/Actions/RetryJob.py
@@ -134,7 +134,7 @@ class RetryJob(object):
         Need a doc string here.
         """
         job_status_name = None
-        for name, code in JOB_RETURN_CODES._asdict().iteritems():
+        for name, code in JOB_RETURN_CODES._asdict().items():
             if code == job_status:
                 job_status_name = name
         try:

--- a/src/python/TaskWorker/Actions/TaskAction.py
+++ b/src/python/TaskWorker/Actions/TaskAction.py
@@ -1,9 +1,13 @@
 import os
 import json
-import urllib
 import logging
 from base64 import b64encode
-from httplib import HTTPException
+from http.client import HTTPException
+import sys
+if sys.version_info >= (3, 0):
+    from urllib.parse import urlencode  # pylint: disable=no-name-in-module
+if sys.version_info < (3, 0):
+    from urllib import urlencode
 
 from ServerUtilities import truncateError
 
@@ -53,7 +57,7 @@ class TaskAction(object):
                      'workflow': taskname,
                      'warning': b64encode(truncWarning)}
         try:
-            self.crabserver.post(api='/task', data=urllib.urlencode(configreq))
+            self.crabserver.post(api='/task', data=urlencode(configreq))
         except HTTPException as hte:
             self.logger.error("Error uploading warning: %s", str(hte))
             self.logger.warning("Cannot add a warning to REST interface. Warning message: %s", warning)
@@ -62,7 +66,7 @@ class TaskAction(object):
     def deleteWarnings(self, userProxy, taskname):
         configreq = {'subresource': 'deletewarnings', 'workflow': taskname}
         try:
-            self.crabserver.post(api='task', data=urllib.urlencode(configreq))
+            self.crabserver.post(api='task', data=urlencode(configreq))
         except HTTPException as hte:
             self.logger.error("Error deleting warnings: %s", str(hte))
             self.logger.warning("Can not delete warnings from REST interface.")

--- a/src/python/TaskWorker/MasterWorker.py
+++ b/src/python/TaskWorker/MasterWorker.py
@@ -7,13 +7,17 @@ import os
 import shutil
 import sys
 import time
-import urllib
 import signal
 import logging
 from base64 import b64encode
 
-from httplib import HTTPException
+from http.client import HTTPException
 from MultiProcessingLog import MultiProcessingLog
+
+if sys.version_info >= (3, 0):
+    from urllib.parse import urlencode  # pylint: disable=no-name-in-module
+if sys.version_info < (3, 0):
+    from urllib import urlencode
 
 #WMcore dependencies
 from WMCore.Configuration import loadConfigurationFile
@@ -255,8 +259,8 @@ class MasterWorker(object):
 
         configreq = {'subresource': 'process', 'workername': self.config.TaskWorker.name, 'getstatus': getstatus, 'limit': limit, 'status': setstatus}
         try:
-            #self.server.post(self.restURInoAPI + '/workflowdb', data=urllib.urlencode(configreq))
-            self.crabserver.post(api='workflowdb', data=urllib.urlencode(configreq))
+            #self.server.post(self.restURInoAPI + '/workflowdb', data=urlencode(configreq))
+            self.crabserver.post(api='workflowdb', data=urlencode(configreq))
         except HTTPException as hte:
             msg = "HTTP Error during _lockWork: %s\n" % str(hte)
             msg += "HTTP Headers are %s: " % hte.headers
@@ -299,8 +303,8 @@ class MasterWorker(object):
 
         configreq = {'workflow': taskname, 'command': command, 'status': status, 'subresource': 'state'}
         try:
-            #self.server.post(self.restURInoAPI + '/workflowdb', data=urllib.urlencode(configreq))
-            self.crabserver.post(api='workflowdb', data=urllib.urlencode(configreq))
+            #self.server.post(self.restURInoAPI + '/workflowdb', data=urlencode(configreq))
+            self.crabserver.post(api='workflowdb', data=urlencode(configreq))
         except HTTPException as hte:
             msg = "HTTP Error during updateWork: %s\n" % str(hte)
             msg += "HTTP Headers are %s: " % hte.headers
@@ -354,7 +358,7 @@ class MasterWorker(object):
             warning = 'username %s banned in CRAB TaskWorker configuration' % task['tm_username']
             configreq = {'subresource': 'addwarning', 'workflow': taskname, 'warning': warning}
             try:
-                self.crabserver.post(api='task', data=urllib.urlencode(configreq))
+                self.crabserver.post(api='task', data=urlencode(configreq))
             except Exception as e:
                 self.logger.error("Error uploading warning: %s", str(e))
                 self.logger.warning("Cannot add a warning to REST interface. Warning message: %s", warning)
@@ -382,7 +386,7 @@ class MasterWorker(object):
             warning = 'command %s disabled in CRAB TaskWorker configuration' % command
             configreq = {'subresource': 'addwarning', 'workflow': taskname, 'warning': b64encode(warning)}
             try:
-                self.crabserver.post(api='task', data=urllib.urlencode(configreq))
+                self.crabserver.post(api='task', data=urlencode(configreq))
             except Exception as e:
                 self.logger.error("Error uploading warning: %s", str(e))
                 self.logger.warning("Cannot add a warning to REST interface. Warning message: %s", warning)

--- a/src/python/TaskWorker/Worker.py
+++ b/src/python/TaskWorker/Worker.py
@@ -1,15 +1,20 @@
 from __future__ import print_function
 import os
 import time
-import urllib
 import logging
 import traceback
 import multiprocessing
 from Queue import Empty
 from base64 import b64encode
 from logging import FileHandler
-from httplib import HTTPException
+from http.client import HTTPException
 from logging.handlers import TimedRotatingFileHandler
+
+import sys
+if sys.version_info >= (3, 0):
+    from urllib.parse import urlencode  # pylint: disable=no-name-in-module
+if sys.version_info < (3, 0):
+    from urllib import urlencode
 
 from RESTInteractions import CRABRest
 from TaskWorker.DataObjects.Result import Result
@@ -49,7 +54,7 @@ def failTask(taskName, crabserver, msg, log, failstatus='FAILED'):
                      'subresource': 'failure',
                      # Limit the message to 7500 chars, which means no more than 10000 once encoded. That's the limit in the REST
                      'failure': b64encode(truncMsg)}
-        crabserver.post(api='workflowdb', data = urllib.urlencode(configreq))
+        crabserver.post(api='workflowdb', data = urlencode(configreq))
         log.info("Failure message successfully uploaded to the REST")
     except HTTPException as hte:
         log.warning("Cannot upload failure message to the REST for task %s. HTTP exception headers follows:", taskName)

--- a/src/python/WMArchiveUploader.py
+++ b/src/python/WMArchiveUploader.py
@@ -11,7 +11,7 @@ import pycurl
 import signal
 import logging
 import subprocess
-from httplib import HTTPException
+from http.client import HTTPException
 from logging.handlers import TimedRotatingFileHandler
 
 from WMCore.WMException import WMException

--- a/test-old/python/CRABInterface_t/RESTFileUserTransfers_t.py
+++ b/test-old/python/CRABInterface_t/RESTFileUserTransfers_t.py
@@ -88,7 +88,7 @@ class FileTransfersTest(unittest.TestCase):
                 print(self.fileDoc)
                 self.server.put('/crabserver/dev/fileusertransfers', data=encodeRequest(self.fileDoc))
                 # if I will put the same doc twice, it should raise an error.
-                # self.server.put('/crabserver/dev/fileusertransfers', data=urllib.urlencode(self.fileDoc))
+                # self.server.put('/crabserver/dev/fileusertransfers', data=urlencode(self.fileDoc))
                 # This tasks are for the future and next calls
                 if user not in self.tasks:
                     self.tasks[user] = {'workflowName': workflowName, 'taskname': taskname, 'listOfIds': [],


### PR DESCRIPTION
Massive (sorry) set of changes for python3 compatibility.
Besides some changes like fix import of HTTPException or use of iteritems in dictionaries which are applied everywhere, the main thrust of this PR is  a version of the "things which run on sched" which works with python3. Since this work evolved over some time while other changes were pushed in master, this PR has a horrible history also after squashing. Let's take it as is

Initial tests are OK, some tasks work with this.
Known shortcomings:
1. FTS_transfers.py is still called with python, not python3, waiting for a py3 FTS client.
1. automatic splitting will most certainly fail until TaskWorker actions code is all properly ported

Incomplete list of changes:

change python to python3 when calling scripts from bash
fix import of HTTPException
use our own pycurl on sched
pick urlencode from urllib.parse
define pythonpath for pycurl in correct script
open file in wb for pickle and cleanup a bit
remove unused and failing unittests
binary files for pickle in cache_status_jel
use py3 version of rucio
define pycurl for dag_bootstrap.sh as well
consistently open defe_ info_file in PJ as text, not binary
replace all occurrences of iteritems with items
use getHaslLfn also in PostJonb and py3-ize it
add comments and better parsing of fjr_parse_results.txt
add comments and port to py3 code in cache_status_jel/parseErrorReport
