### PR TITLE
setup.py - remove RESTInteractions from CRABClient build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ systems = \
 {
     'CRABClient': #Will be used if we moved the CRABClient repository
     {
-        'py_modules': ['RESTInteractions', 'ServerUtilities'],
+        'py_modules': ['ServerUtilities'],
         'python': [],
     },
     'CRABInterface':


### PR DESCRIPTION
In CRABClient we are no longer taking `RESTInteractions` from CRABServer, we can change the setup.py

fyi: @ddaina