### PR TITLE
remove use of b64 encoding in CRABServer

### DIFF
--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -6,9 +6,7 @@ import re
 import random
 import logging
 import cherrypy
-from base64 import b64decode
 # WMCore dependecies here
-from Utils.Utilities import decodeBytesToUnicode
 from WMCore.REST.Server import RESTEntity, restcall
 from WMCore.REST.Error import ExecutionError, InvalidParameter
 from WMCore.REST.Validation import validate_str, validate_strlist, validate_num, validate_real
@@ -21,7 +19,7 @@ from CRABInterface.RESTExtensions import authz_owner_match
 from CRABInterface.Regexps import (RX_TASKNAME, RX_ACTIVITY, RX_JOBTYPE, RX_GENERATOR, RX_LUMIEVENTS, RX_CMSSW, RX_ARCH, RX_DATASET,
     RX_CMSSITE, RX_SPLIT, RX_CACHENAME, RX_CACHEURL, RX_LFN, RX_USERFILE, RX_VOPARAMS, RX_DBSURL, RX_LFNPRIMDS, RX_OUTFILES,
     RX_RUNS, RX_LUMIRANGE, RX_ASOURL, RX_ASODB, RX_SCRIPTARGS, RX_SCHEDD_NAME, RX_COLLECTOR, RX_SUBRESTAT, RX_JOBID, RX_ADDFILE,
-    RX_ANYTHING, RX_USERNAME, RX_DATE, RX_TEXT_FAIL)
+    RX_ANYTHING, RX_USERNAME, RX_DATE, RX_MANYLINES_SHORT)
 from CRABInterface.Utilities import CMSSitesCache, conn_handler, getDBinstance
 from ServerUtilities import checkOutLFN, generateTaskName
 
@@ -545,13 +543,7 @@ class RESTUserWorkflow(RESTEntity):
 
         elif method in ['DELETE']:
             validate_str("workflow", param, safe, RX_TASKNAME, optional=False)
-            validate_str("killwarning", param, safe, RX_TEXT_FAIL, optional=True)
-            #decode killwarning message if present
-            if safe.kwargs['killwarning']:
-                try:
-                    safe.kwargs['killwarning'] = decodeBytesToUnicode(b64decode(safe.kwargs['killwarning']))
-                except TypeError:
-                    raise InvalidParameter("Failure message is not in the accepted format")
+            validate_str("killwarning", param, safe, RX_MANYLINES_SHORT, optional=True)
 
 
     @restcall

--- a/src/python/CRABInterface/RESTWorkerWorkflow.py
+++ b/src/python/CRABInterface/RESTWorkerWorkflow.py
@@ -10,12 +10,11 @@ from WMCore.REST.Error import InvalidParameter
 from ServerUtilities import getEpochFromDBTime
 from CRABInterface.Utilities import getDBinstance
 from CRABInterface.RESTExtensions import authz_login_valid
-from CRABInterface.Regexps import (RX_TASKNAME, RX_WORKER_NAME, RX_STATUS, RX_TEXT_FAIL, RX_SUBPOSTWORKER,
+from CRABInterface.Regexps import (RX_MANYLINES_SHORT, RX_TASKNAME, RX_WORKER_NAME, RX_STATUS, RX_SUBPOSTWORKER,
                                   RX_JOBID)
 
 # external dependecies here
 from ast import literal_eval
-from base64 import b64decode
 
 
 class RESTWorkerWorkflow(RESTEntity):
@@ -36,7 +35,7 @@ class RESTWorkerWorkflow(RESTEntity):
             validate_str("status", param, safe, RX_STATUS, optional=True)
             validate_str("command", param, safe, RX_STATUS, optional=True)
             validate_str("getstatus", param, safe, RX_STATUS, optional=True)
-            validate_str("failure", param, safe, RX_TEXT_FAIL, optional=True)
+            validate_str("failure", param, safe, RX_MANYLINES_SHORT, optional=True)
             validate_strlist("resubmittedjobs", param, safe, RX_JOBID)
             validate_str("workername", param, safe, RX_WORKER_NAME, optional=True)
             validate_str("subresource", param, safe, RX_SUBPOSTWORKER, optional=True)
@@ -61,11 +60,6 @@ class RESTWorkerWorkflow(RESTEntity):
     @restcall
     def post(self, workflow, status, command, subresource, failure, resubmittedjobs, getstatus, workername, limit, clusterid):
         """ Updates task information """
-        if failure is not None:
-            try:
-                failure = decodeBytesToUnicode(b64decode(failure))
-            except TypeError:
-                raise InvalidParameter("Failure message is not in the accepted format")
         methodmap = {"state": {"args": (self.Task.SetStatusTask_sql,), "method": self.api.modify, "kwargs": {"status": [status],
                      "command": [command], "taskname": [workflow]}},
                      #TODO MM - I don't see where this start API is used

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -2,10 +2,14 @@ import re
 from WMCore.Lexicon import lfnParts, DATASET_RE
 
 
-## This regular expression matches anything. It is useful for example for
+## This regular expression matches any single-line string. It is useful for example for
 ## functions that require a regular expression against which they will match a
 ## given value, but we don't really want to do that matching.
 RX_ANYTHING = re.compile(r"^.*$")
+# This regular expression matches any string, also multi-line strings.
+# as of 2022-03 it is used for warning and failure messages, which were previously
+# encoded in b64 and matched with RX_TEXT_FAIL. see #7106
+RX_MANYLINES_SHORT = re.compile(r"(?s)^.{0,1100}$")
 # TODO: we should start replacing most of the regex here with what we have in WMCore.Lexicon
 #       (this probably requires to adapt something on Lexicon)
 pNameRE      = r"(?=.{0,400}$)[a-zA-Z0-9\-_.]+"
@@ -97,8 +101,6 @@ RX_DATE = re.compile(r"^(19|20)\d\d[- /.](0[1-9]|1[012])[- /.](0[1-9]|[12][0-9]|
 RX_ASOURL = RX_DBSURL
 RX_ASODB = RX_USERNAME
 
-## need to be careful with this
-RX_TEXT_FAIL = re.compile(r"^[A-Za-z0-9\-\._\s\=\+/]{0,10000}$")
 ## user dn
 RX_DN = re.compile(r"^/(?:C|O|DC)=.*/CN=.")
 ## worker subresources

--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -157,7 +157,7 @@ def getTestDataDirectory():
     return os.sep.join(testdirList)
 
 def truncateError(msg):
-    """Truncate the error message to the first 7400 chars if needed, and add a message if we truncate it.
+    """Truncate the error message to the first 1000 chars if needed, and add a message if we truncate it.
        See https://github.com/dmwm/CRABServer/pull/4867#commitcomment-12086393
     """
     MSG_LIMIT = 1100

--- a/src/python/TaskWorker/Actions/TaskAction.py
+++ b/src/python/TaskWorker/Actions/TaskAction.py
@@ -1,7 +1,6 @@
 import os
 import json
 import logging
-from base64 import b64encode
 from http.client import HTTPException
 import sys
 if sys.version_info >= (3, 0):
@@ -10,8 +9,6 @@ if sys.version_info < (3, 0):
     from urllib import urlencode
 
 from ServerUtilities import truncateError
-
-from Utils.Utilities import encodeUnicodeToBytes
 
 class TaskAction(object):
     """The ABC of all actions"""
@@ -57,7 +54,7 @@ class TaskAction(object):
         truncWarning = truncateError(warning)
         configreq = {'subresource': 'addwarning',
                      'workflow': taskname,
-                     'warning': b64encode(encodeUnicodeToBytes(truncWarning))}
+                     'warning': truncWarning}
         try:
             self.crabserver.post(api='task', data=urlencode(configreq))
         except HTTPException as hte:

--- a/src/python/TaskWorker/MasterWorker.py
+++ b/src/python/TaskWorker/MasterWorker.py
@@ -9,7 +9,6 @@ import sys
 import time
 import signal
 import logging
-from base64 import b64encode
 
 from http.client import HTTPException
 from MultiProcessingLog import MultiProcessingLog
@@ -20,7 +19,6 @@ if sys.version_info < (3, 0):
     from urllib import urlencode
 
 #WMcore dependencies
-from Utils.Utilities import encodeUnicodeToBytes
 from WMCore.Configuration import loadConfigurationFile
 
 #CRAB dependencies
@@ -357,7 +355,9 @@ class MasterWorker(object):
                 failstatus = 'FAILED'
             self.updateWork(taskname, command, failstatus)
             warning = 'username %s banned in CRAB TaskWorker configuration' % task['tm_username']
-            configreq = {'subresource': 'addwarning', 'workflow': taskname, 'warning': warning}
+            configreq = {'subresource': 'addwarning', 
+                         'workflow': taskname, 
+                         'warning': warning}
             try:
                 self.crabserver.post(api='task', data=urlencode(configreq))
             except Exception as e:
@@ -385,7 +385,7 @@ class MasterWorker(object):
             if command == 'KILL':  # ignore, i.e. leave in status 'SUBMITTED'
                 self.updateWork(taskname, command, 'SUBMITTED')
             warning = 'command %s disabled in CRAB TaskWorker configuration' % command
-            configreq = {'subresource': 'addwarning', 'workflow': taskname, 'warning': b64encode(encodeUnicodeToBytes(warning))}
+            configreq = {'subresource': 'addwarning', 'workflow': taskname, 'warning': warning}
             try:
                 self.crabserver.post(api='task', data=urlencode(configreq))
             except Exception as e:

--- a/src/python/TaskWorker/Worker.py
+++ b/src/python/TaskWorker/Worker.py
@@ -5,7 +5,6 @@ import logging
 import traceback
 import multiprocessing
 from queue import Empty
-from base64 import b64encode
 from logging import FileHandler
 from http.client import HTTPException
 from logging.handlers import TimedRotatingFileHandler
@@ -21,7 +20,6 @@ from TaskWorker.DataObjects.Result import Result
 from ServerUtilities import truncateError, executeCommand
 from TaskWorker.WorkerExceptions import WorkerHandlerException, TapeDatasetException
 
-from Utils.Utilities import encodeUnicodeToBytes
 
 ## Creating configuration globals to avoid passing these around at every request
 ## and tell pylink to bare with this :-)
@@ -54,8 +52,8 @@ def failTask(taskName, crabserver, msg, log, failstatus='FAILED'):
         configreq = {'workflow': taskName,
                      'status': failstatus,
                      'subresource': 'failure',
-                     # Limit the message to 7500 chars, which means no more than 10000 once encoded. That's the limit in the REST
-                     'failure': b64encode(encodeUnicodeToBytes(truncMsg))}
+                     # Limit the message to 1000. That's the limit in the REST
+                     'failure': truncMsg}
         crabserver.post(api='workflowdb', data = urlencode(configreq))
         log.info("Failure message successfully uploaded to the REST")
     except HTTPException as hte:


### PR DESCRIPTION
Fixes #7089

### status

Current status: 
- [x] I am content with current implementation
- [x] squash commits
- [x] test: fail a task -> test5
- [x] test: add warning when submission works. -> test6
- [x] test: add warning when we ban a user -> test7
- [x] test: crabclient CLI needs to be updated as well -> test8 fail, fixed in test9 with proper change in crabclient, as provided in PR https://github.com/dmwm/CRABClient/pull/5158
- [x] reduced limit to 1000 characters, test10, test11 and test12 are looking good

### description of current implementation

The error in #7089 emerged because we passed from MasterWorker (when banning a user) to `task (api)/addwarning (subresource)` a warning message without b64-encoding it before.

The first draft of this PR simply added b64 encoding in MasterWorker. This was the easiest option to close this issue, but Stefano pointed out that keeping with the status quo would have been error prone. It is not clear/obvious that we need to b64-encode a string, it would have been easy to miss it.

The second approach then was removing the use of b64 encoding. This requires changing the warning message validation regex. b64-encoded strings are validated with `RX_TEXT_FAIL`, a generic unicode strings requires a generic regex. Currently we have the `RX_ANYTHING` regex that we can use for this purpose, but since it have start- end-line anchors, it fails with warning/fail messages, which contains multiple `\n`. We therefore propose to introduce a new generic regex `RX_ANYTHING_MULTILINE` to "validate" warning/failure messages.


