### PR TITLE
force 'runs' and 'lumis' in tm_split_args to be unicode with py3 REST

### DIFF
--- a/src/python/CRABInterface/RESTWorkerWorkflow.py
+++ b/src/python/CRABInterface/RESTWorkerWorkflow.py
@@ -133,6 +133,11 @@ def fixupTask(task):
             if isinstance(value, bytes):
                 result[field][idx] = value.decode("utf8")
 
+    # py3 crabserver compatible with tasks submitted with py2 crabserver
+    for arg in ('lumis', 'runs'):
+        for idx, val in enumerate(result['tm_split_args'].get(arg)):
+            result['tm_split_args'][arg][idx] = decodeBytesToUnicode(val)
+
     #convert tm_arguments to the desired values
     extraargs = result['tm_arguments']
     result['resubmit_publication'] = extraargs['resubmit_publication'] if 'resubmit_publication' in extraargs else None


### PR DESCRIPTION
Related to #6830 

#### status

tested on cmsweb test1 in last couple of days, ready to merge

#### descriptions

This PR fixes the first problem that we found when passing to the TW via a py3 rest interface a task that was submitted via a py2 rest interface. The only problem that we found so far and that we address in this PR is:

- tm_split_args: convert to unicode the values in the lists: 'lumis' and 'runs'

