### PR TITLE
fix not py3-compatible pycurl.error handling in RESTInteractions

### DIFF
--- a/src/python/RESTInteractions.py
+++ b/src/python/RESTInteractions.py
@@ -44,7 +44,7 @@ def retriableError(ex):
     if isinstance(ex, pycurl.error):
         #28 is 'Operation timed out...'
         #35,is 'Unknown SSL protocol error', see https://github.com/dmwm/CRABServer/issues/5102
-        return ex[0] in [28, 35]
+        return ex.args[0] in [28, 35]
     return False
 
 


### PR DESCRIPTION
#### status

fixes #6995 

ready to merge

#### description

Oooops, my bad. I should have looked better for such exception handling, even if it is not trivial to grep for this. 

thanks Stefano for reporting!

- `pycurl.error` should be used as an Exception: https://github.com/pycurl/pycurl/blob/e98d0e79aef6b5dad2b98c62f1d6b4e4b8df60fd/tests/error_test.py#L21
- in py3 it is not possible to index exceptions: https://pylint.pycqa.org/en/v2.10.2/technical_reference/features.html#python3-checker-messages `indexing-exceptions` (W1624).