### PR TITLE
add CRAB logstash deployment files

### DIFF
--- a/src/script/Monitor/logstash/deployment/logstash-nodeport.yaml
+++ b/src/script/Monitor/logstash/deployment/logstash-nodeport.yaml
@@ -1,0 +1,77 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: crab3-logstash
+  namespace: crab-monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: crab3-logstash
+  template:
+    metadata:
+      labels:
+        app: crab3-logstash
+    spec:
+      containers:
+      - image: docker.elastic.co/logstash/logstash:7.4.1
+        name: crab3-logstash
+        env:
+        - name: LS_JAVA_OPTS #added 210930
+          value: "-Xms2g -Xmx2g" #added 210930
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: "400m"
+          limits:
+            memory: 4Gi
+            cpu: "2000m"
+        ports:
+        - name: logstash
+          containerPort: 5044
+          protocol: TCP
+        volumeMounts:
+        - name: config
+          mountPath: /usr/share/logstash/config/logstash.yml
+          subPath: logstash.yml
+          readOnly: true
+        - name: pipeline
+          mountPath: /usr/share/logstash/pipeline/
+        command:
+        - logstash
+      volumes:
+      - name: pipeline
+        configMap:
+          name: crab3-logstash
+          items:
+          - key: crabtaskworker.conf
+            path: crabtaskworker.conf
+      - name: config
+        configMap:
+          name: logstash-config
+          items:
+          - key: logstash.yml
+            path: logstash.yml
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: crab3-logstash
+  namespace: crab-monitoring
+  labels:
+    app: crab3-logstash
+spec:
+  type: NodePort
+  selector:
+    app: crab3-logstash
+  ports:
+  - protocol: TCP
+    port: 5044
+    targetPort: 5044
+    nodePort: 30102
+    name: filebeat
+  - protocol: TCP
+    port: 9600
+    targetPort: 9600
+    name: logstash

--- a/src/script/Monitor/logstash/deployment/logstash.yml
+++ b/src/script/Monitor/logstash/deployment/logstash.yml
@@ -1,0 +1,6 @@
+http.host: "0.0.0.0"
+path.config: /usr/share/logstash/pipeline
+# disable connection to ES
+xpack.monitoring.enabled: false
+pipeline.workers: 8
+pipeline.batch.size: 256


### PR DESCRIPTION
adding CRAB k8s logstash deployment files. documentation how to use CRAB k8s cluster for logstash deployment can be found here: https://twiki.cern.ch/twiki/bin/view/CMSPublic/CRABlogstash