### PR TITLE
Enable idtokens on TaskWorker

### DIFF
--- a/src/python/HTCondorUtils.py
+++ b/src/python/HTCondorUtils.py
@@ -41,12 +41,13 @@ class OutputObj:
 
 class AuthenticatedSubprocess(object):
 
-    def __init__(self, proxy, pickleOut=False, outputObj = None, logger = logging):
+    def __init__(self, proxy, tokenDir=None, pickleOut=False, outputObj=None, logger=logging):
         self.proxy = proxy
         self.pickleOut = pickleOut
         self.outputObj = outputObj
         self.timedout = False
         self.logger = logger
+        self.tokenDir = tokenDir
 
     def __enter__(self):
         self.r, self.w = os.pipe()
@@ -59,7 +60,11 @@ class AuthenticatedSubprocess(object):
         self.pid = os.fork()
         if self.pid == 0:
             htcondor.SecMan().invalidateAllSessions()
-            htcondor.param['SEC_CLIENT_AUTHENTICATION_METHODS'] = 'FS,GSI'
+            if self.tokenDir:
+                htcondor.param['SEC_TOKEN_DIRECTORY'] = self.tokenDir
+                htcondor.param['SEC_CLIENT_AUTHENTICATION_METHODS'] = 'IDTOKENS,FS,GSI'
+            else:
+                htcondor.param['SEC_CLIENT_AUTHENTICATION_METHODS'] = 'FS,GSI'
             htcondor.param['DELEGATE_FULL_JOB_GSI_CREDENTIALS'] = 'true'
             htcondor.param['DELEGATE_JOB_GSI_CREDENTIALS_LIFETIME'] = '0'
             os.environ['X509_USER_PROXY'] = self.proxy

--- a/src/python/TaskWorker/Actions/DagmanKiller.py
+++ b/src/python/TaskWorker/Actions/DagmanKiller.py
@@ -92,7 +92,8 @@ class DagmanKiller(TaskAction):
         # TODO: Remove jobConst query when htcondor ticket is solved
         # https://htcondor-wiki.cs.wisc.edu/index.cgi/tktview?tn=5175
 
-        with HTCondorUtils.AuthenticatedSubprocess(self.proxy) as (parent, rpipe):
+        tokenDir = getattr(self.config.TaskWorker, 'SEC_TOKEN_DIRECTORY', None)
+        with HTCondorUtils.AuthenticatedSubprocess(self.proxy, tokenDir) as (parent, rpipe):
             if not parent:
                 with self.schedd.transaction() as dummytsc:
                     self.schedd.act(htcondor.JobAction.Hold, rootConst)

--- a/src/python/TaskWorker/Actions/DagmanSubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanSubmitter.py
@@ -527,7 +527,10 @@ class DagmanSubmitter(TaskAction.TaskAction):
         dagAd["TransferInput"] = str(info['inputFilesString'])
 
         condorIdDict = {}
-        with HTCondorUtils.AuthenticatedSubprocess(info['user_proxy'], pickleOut=True, outputObj=condorIdDict, logger=self.logger) as (parent, rpipe):
+        tokenDir = getattr(self.config.TaskWorker, 'SEC_TOKEN_DIRECTORY', None)
+        with HTCondorUtils.AuthenticatedSubprocess(info['user_proxy'], tokenDir,
+                                                   pickleOut=True, outputObj=condorIdDict,
+                                                   logger=self.logger) as (parent, rpipe):
             if not parent:
                 resultAds = []
                 condorIdDict['ClusterId'] = schedd.submit(dagAd, 1, True, resultAds)

--- a/src/script/Deployment/TaskWorker/TaskWorkerConfig.py
+++ b/src/script/Deployment/TaskWorker/TaskWorkerConfig.py
@@ -62,6 +62,10 @@ config.TaskWorker.cmscert = '/data/certs/servicecert.pem'
 config.TaskWorker.cmskey = '/data/certs/servicekey.pem'
 
 config.TaskWorker.backend = 'glidein'
+
+# for connection to HTCondor scheds
+config.TaskWorker.SEC_TOKEN_DIRECTORY = '/data/certs/tokens.d'
+
 #Retry policy
 config.TaskWorker.max_retry = 4
 config.TaskWorker.retry_interval = [30, 60, 120, 0]


### PR DESCRIPTION
This TW version adds support for IDTOKENS authentication.
If SEC_TOKEN_DIRECTORY is defined in TaskWorkerConfiguration.py and contains an htcondor token valid for the requested pool, IDTOKENS authentication is used. Otherwise TW falls back to usual GSI authentication.
