### PR TITLE
crabserver py3 - change version of wmcore to tag to private repo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@
 # Format:
 # Dependency==version          
 
-wmcver==1.5.5
+wmcver==py3.211209


### PR DESCRIPTION
#### status

ready to merge.

Plan:
- merge https://github.com/cms-sw/cmsdist/pull/7496
- merge this PR
- make a new release/tag `py3.211209patch1` in dmwm/CRABServer so that jenkins will build a crabserver image with the patched WMCore from our private repo inside.

#### description

Since we want to build crabserver via jenkins but with changes to WMCore that have not been merged yet, since jenkins uses the WMCore version in `requirements.txt` to replace the value we specify in the specfile, we need to change the put in requirements the tag to my private repo: https://github.com/mapellidario/WMCore/releases/tag/py3.211209

