### PR TITLE
REST-py3 backward compatibile with publisher-py2

### DIFF
--- a/src/python/CRABInterface/DataFileMetadata.py
+++ b/src/python/CRABInterface/DataFileMetadata.py
@@ -7,6 +7,8 @@ import json
 import logging
 from ast import literal_eval
 
+from Utils.Utilities import decodeBytesToUnicode
+
 from CRABInterface.Utilities import getDBinstance
 
 class DataFileMetadata(object):
@@ -33,7 +35,7 @@ class DataFileMetadata(object):
         for row in rows:
             row = self.FileMetaData.GetFromTaskAndType_tuple(*row)
             if lfn==[] or row.lfn in lfn:
-                yield json.dumps({
+                filedict = {
                     'taskname': taskname,
                     'filetype': filetype,
                     'jobid': row.jobid,
@@ -53,9 +55,49 @@ class DataFileMetadata(object):
                      'filesize': row.filesize,
                      'parents': literal_eval(row.parents.read()),
                      'state': row.state,
-                     'created': str(row.parents),
+                     'created': literal_eval(row.parents.read()),  # postpone conversion to str
                      'tmplfn': row.tmplfn
-            })
+                }
+                ## temporary changes for making REST py3 compatible with Publisher py2 - start
+                ## this block of code can be removed after we complete the 
+                ## deployment in production of the services running in python3
+                # we aim at replacing with unicode all the bytes from such a dictionary:
+                # {'taskname': '220113_142727:dmapelli_crab_20220113_152722', 
+                # 'filetype': 'EDM', 
+                # 'jobid': '7', 
+                # 'outdataset': '/GenericTTbar/dmapelli-[...]-94ba0e06145abd65ccb1d21786dc7e1d/USER', 
+                # 'acquisitionera': 'null', 
+                # 'swversion': 'CMSSW_10_6_29', 
+                # 'inevents': 300, 
+                # 'globaltag': 'None', 
+                # 'publishname': '[...]-94ba0e06145abd65ccb1d21786dc7e1d', 
+                # 'location': 'T2_CH_CERN', 
+                # 'tmplocation': 'T2_UK_London_Brunel', 
+                # 'runlumi': {b'1': {b'2521': b'300'}},                  ## THIS CONTAINS BYTES
+                # 'adler32': '31018715', 
+                # 'cksum': 2091402041, 'md5': 'asda', 
+                # 'lfn': '/store/user/dmapelli/GenericTTbar/[...]/220113_142727/0000/output_7.root', 
+                # 'filesize': 651499, 
+                # 'parents': [b'/store/[...]-0CC47A7C34C8.root'],        ## THIS CONTAINS BYTES
+                # 'state': None, 
+                # 'created': "[b'/store/[...]-0CC47A7C34C8.root']",      ## THIS CONTAINS BYTES
+                # 'tmplfn': '/store/user/dmapelli/GenericTTbar/[...]/220113_142727/0000/output_7.root'}
+                self.logger.info("converting bytes into unicode in filemetadata - before - %s", filedict)
+                for key0, val0 in filedict.items():
+                    if isinstance(val0, list):  # 'parents' and 'created'
+                        filedict[key0]  = [decodeBytesToUnicode(el) for el in val0]
+                    if isinstance(val0, dict):  # 'runlumi'
+                        for key1, val1 in list(val0.items()):
+                            val0.pop(key1)
+                            val0[decodeBytesToUnicode(key1)] = val1
+                            if isinstance(val1, dict):
+                                for key2, val2 in list(val1.items()):
+                                    val1.pop(key2)
+                                    val1[decodeBytesToUnicode(key2)] = decodeBytesToUnicode(val2)
+                self.logger.info("converting bytes into unicode in filemetadata - after - %s", filedict)
+                ## temporary changes for making REST py3 compatible with Publisher py2 - end
+                filedict['created'] = str(filedict['created'])   # convert to str, after removal of bytes
+                yield json.dumps(filedict)
 
     def inject(self, **kwargs):
         """ Insert or update a record in the database


### PR DESCRIPTION
### state

This has been tested in `test3f` and `test3e` described in https://github.com/dmwm/CRABServer/issues/6938#issuecomment-1010995060

It is ready to be merged

### description

While testing the migration from py2 services to py3 services, we found out that if we deploy the REST-py3 when there are files that wait to be published or are about to be (publication status `new` or `acuired`), then the publication fails because of a json encoding error in the REST-py3. The failure is describe the comment above linked above, in `test3`.

The simplest solution that came to our mind was converting all the bytes into unicode in the REST-py3 before dumping the dictionary into a json file. This is the approach that I take in this PR. I know that the variable naming is not perfect, that we might have found a better way of achieving this, any suggestion is very well welcomed!

The commit contained in this PR can be reverted after we deploy all the services in python3.
