### PR TITLE
[py3] apply py3-modernization changes to whole dmwm/CRABServer

### DIFF
--- a/bin/logon_myproxy_openssl.py
+++ b/bin/logon_myproxy_openssl.py
@@ -18,5 +18,5 @@ defaultDelegation = {'logger': logger,
                      'server_cert': sys.argv[3],}
 timeleftthreshold = 60 * 60 * 24
 mypclient = SimpleMyProxy(defaultDelegation)
-userproxy = mypclient.logonRenewMyProxy(username=sha1(sys.argv[4]+userdn).hexdigest(), myproxyserver=myproxyserver, myproxyport=7512)
+userproxy = mypclient.logonRenewMyProxy(username=sha1((sys.argv[4]+userdn).encode("utf8")).hexdigest(), myproxyserver=myproxyserver, myproxyport=7512)
 print ("Proxy Retrieved with len ", len(userproxy))

--- a/scripts/CMSRunAnalysis.py
+++ b/scripts/CMSRunAnalysis.py
@@ -742,7 +742,7 @@ if __name__ == "__main__":
         print("== Execution site from site-local-config.xml: %s" % slCfg.siteName)
         with open('jobReport.json', 'w') as of:
             json.dump(rep, of)
-        with open('jobReportExtract.pickle', 'w') as of:
+        with open('jobReportExtract.pickle', 'wb') as of:
             pickle.dump(rep, of)
         print("==== Report file creation FINISHED at %s ====" % time.asctime(time.gmtime()))
     except FwkJobReportException as FJRex:

--- a/src/python/CRABInterface/Utilities.py
+++ b/src/python/CRABInterface/Utilities.py
@@ -18,6 +18,8 @@ from WMCore.Credential.SimpleMyProxy import SimpleMyProxy, MyProxyException
 from WMCore.Credential.Proxy import Proxy
 from WMCore.Services.pycurl_manager import ResponseHeader
 
+from Utils.Utilities import encodeUnicodeToBytes
+
 from CRABInterface.Regexps import RX_CERT
 """
 The module contains some utility functions used by the various modules of the CRAB REST interface
@@ -198,7 +200,7 @@ def retrieveUserCert(func):
                              'server_cert': serverCert,}
         mypclient = SimpleMyProxy(defaultDelegation)
         userproxy = None
-        userhash  = sha1(kwargs['userdn']).hexdigest()
+        userhash  = sha1(encodeUnicodeToBytes(kwargs['userdn'])).hexdigest()
         if serverDN:
             try:
                 userproxy = mypclient.logonRenewMyProxy(username=userhash, myproxyserver=myproxyserver, myproxyport=7512)

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -601,6 +601,8 @@ class DagmanCreator(TaskAction):
                 localOutputFiles.append("%s=%s" % (origFile, fileName))
             remoteOutputFilesStr = " ".join(remoteOutputFiles)
             localOutputFiles = ", ".join(localOutputFiles)
+            # no need to use // in the next line, thanks to integer formatting with `%d`
+            # see: https://docs.python.org/3/library/string.html#formatstrings
             counter = "%04d" % (i / 1000)
             tempDest = os.path.join(temp_dest, counter)
             directDest = os.path.join(dest, counter)

--- a/src/python/TaskWorker/Actions/DagmanResubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanResubmitter.py
@@ -87,19 +87,9 @@ class DagmanResubmitter(TaskAction):
         overwrite = False
         for taskparam in params.values():
             if ('resubmit_'+taskparam in task) and task['resubmit_'+taskparam] != None:
-                # In case resubmission parameters contain a list of unicode strings,
-                # convert it to a list of ascii strings because of HTCondor unicode
-                # incompatibility.
-                # Note that unicode strings that are not in a list are not handled,
-                # but so far they don't exist in this part of the code.
+                # py3: we can revert changes coming from #5317
                 if isinstance(task['resubmit_'+taskparam], list):
-                    nonUnicodeList = []
-                    for p in task['resubmit_'+taskparam]:
-                        if isinstance(p, unicode):
-                            nonUnicodeList.append(p.encode('ascii', 'ignore'))
-                        else:
-                            nonUnicodeList.append(p)
-                    ad[taskparam] = nonUnicodeList
+                    ad[taskparam] = task['resubmit_'+taskparam]
                 if taskparam != 'jobids':
                     overwrite = True
 

--- a/src/python/TaskWorker/Actions/DryRunUploader.py
+++ b/src/python/TaskWorker/Actions/DryRunUploader.py
@@ -136,5 +136,5 @@ class SplittingSummary(object):
                             'avg_files': sum(self.filesPerJob)/float(len(self.filesPerJob)),
                             'min_files': min(self.filesPerJob)})
 
-        with open(outname, 'wb') as f:
+        with open(outname, 'w') as f:
             json.dump(summary, f)

--- a/src/python/TaskWorker/Actions/MyProxyLogon.py
+++ b/src/python/TaskWorker/Actions/MyProxyLogon.py
@@ -51,8 +51,8 @@ class MyProxyLogon(TaskAction):
             self.logger.error("===========PROXY ERROR END   ==========================")
             raise TaskWorkerException(errmsg)
 
-        hoursleft = timeleft/3600
-        minutesleft = (timeleft%3600)/60
+        hoursleft = timeleft // 3600
+        minutesleft = (timeleft % 3600) // 60
         self.logger.info('retrieved proxy lifetime in h:m: %d:%d', hoursleft, minutesleft)
         return (userproxy, usergroups)
 

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -2705,7 +2705,7 @@ class PostJob():
                 self.logger.warning("       -----> Failed to set job ClassAd attributes -----")
                 maxSleep = 2*counter -1
                 self.logger.warning("Sleeping for %d minute at most...", maxSleep)
-                time.sleep(60 * random.randint(2*(counter/3), maxSleep+1))
+                time.sleep(60 * random.randint(2*(counter//3), maxSleep+1))
             else:
                 self.logger.error("Failed to set job ClassAd attributes for %d times, will not retry. Dashboard may report stale job status/exit-code.", limit)
 

--- a/src/python/TaskWorker/Actions/Recurring/BanDestinationSites.py
+++ b/src/python/TaskWorker/Actions/Recurring/BanDestinationSites.py
@@ -3,7 +3,7 @@ import os
 import sys
 import json
 import shutil
-import urllib
+import urllib.request
 import logging
 import traceback
 

--- a/src/python/TaskWorker/Actions/Recurring/FMDCleaner.py
+++ b/src/python/TaskWorker/Actions/Recurring/FMDCleaner.py
@@ -5,7 +5,6 @@ via periodical partition dropping, but is kept as reference of how to use
 the filemetadata delete API
 """
 import sys
-import urllib
 import logging
 from http.client import HTTPException
 

--- a/src/python/TaskWorker/Actions/Recurring/GenerateXML.py
+++ b/src/python/TaskWorker/Actions/Recurring/GenerateXML.py
@@ -1,11 +1,7 @@
 # report health of TaskWorker to SLS
 import os
 import sys
-import time
-import json
-import urllib
 import logging
-import traceback
 import subprocess
 from datetime import datetime
 from TaskWorker.Actions.Recurring.BaseRecurringAction import BaseRecurringAction

--- a/src/python/TaskWorker/Actions/RetryJob.py
+++ b/src/python/TaskWorker/Actions/RetryJob.py
@@ -219,7 +219,7 @@ class RetryJob(object):
         """
         # If job was killed on the worker node, we probably don't have a FJR.
         if self.ad.get("RemoveReason", "").startswith("Removed due to memory use"):
-            job_rss = int(self.ad.get("ResidentSetSize","0"))/1000
+            job_rss = int(self.ad.get("ResidentSetSize","0")) // 1000
             exitMsg = "Job killed by HTCondor due to excessive memory use"
             exitMsg += " (RSS=%d MB)." % job_rss
             exitMsg += " Will not retry it." 

--- a/src/python/TaskWorker/Actions/Splitter.py
+++ b/src/python/TaskWorker/Actions/Splitter.py
@@ -43,7 +43,7 @@ class Splitter(TaskAction):
                 splitparam['files_per_job'] = (len(data.getFiles()) + numProbes - 1) // numProbes
         elif kwargs['task']['tm_job_type'] == 'PrivateMC':
             # sanity check
-            nJobs = kwargs['task']['tm_totalunits'] / splitparam['events_per_job']
+            nJobs = kwargs['task']['tm_totalunits'] // splitparam['events_per_job']
             if nJobs > maxJobs:
                 raise TaskWorkerException(
                     "Your task would generate %s jobs. The maximum number of jobs in each task is %s" %

--- a/src/python/TaskWorker/Actions/StageoutCheck.py
+++ b/src/python/TaskWorker/Actions/StageoutCheck.py
@@ -5,7 +5,7 @@ from TaskWorker.Actions.TaskAction import TaskAction
 from TaskWorker.WorkerExceptions import TaskWorkerException
 from ServerUtilities import isFailurePermanent
 from ServerUtilities import getCheckWriteCommand, createDummyFile
-from ServerUtilities import removeDummyFile, executeCommand
+from ServerUtilities import removeDummyFile, execute_command
 from RucioUtils import getWritePFN
 
 class StageoutCheck(TaskAction):
@@ -30,7 +30,7 @@ class StageoutCheck(TaskAction):
         Return 0 otherwise
         """
         self.logger.info("Executing command: %s ", Cmd)
-        out, err, exitcode = executeCommand(Cmd)
+        out, err, exitcode = execute_command(Cmd)
         if exitcode != 0:
             isPermanent, failure, dummyExitCode = isFailurePermanent(err)
             if isPermanent:

--- a/src/python/TaskWorker/TaskManagerBootstrap.py
+++ b/src/python/TaskWorker/TaskManagerBootstrap.py
@@ -36,7 +36,7 @@ def bootstrap():
     print("..done")
     in_args = []
     if infile != "None":
-        with open(infile, "r") as fd:
+        with open(infile, "rb") as fd:
             in_args = pickle.load(fd)
 
     config = Configuration.Configuration()
@@ -75,7 +75,7 @@ def bootstrap():
     results = task.execute(in_args, task=ad).result
 
     print(results)
-    with open(outfile, "w") as fd:
+    with open(outfile, "wb") as fd:
         pickle.dump(results, fd)
 
     return 0


### PR DESCRIPTION
Fixes #6920 
Fixes #6918 

#### status

Tests look good and I think we can merge this

testing in preprod with the following configuration

- crabserver.spec: 
  - removed dbs client, using this repo for the specfile https://github.com/cms-sw/cmsdist/compare/comp_gcc630...mapellidario:comp_gcc630-crabserver_nodbs
  - tag mapellidario/CRABServer/py3.211221.dario
  - tag mapellidario/WMCore/py3.211221.dario
  - image: registry.cern.ch/cmsweb/crabserver:py3.211221.dario
- taskworker and publisher_schedd:
  - tag mapellidario/CRABServer/py3.211221.dario
  - tag dmwm/WMCore/1.5.7.pre3
  - image: mapellidario/crabtaskworker:py3.211221.dario
  - notes: included latest dbs-client https://github.com/cms-sw/cmsdist/pull/7524#issuecomment-997716047


successfull tests:

- [x] simple submission: works. example `211217_185159:dmapelli_crab_20211217_195156`

- [x] https://cmssdt.cern.ch/dmwm-jenkins/job/CRABServer_ExecuteTests/494/
  - [x] [211220_173125:cmsbot_crab_20211220_183123](https://monit-grafana.cern.ch/d/cmsTMDetail/cms-task-monitoring-task-view?orgId=11&var-user=cmsbot&var-task=211220_173125:cmsbot_crab_20211220_183123&from=1640017885000&to=now&var-site=All&var-schedd=059&var-cmsUserId=cms283&var-current_url=https:%2F%2Fmonit-grafana.cern.ch%2Fd%2FcmsTMDetail%2Fcms_task_monitoring&var-task_str=cmsbot_crab_20211220_183123&var-status=All&var-crabid=All&var-rest_host=https:%2F%2Fcmsweb.cern.ch:8443) some tasks failed with 50664 (hit max wall time). can/should we consider this as a successfull test for the TW? at least the resubmission https://github.com/dmwm/CRABServer/issues/6918 now works
- [x] https://cmssdt.cern.ch/dmwm-jenkins/job/CRABServer_ExecuteTests/495/ 
  - [x] [211220_190222:cmsbot_crab_20211220_200220](https://monit-grafana.cern.ch/d/cmsTMDetail/cms-task-monitoring-task-view?orgId=11&from=now-30d&to=now&var-site=All&var-user=cmsbot&var-task=211220_190222:cmsbot_crab_20211220_200220&var-schedd=059&var-cmsUserId=cms283&var-current_url=https:%2F%2Fmonit-grafana.cern.ch%2Fd%2FcmsTMDetail%2Fcms_task_monitoring&var-task_str=cmsbot_crab_20211220_200220&var-status=All&var-crabid=All&var-rest_host=https:%2F%2Fcmsweb.cern.ch:8443) as above, a single job failed with 50664 

known problems

- [x] (1) if you run out of space at the destination site, the submission fails but the error reporting procedure breaks.
  - https://github.com/dmwm/CRABServer/pull/6921#issuecomment-996972047
  - solved by using `execute_command`, as suggested by Stefano: https://github.com/dmwm/CRABServer/pull/6921#issuecomment-997047751
- [x] every now and then, all TW subprocesses die and do not process new tasks
  - https://github.com/dmwm/CRABServer/pull/6921#issuecomment-997858345
  - seems to have been fixed by #6927 

#### description 

##### Overview

- [x] apply changes suggested from futurize
- [x] look manually for potential issues, based on past experience
  - [x] pickle. load and dump from `bytes` streams
  - [x] json. load and dump from `str` streams 
  - [x] `hashlib.sha1(input)`: `input` must be `bytes`
  - [x] `base64` encoding and decoding. input is bytes, output is bytes. we need to convert these from/into `str`
  - [x] `io.BytesIO()` should be used as a `bytes` stream
  - [x] any other idea? 

##### details

I run `futurize` on the whole `dmwm/CRABServer` repository. The changes that he suggested are collected in this branch: https://github.com/dmwm/CRABServer/compare/e74b065...mapellidario:python3-sugggestions-futurize

`futurize` suggested changes aims at keeping both py2 and py3 compatibility, but we need to be only py3 compatible, therefore I applied only the relevant changes.

Quick overview:

- `src/python/TaskWorker/Actions/DagmanResubmitter.py`: I think we can safely revert the changes contained in this commit. Am I wrong?
- updated how `urllib` is imported, to be compatible with urllib py3 api.
-  use `//` instead of `/` when we want the division to only return the integer part of the float result, as in py2. I did not apply this change when it was obvious that the result of the division would have been only for logging purposes.

Then I run a series of manual checks, consisting in grepping a series of things that we know have cause troubles in the past, such as `pickle.load`, `pickle.dump`, `sha1(`, ... If you have any other idea, please suggest it! :)

#### open questions

- [x] is it a problem that we do not close files after reading them in these files?  [STEFANO: apparently not, but surely closing is good, even if unrelated to py3]
  - https://github.com/dmwm/CRABServer/blob/0b1c2ec6bbe34f81460403bc7b604a5085c3f4ca/scripts/cmscp.py#L913 
  - https://github.com/dmwm/CRABServer/blob/0b1c2ec6bbe34f81460403bc7b604a5085c3f4ca/src/python/CMSGroupMapper.py#L78
  - moved discussion to: #6934
 - [x] input in `hashlib.sha1(input)` must be bytes. We did not force it to be `bytes` in `src/python/CRABInterface/Utilities.py` why haven't we noticed? [STEFANO: becasue that function is never used and ripe for another cleanup, unrelated to py3]
    - https://github.com/dmwm/CRABServer/blob/e74b065b57906ddbe53f399097ff59a6e8b245e5/src/python/CRABInterface/Utilities.py#L201
    - moved discussion to: #6935