### PR TITLE
src/python/Databases support py3

### DIFF
--- a/obsolete/Databases/FileMetaDataDB/MySQL/Destroy.py
+++ b/obsolete/Databases/FileMetaDataDB/MySQL/Destroy.py
@@ -3,7 +3,6 @@ _Destroy_
 
 """
 import threading
-import string
 
 from WMCore.Database.DBCreator import DBCreator
 from Databases.FileMetaDataDB.Oracle.Create import Create
@@ -29,6 +28,6 @@ class Destroy(DBCreator):
         i = 0
         for tableName in orderedTables:
             i += 1
-            prefix = string.zfill(i, 2)
+            prefix = str(i).zfill(2)
             self.create[prefix + tableName] = "DROP TABLE %s" % tableName
 

--- a/obsolete/Databases/FileTransfersDB/MySQL/Destroy.py
+++ b/obsolete/Databases/FileTransfersDB/MySQL/Destroy.py
@@ -3,7 +3,6 @@ _Destroy_
 
 """
 import threading
-import string
 
 from WMCore.Database.DBCreator import DBCreator
 from Databases.TaskDB.Oracle.Create import Create
@@ -29,5 +28,5 @@ class Destroy(DBCreator):
         i = 0
         for tableName in orderedTables:
             i += 1
-            prefix = string.zfill(i, 2)
+            prefix = str(i).zfill(2)
             self.create[prefix + tableName] = "DROP TABLE %s" % tableName

--- a/obsolete/Databases/TaskDB/MySQL/Destroy.py
+++ b/obsolete/Databases/TaskDB/MySQL/Destroy.py
@@ -3,7 +3,6 @@ _Destroy_
 
 """
 import threading
-import string
 
 from WMCore.Database.DBCreator import DBCreator
 from Databases.TaskDB.Oracle.Create import Create
@@ -29,5 +28,5 @@ class Destroy(DBCreator):
         i = 0
         for tableName in orderedTables:
             i += 1
-            prefix = string.zfill(i, 2)
+            prefix = str(i).zfill(2)
             self.create[prefix + tableName] = "DROP TABLE %s" % tableName

--- a/src/python/Databases/FileMetaDataDB/Oracle/Destroy.py
+++ b/src/python/Databases/FileMetaDataDB/Oracle/Destroy.py
@@ -3,7 +3,6 @@ _Destroy_
 
 """
 import threading
-import string
 
 from WMCore.Database.DBCreator import DBCreator
 from Databases.FileMetaDataDB.Oracle.Create import Create
@@ -29,6 +28,6 @@ class Destroy(DBCreator):
         i = 0
         for tableName in orderedTables:
             i += 1
-            prefix = string.zfill(i, 2)
+            prefix = str(i).zfill(2)
             self.create[prefix + tableName] = "DROP TABLE %s" % tableName
 

--- a/src/python/Databases/FileTransfersDB/Oracle/Destroy.py
+++ b/src/python/Databases/FileTransfersDB/Oracle/Destroy.py
@@ -3,7 +3,6 @@ _Destroy_
 
 """
 import threading
-import string
 
 from WMCore.Database.DBCreator import DBCreator
 from Databases.TaskDB.Oracle.Create import Create
@@ -29,7 +28,7 @@ class Destroy(DBCreator):
         i = 0
         for tableName in orderedTables:
             i += 1
-            prefix = string.zfill(i, 2)
+            prefix = str(i).zfill(2)
             if tableName.endswith("_seq"):
                  self.create[prefix + tableName] = "DROP SEQUENCE %s" % tableName
             elif tableName.endswith("_trg"):

--- a/src/python/Databases/TaskDB/Oracle/Destroy.py
+++ b/src/python/Databases/TaskDB/Oracle/Destroy.py
@@ -3,7 +3,6 @@ _Destroy_
 
 """
 import threading
-import string
 
 from WMCore.Database.DBCreator import DBCreator
 from Databases.TaskDB.Oracle.Create import Create
@@ -29,7 +28,7 @@ class Destroy(DBCreator):
         i = 0
         for tableName in orderedTables:
             i += 1
-            prefix = string.zfill(i, 2)
+            prefix = str(i).zfill(2)
             if tableName.endswith("_seq"):
                  self.create[prefix + tableName] = "DROP SEQUENCE %s" % tableName
             elif tableName.endswith("_trg"):


### PR DESCRIPTION
Fixes #6827 

In python3 `zfill()` is a member of `str`, not of `import string`, as in [1].

Note that `mystr.zfill(10)` also works in py2, but "if aint broke dont fix it" and i'd rather merge this commit into `python3` branch only nonetheless.

[1]

```bash
> python3
Python 3.9.7 (default, Aug 30 2021, 00:00:00) 
[GCC 11.2.1 20210728 (Red Hat 11.2.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import string
>>> dir(string)
['Formatter', 'Template', '_ChainMap', '__all__', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__spec__', '_re', '_sentinel_dict', '_string', 'ascii_letters', 'ascii_lowercase', 'ascii_uppercase', 'capwords', 'digits', 'hexdigits', 'octdigits', 'printable', 'punctuation', 'whitespace']
>>> dir(str)
['__add__', '__class__', '__contains__', '__delattr__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__getitem__', '__getnewargs__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__iter__', '__le__', '__len__', '__lt__', '__mod__', '__mul__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__rmod__', '__rmul__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', 'capitalize', 'casefold', 'center', 'count', 'encode', 'endswith', 'expandtabs', 'find', 'format', 'format_map', 'index', 'isalnum', 'isalpha', 'isascii', 'isdecimal', 'isdigit', 'isidentifier', 'islower', 'isnumeric', 'isprintable', 'isspace', 'istitle', 'isupper', 'join', 'ljust', 'lower', 'lstrip', 'maketrans', 'partition', 'removeprefix', 'removesuffix', 'replace', 'rfind', 'rindex', 'rjust', 'rpartition', 'rsplit', 'rstrip', 'split', 'splitlines', 'startswith', 'strip', 'swapcase', 'title', 'translate', 'upper', 'zfill']
```