### PR TITLE
remove references to asourl/asodb in TW

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -97,8 +97,6 @@ CRAB_Id = $(count)
 +CRAB_OutTempLFNDir = "%(temp_dest)s"
 +CRAB_OutLFNDir = "%(output_dest)s"
 +CRAB_oneEventMode = %(oneEventMode)s
-+CRAB_ASOURL = %(tm_asourl)s
-+CRAB_ASODB = %(tm_asodb)s
 +CRAB_PrimaryDataset = %(primarydataset)s
 +TaskType = "Job"
 accounting_group = %(accounting_group)s
@@ -284,7 +282,7 @@ def transform_strings(data):
     for var in 'workflow', 'jobtype', 'jobsw', 'jobarch', 'inputdata', 'primarydataset', 'splitalgo', 'algoargs', \
                'cachefilename', 'cacheurl', 'userhn', 'publishname', 'asyncdest', 'dbsurl', 'publishdbsurl', \
                'userdn', 'requestname', 'oneEventMode', 'tm_user_vo', 'tm_user_role', 'tm_user_group', \
-               'tm_maxmemory', 'tm_numcores', 'tm_maxjobruntime', 'tm_priority', 'tm_asourl', 'tm_asodb', \
+               'tm_maxmemory', 'tm_numcores', 'tm_maxjobruntime', 'tm_priority', \
                'stageoutpolicy', 'taskType', 'worker_name', 'cms_wmtool', 'cms_tasktype', 'cms_type', \
                'desired_arch', 'resthost', 'dbinstance', 'submitter_ip_addr', \
                'task_lifetime_days', 'task_endtime', 'maxproberuntime', 'maxtailruntime':
@@ -465,9 +463,6 @@ class DagmanCreator(TaskAction):
         info['tfileoutfiles'] = task['tm_tfile_outfiles']
         info['edmoutfiles'] = task['tm_edm_outfiles']
         info['oneEventMode'] = 1 if info['tm_one_event_mode'] == 'T' else 0
-        info['ASOURL'] = task['tm_asourl']
-        asodb = task.get('tm_asodb', 'asynctransfer') or 'asynctransfer'
-        info['ASODB'] = asodb
         info['taskType'] = self.getDashboardTaskType(task)
         info['worker_name'] = getattr(self.config.TaskWorker, 'name', 'unknown')
         info['retry_aso'] = 1 if getattr(self.config.TaskWorker, 'retryOnASOFailures', True) else 0

--- a/src/python/TaskWorker/Actions/DagmanSubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanSubmitter.py
@@ -86,8 +86,6 @@ SUBMIT_INFO = [ \
     ('MaxWallTimeMinsProbe', 'maxproberuntime'),
     ('MaxWallTimeMinsTail', 'maxtailruntime'),
     ('JobPrio', 'tm_priority'),
-    ('CRAB_ASOURL', 'tm_asourl'),
-    ('CRAB_ASODB', 'tm_asodb'),
     ('CRAB_FailedNodeLimit', 'faillimit'),
     ('CRAB_DashboardTaskType', 'taskType'),
     ('CRAB_MaxIdle', 'maxidle'),

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -311,14 +311,11 @@ class ASOServerJob(object):
         self.aso_start_timestamp = aso_start_timestamp
         proxy = os.environ.get('X509_USER_PROXY', None)
         self.proxy = proxy
-        self.aso_db_url = self.job_ad['CRAB_ASOURL']
         self.rest_host = rest_host
         self.db_instance = db_instance
         self.rest_url = rest_host + '/crabserver/' + db_instance + '/'  # used in logging
         self.found_doc_in_db = False
         try:
-            if first_pj_execution():
-                self.logger.info("Will use ASO server at %s." % (self.aso_db_url))
             self.crabserver = CRABRest(self.rest_host, proxy, proxy, retry=2, userAgent='CRABSchedd')
             self.crabserver.setDbInstance(self.db_instance)
         except Exception as ex:
@@ -2481,8 +2478,6 @@ class PostJob():
         """
         required_job_ad_attrs = {'CRAB_UserRole': {'allowUndefined': True},
                                  'CRAB_UserGroup': {'allowUndefined': True},
-                                 'CRAB_ASOURL': {'allowUndefined': False},
-                                 'CRAB_ASODB': {'allowUndefined': True},
                                  'CRAB_AsyncDest': {'allowUndefined': False},
                                  'CRAB_DBSURL': {'allowUndefined': False},
                                  'DESIRED_CMSDataset': {'allowUndefined': True},


### PR DESCRIPTION
stop using asodb/asourl (in various spellings) i.e. things from asoconfig key in https://gitlab.cern.ch/crab3/CRAB3ServerConfig/-/blob/master/cmsweb-rest-config.json in TaskWorker.
Should be backward compatible and can go in immediately
