### PR TITLE
Adjust code to work with new DBS Go based server

### DIFF
--- a/src/python/Publisher/TaskPublish.py
+++ b/src/python/Publisher/TaskPublish.py
@@ -283,6 +283,8 @@ def requestBlockMigration(taskname, migrateApi, sourceApi, block, migLogDir):
     if not atDestination:
         msg = "Result of migration request: %s" % str(result)
         logger.info(msg)
+        if isinstance(result, list):
+            result = result[0] # New DBS server returns list of dicts
         reqid = result.get('migration_details', {}).get('migration_request_id')
         report = result.get('migration_report')
         migInput = result.get('migration_details', {}).get('migration_input')


### PR DESCRIPTION
In new DBS (Go based) server all results are list data-type. Therefore, in order to properly read status report I created a patch for TaskPublish.py code base.

I suggest that @belforte try out new code against the following
```
    host    = 'https://cmsweb-test3.cern.ch'
    migUrl  = host + '/dbs2go-migrate'
    phy3Url = host + '/dbs2go-writer'
    globUrl = 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader'

    globalApi   = DbsApi(url=globUrl)
    destReadApi = DbsApi(url=phy3Url)
    migrateApi  = DbsApi(url=migUrl)
```

The cmsweb-test3 points to dbs3_int_phys01 DBS DB which does not have much datasets. I was able to successfully migrate few datasets from DBS global to this instance. For my tests I copied part of this code (functions: migrateByBlockDBS3 and requestBlockMigration) and run it. But I did not run TaskPublish.py as is and it would be nice to test it in your environment. Please report in this PR or independently about results of the migration tests.