### PR TITLE
[logstash] add acquired_files_status filter for publisher

### DIFF
--- a/src/script/Monitor/logstash/crabtaskworker.conf
+++ b/src/script/Monitor/logstash/crabtaskworker.conf
@@ -23,7 +23,6 @@ filter{
       }
 
 
-###BELOW
   } else if [message] =~ /.*PUBSTART.*/ {
       grok{
         match => {
@@ -33,10 +32,8 @@ filter{
         add_field => {"log_type" => "publisher_config_data"}
         overwrite => ["message"]
       }
-###END
 
 
-###BELOW
   } else if [message] =~ /.*TWSTART.*/ {
       grok{
         match => {
@@ -46,7 +43,6 @@ filter{
         add_field => {"log_type" => "tw_config_data"}
         overwrite => ["message"]
       }
-###END
 
 
   } else if [message] =~ /.*Starting.*at.*on.*/ {
@@ -89,6 +85,8 @@ filter{
         overwrite => ["message"]
       }
 
+  # This filter is currently used for production publisher.
+  # after we deploy preprod to prod, this filter can be dropped
   } else if [message] =~ /.*DEBUG:master.*/ {
       grok{
         match => {
@@ -98,6 +96,18 @@ filter{
         add_field => {"log_type" => "acquired_files"}
         overwrite => ["message"]
       }
+
+  # this filter mathces changes in #6861, which is already in preprod and dev
+  } else if [message] =~ /.*acquired_files.*/ {
+      grok{
+        match => {
+          # 2021-12-03 20:13:59,965:DEBUG:PublisherMaster,413:acquired_files:   OK    89 : 211203_174945:cmsbot_crab_20211203_184942
+          "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:%{NOTSPACE:logMsg}:PublisherMaster,%{INT}:acquired_files:%{SPACE}%{NOTSPACE:acquiredFilesStatus}%{SPACE}%{INT:acquiredFiles}%{SPACE}:%{SPACE}%{NOTSPACE:taskName}"
+        }
+        add_field => {"log_type" => "acquired_files_status"}
+        overwrite => ["message"]
+      }
+
 
   } else if [message] =~ /.*Finished.*object at .*/ {
       grok{
@@ -146,11 +156,8 @@ filter{
             event.remove("tw_json_data")
         '
          }
-   }	
+   }
 }
-
-
-
 
 output {
   if [log_type] == "work_on_task_completed" {
@@ -196,7 +203,6 @@ output {
    }
 
 
-#######
   if [log_type] == "publisher_config_data" {
     http {
         http_method => post
@@ -206,10 +212,8 @@ output {
         message => '{"hostname": "%{hostname}", "rec_timestamp":"%{rec_timestamp}", "log_file": "%{log_file}", "producer": "crab", "type": "publisher", "timestamp":"%{timestamp}", "producer_time":"%{producer_time}", "log_type":"%{log_type}", "logMsg":"%{logMsg}", "max_slaves":"%{max_slaves}", "dryRun":"%{dryRun}", "asoworker":"%{asoworker}", "DBShost":"%{DBShost}", "instance":"%{instance}", "version":"%{version}"}'
      }
    }
-#######
 
 
-#######
   if [log_type] == "tw_config_data" {
     http {
         http_method => post
@@ -219,7 +223,6 @@ output {
         message => '{"hostname": "%{hostname}", "rec_timestamp":"%{rec_timestamp}", "log_file": "%{log_file}", "producer": "crab", "type": "crabtaskworker", "timestamp":"%{timestamp}", "producer_time":"%{producer_time}", "log_type":"%{log_type}", "logMsg":"%{logMsg}", "restHost":"%{restHost}", "name":"%{name}", "DBSHostName":"%{DBSHostName}", "instance":"%{instance}", "version":"%{version}", "dbInstance":"%{dbInstance}", "nslaves":"%{nslaves}"}'
      }
    }
-#######
 
 
   if [log_type] == "publication_error" {
@@ -232,7 +235,8 @@ output {
      }
    }
 
-
+  # This filter is currently used for production publisher.
+  # after we deploy preprod to prod, this filter can be dropped
   if [log_type] == "acquired_files" {
     http {
         http_method => post
@@ -243,6 +247,16 @@ output {
      }
    }
 
+  # this filter mathces changes in #6861, which is already in preprod and dev
+  if [log_type] == "acquired_files_status" {
+    http {
+        http_method => post
+        url => "http://monit-logs.cern.ch:10012/"
+        content_type => "application/json; charset=UTF-8"
+        format => "message"
+        message => '{"hostname": "%{hostname}", "rec_timestamp":"%{rec_timestamp}", "log_file": "%{log_file}", "producer": "crab", "type": "publisher", "timestamp":"%{timestamp}", "producer_time":"%{producer_time}", "log_type":"%{log_type}", "logMsg":"%{logMsg}", "acquiredFiles":"%{acquiredFiles}", "taskName":"%{taskName}","acquiredFilesStatus":"%{acquiredFilesStatus}"  }'
+     }
+   }
 
   if [log_type] == "action_on_task_finished" {
     http {


### PR DESCRIPTION
#### Status

ready to merge.

#### Description

This PR adds the filter `acquired_files_status` to the logstash configuration that matches a new log messaeg format introduced by #6861.

This filter has been deployed to the crab logstash k8s cluster this morning and it has parsed logs coming from the preprod Publisher, which is running with #6861. The log mathces are visible in [kibana](https://monit-timber.cern.ch/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15h,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),exists:(field:data.acquiredFilesStatus),meta:(alias:!n,disabled:!f,index:'79556f50-3329-11eb-aa97-f3b963ed973a',key:data.acquiredFilesStatus,negate:!f,type:exists,value:exists))),index:'79556f50-3329-11eb-aa97-f3b963ed973a',interval:auto,query:(language:kuery,query:''),sort:!(metadata.timestamp,desc))) , so this new filter is doing its job.