### PR TITLE
Make jenkins pipeline to use robot account credentials

### DIFF
--- a/cicd/build/jenkins_build_docker.sh
+++ b/cicd/build/jenkins_build_docker.sh
@@ -11,6 +11,9 @@ echo "(DEBUG) jenkin job's env variables:"
 echo "(DEBUG)   \- WORKSPACE: $WORKSPACE"
 echo "(DEBUG) end"
 
+# use docker config on our WORKSPACE area, avoid replace default creds in ~/.docker that many pipeline depend on it
+export DOCKER_CONFIG=$PWD/docker_login
+
 #build and push crabtaskworker image
 git clone https://github.com/dmwm/CRABServer.git
 cd CRABServer/Docker
@@ -23,7 +26,6 @@ diff -u install.sh.bak install.sh || true
 echo "(DEBUG) end"
 
 # use cmscrab robot account credentials
-export DOCKER_CONFIG=$PWD/docker_login
 docker login registry.cern.ch --username $HARBOR_CMSCRAB_USERNAME --password-stdin <<< $HARBOR_CMSCRAB_PASSWORD
 
 docker build . -t registry.cern.ch/cmscrab/crabtaskworker:${RELEASE_TAG} --network=host \

--- a/cicd/build/jenkins_build_docker.sh
+++ b/cicd/build/jenkins_build_docker.sh
@@ -18,22 +18,26 @@ echo "(DEBUG) diff dmwm/CRABServer/Docker/install.sh"
 diff -u install.sh.bak install.sh
 echo "(DEBUG) end"
 
-docker build . -t cmssw/crabtaskworker:${RELEASE_TAG} --network=host \
+# use cmscrab robot account credentials
+export DOCKER_CONFIG=$PWD/docker_login
+docker login registry.cern.ch --username $HARBOR_CMSCRAB_USERNAME --password-stdin <<< $HARBOR_CMSCRAB_USERNAME
+
+docker build . -t registry.cern.ch/cmscrab/crabtaskworker:${RELEASE_TAG} --network=host \
         --build-arg RELEASE_TAG=${RELEASE_TAG} \
         --build-arg RPM_RELEASETAG_HASH=${RPM_RELEASETAG_HASH}
-docker push cmssw/crabtaskworker:${RELEASE_TAG}
-docker rmi cmssw/crabtaskworker:${RELEASE_TAG}
+docker push registry.cern.ch/cmscrab/crabtaskworker:${RELEASE_TAG}
+docker rmi registry.cern.ch/cmscrab/crabtaskworker:${RELEASE_TAG}
 
-#build and push crabserver image
-cd $WORKSPACE
-git clone https://github.com/dmwm/CMSKubernetes.git
-cd CMSKubernetes/docker/
-
-#get HG version tag from comp.crab_${BRANCH} repo, e.g. HG2201a-cde79778caecdc06e9b316b5530c1da5
-HGVERSION=$(curl -s "http://cmsrep.cern.ch/cmssw/repos/comp.crab_${BRANCH}/slc7_amd64_gcc630/latest/RPMS.json" | grep -oP 'HG\d{4}(.*)(?=":)' | head -1)
-sed -i.bak -e "/REPO=\"comp*/c\REPO=\"comp.crab_${BRANCH}\"" -e "s/VER=HG.*/VER=$HGVERSION/g" -- crabserver/install.sh
-echo "(DEBUG) diff dmwm/CMSKubernetes/docker/crabserver/install.sh"
-diff -u crabserver/install.sh.bak crabserver/install.sh
-echo "(DEBUG) end"
-
-CMSK8STAG=${RELEASE_TAG} ./build.sh "crabserver"
+##build and push crabserver image
+#cd $WORKSPACE
+#git clone https://github.com/dmwm/CMSKubernetes.git
+#cd CMSKubernetes/docker/
+#
+##get HG version tag from comp.crab_${BRANCH} repo, e.g. HG2201a-cde79778caecdc06e9b316b5530c1da5
+#HGVERSION=$(curl -s "http://cmsrep.cern.ch/cmssw/repos/comp.crab_${BRANCH}/slc7_amd64_gcc630/latest/RPMS.json" | grep -oP 'HG\d{4}(.*)(?=":)' | head -1)
+#sed -i.bak -e "/REPO=\"comp*/c\REPO=\"comp.crab_${BRANCH}\"" -e "s/VER=HG.*/VER=$HGVERSION/g" -- crabserver/install.sh
+#echo "(DEBUG) diff dmwm/CMSKubernetes/docker/crabserver/install.sh"
+#diff -u crabserver/install.sh.bak crabserver/install.sh
+#echo "(DEBUG) end"
+#
+#CMSK8STAG=${RELEASE_TAG} ./build.sh "crabserver"

--- a/cicd/build/jenkins_build_docker.sh
+++ b/cicd/build/jenkins_build_docker.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 echo "(DEBUG) variables from upstream jenkin job (CRABServer_BuildImage_20220127):"
 echo "(DEBUG)   \- BRANCH: ${BRANCH}"
 echo "(DEBUG)   \- RELEASE_TAG: ${RELEASE_TAG}"
@@ -20,7 +22,7 @@ echo "(DEBUG) end"
 
 # use cmscrab robot account credentials
 export DOCKER_CONFIG=$PWD/docker_login
-docker login registry.cern.ch --username $HARBOR_CMSCRAB_USERNAME --password-stdin <<< $HARBOR_CMSCRAB_USERNAME
+docker login registry.cern.ch --username $HARBOR_CMSCRAB_USERNAME --password-stdin <<< $HARBOR_CMSCRAB_PASSWORD
 
 docker build . -t registry.cern.ch/cmscrab/crabtaskworker:${RELEASE_TAG} --network=host \
         --build-arg RELEASE_TAG=${RELEASE_TAG} \

--- a/cicd/build/jenkins_build_docker.sh
+++ b/cicd/build/jenkins_build_docker.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -euo pipefail
+set -x
 
 echo "(DEBUG) variables from upstream jenkin job (CRABServer_BuildImage_20220127):"
 echo "(DEBUG)   \- BRANCH: ${BRANCH}"

--- a/cicd/build/jenkins_build_docker.sh
+++ b/cicd/build/jenkins_build_docker.sh
@@ -32,16 +32,19 @@ docker build . -t registry.cern.ch/cmscrab/crabtaskworker:${RELEASE_TAG} --netwo
 docker push registry.cern.ch/cmscrab/crabtaskworker:${RELEASE_TAG}
 docker rmi registry.cern.ch/cmscrab/crabtaskworker:${RELEASE_TAG}
 
-##build and push crabserver image
-#cd $WORKSPACE
-#git clone https://github.com/dmwm/CMSKubernetes.git
-#cd CMSKubernetes/docker/
-#
-##get HG version tag from comp.crab_${BRANCH} repo, e.g. HG2201a-cde79778caecdc06e9b316b5530c1da5
-#HGVERSION=$(curl -s "http://cmsrep.cern.ch/cmssw/repos/comp.crab_${BRANCH}/slc7_amd64_gcc630/latest/RPMS.json" | grep -oP 'HG\d{4}(.*)(?=":)' | head -1)
-#sed -i.bak -e "/REPO=\"comp*/c\REPO=\"comp.crab_${BRANCH}\"" -e "s/VER=HG.*/VER=$HGVERSION/g" -- crabserver/install.sh
-#echo "(DEBUG) diff dmwm/CMSKubernetes/docker/crabserver/install.sh"
-#diff -u crabserver/install.sh.bak crabserver/install.sh || true
-#echo "(DEBUG) end"
-#
+#build and push crabserver image
+cd $WORKSPACE
+git clone https://github.com/dmwm/CMSKubernetes.git
+cd CMSKubernetes/docker/
+
+#get HG version tag from comp.crab_${BRANCH} repo, e.g. HG2201a-cde79778caecdc06e9b316b5530c1da5
+HGVERSION=$(curl -s "http://cmsrep.cern.ch/cmssw/repos/comp.crab_${BRANCH}/slc7_amd64_gcc630/latest/RPMS.json" | grep -oP 'HG\d{4}(.*)(?=":)' | head -1)
+sed -i.bak -e "/REPO=\"comp*/c\REPO=\"comp.crab_${BRANCH}\"" -e "s/VER=HG.*/VER=$HGVERSION/g" -- crabserver/install.sh
+echo "(DEBUG) diff dmwm/CMSKubernetes/docker/crabserver/install.sh"
+diff -u crabserver/install.sh.bak crabserver/install.sh || true
+echo "(DEBUG) end"
+
+echo $DOCKER_CONFIG
+# relogin to using cmsweb robot account
+#docker login registry.cern.ch --username $HARBOR_CMSWEB_USERNAME --password-stdin <<< $HARBOR_CMSWEB_PASSWORD
 #CMSK8STAG=${RELEASE_TAG} ./build.sh "crabserver"

--- a/cicd/build/jenkins_build_docker.sh
+++ b/cicd/build/jenkins_build_docker.sh
@@ -46,7 +46,6 @@ echo "(DEBUG) diff dmwm/CMSKubernetes/docker/crabserver/install.sh"
 diff -u crabserver/install.sh.bak crabserver/install.sh || true
 echo "(DEBUG) end"
 
-echo $DOCKER_CONFIG
 # relogin to using cmsweb robot account
-#docker login registry.cern.ch --username $HARBOR_CMSWEB_USERNAME --password-stdin <<< $HARBOR_CMSWEB_PASSWORD
-#CMSK8STAG=${RELEASE_TAG} ./build.sh "crabserver"
+docker login registry.cern.ch --username $HARBOR_CMSWEB_USERNAME --password-stdin <<< $HARBOR_CMSWEB_PASSWORD
+CMSK8STAG=${RELEASE_TAG} ./build.sh "crabserver"

--- a/cicd/build/jenkins_build_docker.sh
+++ b/cicd/build/jenkins_build_docker.sh
@@ -18,7 +18,8 @@ cd CRABServer/Docker
 #replace where RPMs are stored
 sed -i.bak -e "/export REPO=*/c\export REPO=comp.crab_${BRANCH}" install.sh
 echo "(DEBUG) diff dmwm/CRABServer/Docker/install.sh"
-diff -u install.sh.bak install.sh
+ls .
+diff -u install.sh.bak install.sh || true
 echo "(DEBUG) end"
 
 # use cmscrab robot account credentials
@@ -40,7 +41,7 @@ docker rmi registry.cern.ch/cmscrab/crabtaskworker:${RELEASE_TAG}
 #HGVERSION=$(curl -s "http://cmsrep.cern.ch/cmssw/repos/comp.crab_${BRANCH}/slc7_amd64_gcc630/latest/RPMS.json" | grep -oP 'HG\d{4}(.*)(?=":)' | head -1)
 #sed -i.bak -e "/REPO=\"comp*/c\REPO=\"comp.crab_${BRANCH}\"" -e "s/VER=HG.*/VER=$HGVERSION/g" -- crabserver/install.sh
 #echo "(DEBUG) diff dmwm/CMSKubernetes/docker/crabserver/install.sh"
-#diff -u crabserver/install.sh.bak crabserver/install.sh
+#diff -u crabserver/install.sh.bak crabserver/install.sh || true
 #echo "(DEBUG) end"
 #
 #CMSK8STAG=${RELEASE_TAG} ./build.sh "crabserver"


### PR DESCRIPTION
Fix https://github.com/dmwm/CRABServer/issues/7027

Retreive robot account credentials from Jenkins Crendentials store, bind it to environment variable `HARBOR_<PROJECT>_USERNAME`, `HARBOR_<PROJECT>_PASSWORD` 

Avoid replace credentials setup by Shahzad in ~/.docker by using `DOCKER_CONFIG` environment variable. It will wipe out after finish build job. 

We need to login 2 times because we push images to 2 differrent projects, crabtaskworker goto cmscrab, and crabserver go to cmsweb.