### PR TITLE
TW - remove Logger and ProcInfo from setup.py and from bin/htcondor_make_runtime.sh

### DIFF
--- a/bin/htcondor_make_runtime.sh
+++ b/bin/htcondor_make_runtime.sh
@@ -63,7 +63,7 @@ if [[ "x$RPM_RELEASE" != "x" ]]; then
 
     mkdir -p bin
     cp -r $ORIGDIR/scripts/{TweakPSet.py,CMSRunAnalysis.py,task_process} .
-    cp $ORIGDIR/src/python/{Logger.py,ProcInfo.py,ServerUtilities.py,RucioUtils.py,CMSGroupMapper.py,RESTInteractions.py} .
+    cp $ORIGDIR/src/python/{ServerUtilities.py,RucioUtils.py,CMSGroupMapper.py,RESTInteractions.py} .
 
 else
     # building runtime tarballs from development area or GH
@@ -100,12 +100,12 @@ else
 
     mkdir -p bin
     cp -r $CRABSERVER_PATH/scripts/{TweakPSet.py,CMSRunAnalysis.py,task_process} .
-    cp $CRABSERVER_PATH/src/python/{Logger.py,ProcInfo.py,ServerUtilities.py,RucioUtils.py,CMSGroupMapper.py,RESTInteractions.py} .
+    cp $CRABSERVER_PATH/src/python/{ServerUtilities.py,RucioUtils.py,CMSGroupMapper.py,RESTInteractions.py} .
 fi
 
 pwd
 echo "Making TaskManagerRun tarball"
-tar zcf $ORIGDIR/TaskManagerRun-$CRAB3_VERSION.tar.gz CRAB3.zip TweakPSet.py CMSRunAnalysis.py task_process Logger.py ProcInfo.py ServerUtilities.py RucioUtils.py CMSGroupMapper.py RESTInteractions.py || exit 4
+tar zcf $ORIGDIR/TaskManagerRun-$CRAB3_VERSION.tar.gz CRAB3.zip TweakPSet.py CMSRunAnalysis.py task_process ServerUtilities.py RucioUtils.py CMSGroupMapper.py RESTInteractions.py || exit 4
 echo "Making CMSRunAnalysis tarball"
-tar zcf $ORIGDIR/CMSRunAnalysis-$CRAB3_VERSION.tar.gz WMCore.zip TweakPSet.py CMSRunAnalysis.py Logger.py ProcInfo.py ServerUtilities.py CMSGroupMapper.py RESTInteractions.py || exit 4
+tar zcf $ORIGDIR/CMSRunAnalysis-$CRAB3_VERSION.tar.gz WMCore.zip TweakPSet.py CMSRunAnalysis.py ServerUtilities.py CMSGroupMapper.py RESTInteractions.py || exit 4
 popd

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@
 # Format:
 # Dependency==version          
 
-wmcver==py3.211214
+wmcver==py3.211214patch1

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ systems = \
     'TaskWorker':
     {
         'py_modules': ['RESTInteractions',
-                       'apmon', 'Logger', 'ProcInfo',
+                       'apmon',
                        'CRABQuality', 'HTCondorUtils', 'HTCondorLocator',
                        'ServerUtilities', 'MultiProcessingLog', 'CMSGroupMapper',
                        'RucioUtils', 'cache_status'],

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ systems = \
     'TaskWorker':
     {
         'py_modules': ['RESTInteractions',
-                       'apmon',
                        'CRABQuality', 'HTCondorUtils', 'HTCondorLocator',
                        'ServerUtilities', 'MultiProcessingLog', 'CMSGroupMapper',
                        'RucioUtils', 'cache_status'],


### PR DESCRIPTION
This PR is a followup to https://github.com/dmwm/CRABServer/pull/6913, and aims at fixing the jenkins [build](https://cmssdt.cern.ch/dmwm-jenkins/job/CRABServer_BuildOnRelease/274/consoleFull).

Is this enough? Do you think we need other changes?