### PR TITLE
update requirements.txt to dmwm/WMCore 1.5.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@
 # Format:
 # Dependency==version          
 
-wmcver==1.5.7.pre5
+wmcver==1.5.7
 


### PR DESCRIPTION
Changing requirements.txt to point to the new release of WMCore https://github.com/dmwm/WMCore/releases/tag/1.5.7 which contains changes that we rely upon for REST-py3