### PR TITLE
scr/pytohn/CRABInterface supports py3

### DIFF
--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -213,7 +213,6 @@ class DataWorkflow(object):
                             edm_outfiles    = [dbSerializer(edmoutfiles)],
                             job_type        = [jobtype],
                             arguments       = [dbSerializer(arguments)],
-                            resubmitted_jobs= [dbSerializer([])],
                             save_logs       = ['T' if savelogsflag else 'F'],
                             user_infiles    = [dbSerializer(adduserfiles)],
                             maxjobruntime   = [maxjobruntime],

--- a/src/python/CRABInterface/HTCondorDataWorkflow.py
+++ b/src/python/CRABInterface/HTCondorDataWorkflow.py
@@ -5,7 +5,7 @@ import json
 import time
 import copy
 import tarfile
-import StringIO
+import io
 import tempfile
 import calendar
 from ast import literal_eval
@@ -52,7 +52,7 @@ class HTCondorDataWorkflow(DataWorkflow):
             backend_urls['htcondorPool'] = row.collector
 
             # need to make sure to pass a simply quoted string, not a byte-array to HTCondor
-            taskName = str(workflow.decode("utf-8")) if isinstance(workflow, bytes) else workflow
+            taskName = workflow.decode("utf-8") if isinstance(workflow, bytes) else workflow
             self.logger.debug("Running condor query for task %s." % taskName)
             try:
                 locator = HTCondorLocator.HTCondorLocator(backend_urls)
@@ -421,7 +421,7 @@ class HTCondorDataWorkflow(DataWorkflow):
         curl = self.prepareCurl()
         fp = tempfile.TemporaryFile()
         curl.setopt(pycurl.WRITEFUNCTION, fp.write)
-        hbuf = StringIO.StringIO()
+        hbuf = io.BytesIO()
         curl.setopt(pycurl.HEADERFUNCTION, hbuf.write)
         try:
             self.logger.debug("Retrieving task status from schedd via http")

--- a/src/python/CRABInterface/RESTBaseAPI.py
+++ b/src/python/CRABInterface/RESTBaseAPI.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import logging
 import cherrypy
-from commands import getstatusoutput
+from subprocess import getstatusoutput
 from time import mktime, gmtime
 
 # WMCore dependecies here

--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -10,8 +10,7 @@ from base64 import b64decode
 # WMCore dependecies here
 from WMCore.REST.Server import RESTEntity, restcall
 from WMCore.REST.Error import ExecutionError, InvalidParameter
-from WMCore.REST.Validation import validate_str, validate_strlist, validate_ustr, validate_ustrlist,\
-    validate_num, validate_real
+from WMCore.REST.Validation import validate_str, validate_strlist, validate_num, validate_real
 from WMCore.Services.TagCollector.TagCollector import TagCollector
 from WMCore.Lexicon import userprocdataset, userProcDSParts, primdataset
 
@@ -349,9 +348,9 @@ class RESTUserWorkflow(RESTEntity):
             validate_num("useparent", param, safe, optional=True)
             validate_str("secondarydata", param, safe, RX_DATASET, optional=True)
             # site black/white list needs to be cast to unicode for later use in self._expandSites
-            validate_ustrlist("siteblacklist", param, safe, RX_CMSSITE)
+            validate_strlist("siteblacklist", param, safe, RX_CMSSITE)
             safe.kwargs['siteblacklist'] = self._expandSites(safe.kwargs['siteblacklist'])
-            validate_ustrlist("sitewhitelist", param, safe, RX_CMSSITE)
+            validate_strlist("sitewhitelist", param, safe, RX_CMSSITE)
             safe.kwargs['sitewhitelist'] = self._expandSites(safe.kwargs['sitewhitelist'])
             validate_str("splitalgo", param, safe, RX_SPLIT, optional=False)
             validate_num("algoargs", param, safe, optional=False)
@@ -399,7 +398,7 @@ class RESTUserWorkflow(RESTEntity):
                 param.kwargs["publishname2"] = safe.kwargs["publishname"]
 
             ## 'publishname' was already validated above in _checkPublishDataName().
-            ## Calling validate_ustr with a fake regexp to move the param to the
+            ## Calling validate_str with a fake regexp to move the param to the
             ## list of validated inputs
             validate_str("publishname2", param, safe, RX_ANYTHING, optional=True)
 
@@ -452,7 +451,7 @@ class RESTUserWorkflow(RESTEntity):
             validate_num("nonvaliddata", param, safe, optional=True)
             #if one and only one between outputDatasetTag and publishDbsUrl is set raise an error (we need both or none of them)
             # asyncdest needs to be cast to unicode for later use in self._checkASODestination
-            validate_ustr("asyncdest", param, safe, RX_CMSSITE, optional=False)
+            validate_str("asyncdest", param, safe, RX_CMSSITE, optional=False)
             self._checkASODestination(safe.kwargs['asyncdest'])
             # We no longer use this attribute, but keep it around for older client compatibility
             validate_num("blacklistT1", param, safe, optional=True)
@@ -491,14 +490,14 @@ class RESTUserWorkflow(RESTEntity):
             ## or whitelist, set it to None and DataWorkflow will use the corresponding
             ## list defined in the initial task submission. If the site black- or whitelist
             ## is equal to the string 'empty', set it to an empty list and don't call
-            ## validate_ustrlist as it would fail.
+            ## validate_strlist as it would fail.
             if 'siteblacklist' not in param.kwargs:
                 safe.kwargs['siteblacklist'] = None
             elif param.kwargs['siteblacklist'] == 'empty':
                 safe.kwargs['siteblacklist'] = []
                 del param.kwargs['siteblacklist']
             else:
-                validate_ustrlist("siteblacklist", param, safe, RX_CMSSITE)
+                validate_strlist("siteblacklist", param, safe, RX_CMSSITE)
                 safe.kwargs['siteblacklist'] = self._expandSites(safe.kwargs['siteblacklist'])
             if 'sitewhitelist' not in param.kwargs:
                 safe.kwargs['sitewhitelist'] = None
@@ -506,7 +505,7 @@ class RESTUserWorkflow(RESTEntity):
                 safe.kwargs['sitewhitelist'] = []
                 del param.kwargs['sitewhitelist']
             else:
-                validate_ustrlist("sitewhitelist", param, safe, RX_CMSSITE)
+                validate_strlist("sitewhitelist", param, safe, RX_CMSSITE)
                 safe.kwargs['sitewhitelist'] = self._expandSites(safe.kwargs['sitewhitelist'])
             validate_num("maxjobruntime", param, safe, optional=True)
             validate_num("maxmemory", param, safe, optional=True)

--- a/src/python/CRABInterface/RESTWorkerWorkflow.py
+++ b/src/python/CRABInterface/RESTWorkerWorkflow.py
@@ -1,6 +1,7 @@
 """ Interface used by the TaskWorker to ucquire tasks and change their state
 """
 # WMCore dependecies here
+from builtins import str
 from WMCore.REST.Server import RESTEntity, restcall
 from WMCore.REST.Validation import validate_str, validate_strlist, validate_num
 from WMCore.REST.Error import InvalidParameter
@@ -81,7 +82,7 @@ class RESTWorkerWorkflow(RESTEntity):
 
         if subresource is None:
             subresource = 'state'
-        if not subresource in methodmap.keys():
+        if not subresource in list(methodmap.keys()):
             raise InvalidParameter("Subresource of workflowdb has not been found")
         methodmap[subresource]['method'](*methodmap[subresource]['args'], **methodmap[subresource]['kwargs'])
         return []

--- a/src/python/CRABInterface/RESTWorkerWorkflow.py
+++ b/src/python/CRABInterface/RESTWorkerWorkflow.py
@@ -10,7 +10,7 @@ from ServerUtilities import getEpochFromDBTime
 from CRABInterface.Utilities import getDBinstance
 from CRABInterface.RESTExtensions import authz_login_valid
 from CRABInterface.Regexps import (RX_TASKNAME, RX_WORKER_NAME, RX_STATUS, RX_TEXT_FAIL, RX_SUBPOSTWORKER,
-                                  RX_SUBGETWORKER, RX_JOBID)
+                                  RX_JOBID)
 
 # external dependecies here
 from ast import literal_eval
@@ -52,7 +52,6 @@ class RESTWorkerWorkflow(RESTEntity):
             validate_str("workername", param, safe, RX_WORKER_NAME, optional=True)
             validate_str("getstatus", param, safe, RX_STATUS, optional=True)
             validate_num("limit", param, safe, optional=True)
-            validate_str("subresource", param, safe, RX_SUBGETWORKER, optional=True)
             # possible combinations to check
             # 1) workername + getstatus + limit
             # 2) subresource + subjobdef + subuser
@@ -75,7 +74,7 @@ class RESTWorkerWorkflow(RESTEntity):
                                  "failure": [failure], "tm_taskname": [workflow]}},
                   #Used in DagmanSubmitter?
                      "success": {"args": (self.Task.SetInjectedTasks_sql,), "method": self.api.modify, "kwargs": {"tm_task_status": [status],
-                                 "tm_taskname": [workflow], "clusterid": [clusterid], "resubmitted_jobs": [str(resubmittedjobs)]}},
+                                 "tm_taskname": [workflow], "clusterid": [clusterid]}},
                      "process": {"args": (self.Task.UpdateWorker_sql,), "method": self.api.modifynocheck, "kwargs": {"tw_name": [workername],
                                   "get_status": [getstatus], "limit": [limit], "set_status": [status]}},
         }
@@ -88,7 +87,7 @@ class RESTWorkerWorkflow(RESTEntity):
         return []
 
     @restcall
-    def get(self, workername, getstatus, limit, subresource):
+    def get(self, workername, getstatus, limit):
         """ Retrieve all columns for a specified task or
             tasks which are in a particular status with
             particular conditions """

--- a/src/python/CRABInterface/Utilities.py
+++ b/src/python/CRABInterface/Utilities.py
@@ -8,7 +8,7 @@ import re
 from hashlib import sha1
 import cherrypy
 import pycurl
-import StringIO
+import io
 import json
 
 from WMCore.WMFactory import WMFactory
@@ -96,8 +96,8 @@ def getCentralConfig(extconfigurl, mode):
 
     def retrieveConfig(externalLink):
 
-        hbuf = StringIO.StringIO()
-        bbuf = StringIO.StringIO()
+        hbuf = io.BytesIO()
+        bbuf = io.BytesIO()
 
         curl = pycurl.Curl()
         curl.setopt(pycurl.URL, externalLink)

--- a/src/python/Databases/FileMetaDataDB/Oracle/FileMetaData/FileMetaData.py
+++ b/src/python/Databases/FileMetaDataDB/Oracle/FileMetaData/FileMetaData.py
@@ -8,7 +8,7 @@ class GetFromTaskAndType():
         Order of parameters must be the same as it is in query GetFromTaskAndType_sql
     """
     JOBID, OUTDS, ACQERA, SWVER, INEVENTS, GLOBALTAG, PUBLISHNAME, LOCATION, TMPLOCATION, RUNLUMI, ADLER32, CKSUM, MD5, LFN, SIZE, PARENTS, STATE,\
-    CREATIONTIME, TMPLFN, TYPE, DIRECTSTAGEOUT = range(22)
+    CREATIONTIME, TMPLFN, TYPE, DIRECTSTAGEOUT = range(21)
 
 class FileMetaData(object):
     """

--- a/src/python/Databases/TaskDB/Oracle/Task/Task.py
+++ b/src/python/Databases/TaskDB/Oracle/Task/Task.py
@@ -52,7 +52,7 @@ class Task(object):
               :split_algo, :split_args, :total_units, :user_sandbox, :debug_files, :cache_url, :username, :user_dn, \
               :user_vo, :user_role, :user_group, :publish_name, :publish_groupname, :asyncdest, :dbs_url, :publish_dbs_url, \
               :publication, :outfiles, :tfile_outfiles, :edm_outfiles, :job_type, :generator, :arguments, \
-              :resubmitted_jobs, :save_logs, :user_infiles, :maxjobruntime, :numcores, :maxmemory, :priority, \
+              :save_logs, :user_infiles, :maxjobruntime, :numcores, :maxmemory, :priority, \
               :scriptexe, :scriptargs, :extrajdl, :asourl, :asodb, :events_per_lumi, :collector, :schedd_name, :dry_run, \
               :user_files, :transfer_outputs, :output_lfn, :ignore_locality, :fail_limit, :one_event_mode, :submitter_ip_addr, :ignore_global_blacklist)"
 


### PR DESCRIPTION
Fixed #6830 

#### overall information

Status: Work in progress

This PR should be merged after merging #6828 

This PR does **not** support py2.

#### details

TDL:
- [x] futurize (all changes suggested by futurize have been vetted. many have been discarded as not necessary, some have been implemented)
- [x] `pylint --py3k` (pylint does not report problems regarding py3 compatibility)
- [x] manual check of known problems that futurize and pylint do not see (`pickle`, `open()` files from disk, access to exception properties, ...)

Open questions:

- [ ] RESTTask.y: use of `str()`
- [ ] Utilities.py: use of `io.BytesIO()` . do we need to convert back yo py3 `str`?

