### PR TITLE
make python3 compatible with master - no merge conflict

### DIFF
--- a/Docker/addGH.sh
+++ b/Docker/addGH.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
 # add GitHub repositories for CRABServer and WMCore
 
-# TW_VERSION is set by Dockerfile
-CRABServerTag=$TW_VERSION
-
 # 0. locate the crabserver directory created by install.sh
+# something like: /data/srv/TaskManager/py3.220105-efe7bf851559ee417e352b26e70998cd/slc7_amd64_gcc630/cms/crabtaskworker
 CRABServerDir=`realpath /data/srv/TaskManager/current/*/cms/crabtaskworker`
 
 # 1. find out which WMCore tag was installed
-export PYTHONPATH=$CRABServerDir/$CRABServerTag/lib/python2.7/site-packages
-WMCoreTag=`python -c "from WMCore import __version__; print __version__"`
+export PYTHONPATH=$CRABServerDir/$RPM_RELEASETAG_HASH/lib/python3.8/site-packages
+WMCoreGHTag=$(grep __version__ $CRABServerDir/$RPM_RELEASETAG_HASH/lib/python*/site-packages/WMCore/__init__.py | cut -f2 -d"=" |  tr -d " '\"")
 
 # 2. create directories for repositories and clone 
 mkdir /data/repos
@@ -19,18 +17,20 @@ git clone https://github.com/dmwm/WMCore.git
 
 # 3. checkout the installed tags and add ptrs to developers repos
 cd CRABServer
-git checkout $CRABServerTag
+git checkout $RELEASE_TAG
 git remote add stefano https://github.com/belforte/CRABServer.git
 git remote add daina https://github.com/ddaina/CRABServer.git
 git remote add mapellidario https://github.com/mapellidario/CRABServer.git
 git remote add diego https://github.com/dciangot/CRABServer.git
+git remote add wa https://github.com/novicecpp/CRABServer.git
 cd ..
 cd WMCore
-git checkout $WMCoreTag
+git checkout $WMCoreGHTag
 git remote add stefano https://github.com/belforte/WMCore.git
 git remote add daina https://github.com/ddaina/WMCore.git
 git remote add mapellidario https://github.com/mapellidario/WMCore.git
 git remote add diego https://github.com/dciangot/WMCore.git
+git remote add wa https://github.com/novicecpp/CRABServer.git
 
 # 4. create .gitconfig
 cat > ~/.gitconfig << EOF

--- a/src/script/Monitor/logstash/crabtaskworker.conf
+++ b/src/script/Monitor/logstash/crabtaskworker.conf
@@ -23,7 +23,6 @@ filter{
       }
 
 
-###BELOW
   } else if [message] =~ /.*PUBSTART.*/ {
       grok{
         match => {
@@ -33,10 +32,8 @@ filter{
         add_field => {"log_type" => "publisher_config_data"}
         overwrite => ["message"]
       }
-###END
 
 
-###BELOW
   } else if [message] =~ /.*TWSTART.*/ {
       grok{
         match => {
@@ -46,7 +43,6 @@ filter{
         add_field => {"log_type" => "tw_config_data"}
         overwrite => ["message"]
       }
-###END
 
 
   } else if [message] =~ /.*Starting.*at.*on.*/ {
@@ -89,6 +85,8 @@ filter{
         overwrite => ["message"]
       }
 
+  # This filter is currently used for production publisher.
+  # after we deploy preprod to prod, this filter can be dropped
   } else if [message] =~ /.*DEBUG:master.*/ {
       grok{
         match => {
@@ -98,6 +96,18 @@ filter{
         add_field => {"log_type" => "acquired_files"}
         overwrite => ["message"]
       }
+
+  # this filter mathces changes in #6861, which is already in preprod and dev
+  } else if [message] =~ /.*acquired_files.*/ {
+      grok{
+        match => {
+          # 2021-12-03 20:13:59,965:DEBUG:PublisherMaster,413:acquired_files:   OK    89 : 211203_174945:cmsbot_crab_20211203_184942
+          "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:%{NOTSPACE:logMsg}:PublisherMaster,%{INT}:acquired_files:%{SPACE}%{NOTSPACE:acquiredFilesStatus}%{SPACE}%{INT:acquiredFiles}%{SPACE}:%{SPACE}%{NOTSPACE:taskName}"
+        }
+        add_field => {"log_type" => "acquired_files_status"}
+        overwrite => ["message"]
+      }
+
 
   } else if [message] =~ /.*Finished.*object at .*/ {
       grok{
@@ -146,11 +156,8 @@ filter{
             event.remove("tw_json_data")
         '
          }
-   }	
+   }
 }
-
-
-
 
 output {
   if [log_type] == "work_on_task_completed" {
@@ -196,7 +203,6 @@ output {
    }
 
 
-#######
   if [log_type] == "publisher_config_data" {
     http {
         http_method => post
@@ -206,10 +212,8 @@ output {
         message => '{"hostname": "%{hostname}", "rec_timestamp":"%{rec_timestamp}", "log_file": "%{log_file}", "producer": "crab", "type": "publisher", "timestamp":"%{timestamp}", "producer_time":"%{producer_time}", "log_type":"%{log_type}", "logMsg":"%{logMsg}", "max_slaves":"%{max_slaves}", "dryRun":"%{dryRun}", "asoworker":"%{asoworker}", "DBShost":"%{DBShost}", "instance":"%{instance}", "version":"%{version}"}'
      }
    }
-#######
 
 
-#######
   if [log_type] == "tw_config_data" {
     http {
         http_method => post
@@ -219,7 +223,6 @@ output {
         message => '{"hostname": "%{hostname}", "rec_timestamp":"%{rec_timestamp}", "log_file": "%{log_file}", "producer": "crab", "type": "crabtaskworker", "timestamp":"%{timestamp}", "producer_time":"%{producer_time}", "log_type":"%{log_type}", "logMsg":"%{logMsg}", "restHost":"%{restHost}", "name":"%{name}", "DBSHostName":"%{DBSHostName}", "instance":"%{instance}", "version":"%{version}", "dbInstance":"%{dbInstance}", "nslaves":"%{nslaves}"}'
      }
    }
-#######
 
 
   if [log_type] == "publication_error" {
@@ -232,7 +235,8 @@ output {
      }
    }
 
-
+  # This filter is currently used for production publisher.
+  # after we deploy preprod to prod, this filter can be dropped
   if [log_type] == "acquired_files" {
     http {
         http_method => post
@@ -243,6 +247,16 @@ output {
      }
    }
 
+  # this filter mathces changes in #6861, which is already in preprod and dev
+  if [log_type] == "acquired_files_status" {
+    http {
+        http_method => post
+        url => "http://monit-logs.cern.ch:10012/"
+        content_type => "application/json; charset=UTF-8"
+        format => "message"
+        message => '{"hostname": "%{hostname}", "rec_timestamp":"%{rec_timestamp}", "log_file": "%{log_file}", "producer": "crab", "type": "publisher", "timestamp":"%{timestamp}", "producer_time":"%{producer_time}", "log_type":"%{log_type}", "logMsg":"%{logMsg}", "acquiredFiles":"%{acquiredFiles}", "taskName":"%{taskName}","acquiredFilesStatus":"%{acquiredFilesStatus}"  }'
+     }
+   }
 
   if [log_type] == "action_on_task_finished" {
     http {


### PR DESCRIPTION
Related to #7095 

### status

ready to merge

### description

In order to make the merge of branch `python3` into `master` smooth without any conflicts, we resolve them beforehand.

In practice, the production version of the files `Docker/addGH.sh` and `src/script/Monitor/logstash/crabtaskworker.conf` is the one we have in master. This PR backports to python3 the version of these two files that we have in master. 

If we merge this PR, then merging python3 branch into master will be smooth.