### PR TITLE
PublisherMaster - delete tempfile after using it

### DIFF
--- a/src/python/Publisher/PublisherMaster.py
+++ b/src/python/Publisher/PublisherMaster.py
@@ -366,7 +366,7 @@ class Master(object):
             return 'KILLED'
         proxiedWebDir = getProxiedWebDir(crabserver=self.crabServer, task=workflow, logFunction=logger)
         # Download status_cache file
-        _, local_status_cache_pkl = tempfile.mkstemp(dir='/tmp', prefix='status-cache-', suffix='.pkl')
+        local_status_cache_fd, local_status_cache_pkl = tempfile.mkstemp(dir='/tmp', prefix='status-cache-', suffix='.pkl')
         url = proxiedWebDir + "/status_cache.pkl"
         # this host is dummy since we will pass full url to downloadFile but WMCore.Requests needs it
         host = 'https://cmsweb.cern.ch'
@@ -377,6 +377,8 @@ class Master(object):
             raise Exception('download attempt returned HTTP code %d' % ret.status)
         with open(local_status_cache_pkl, 'rb') as fp:
             statusCache = pickle.load(fp)
+        os.close(local_status_cache_fd)
+        os.remove(local_status_cache_pkl)
         # get DAG status from downloaded cache_status file
         statusCacheInfo = statusCache['nodes']
         dagInfo = statusCacheInfo['DagStatus']


### PR DESCRIPTION
### status

ready, tested [1]

### description

Just close the temporary file after we load it in memory, using the suggestions at https://stackoverflow.com/a/34717110

### other info

[1] 

```plaintext
# around 12.30, before submitting my task
[crab3@crab-preprod-tw01 Publisher]$ ll /tmp
total 52
drwx------. 2 crab3 crab3    6 Mar 11 16:49 crab3
drwxr-xr-x. 3 crab3 crab3   29 Mar 18 19:01 filebeat
drwxr-xr-x. 3 crab3 crab3   29 Mar  2 19:49 filebeat2
drwxr-xr-x. 2 root  root     6 Nov 13  2020 hsperfdata_root
-rwx------. 1 root  root   836 Nov  1  2020 ks-script-DkFkRX
-rw-------. 1 crab3 crab3 4813 Mar 21 16:25 status-cache-5odh7m7v.pkl
-rw-------. 1 crab3 crab3 4855 Mar 22 17:56 status-cache-b25xdyhf.pkl
-rw-------. 1 crab3 crab3 4810 Mar 22 17:56 status-cache-f6muq0xj.pkl
-rw-------. 1 crab3 crab3 4807 Mar 22 18:26 status-cache-luhkn989.pkl
-rw-------. 1 crab3 crab3 4810 Mar 23 12:26 status-cache-mtor5h41.pkl
-rw-------. 1 crab3 crab3 4677 Mar 23 12:26 status-cache-tw2c8b2v.pkl
-rw-------. 1 root  root     0 Nov  1  2020 yum.log
```

then i submitted `220323_115827:dmapelli_crab_20220323_125823`. Publisher finished managing it at 13:58 (14.28 run of publisher did not process anything). 

```plaintext
> crab status
CRAB project directory:         /afs/cern.ch/user/d/dmapelli/crab/submit/analysis-data/crab_projects/crab_20220323_125823
Task name:                      220323_115827:dmapelli_crab_20220323_125823
Grid scheduler - Task Worker:   crab3@vocms0122.cern.ch - crab-preprod-tw01
Status on the CRAB server:      SUBMITTED
Task URL to use for HELP:       https://cmsweb-testbed.cern.ch/crabserver/ui/task/220323_115827%3Admapelli_crab_20220323_125823
Dashboard monitoring URL:       https://monit-grafana.cern.ch/d/cmsTMDetail/cms-task-monitoring-task-view?orgId=11&var-user=dmapelli&var-task=220323_115827%3Admapelli_crab_20220323_125823&from=1648033107000&to=now
[...]
Status on the scheduler:        COMPLETED

Jobs status:                    finished                100.0% (10/10)

Publication status of 1 dataset(s):     done                    100.0% (10/10)
(from CRAB internal bookkeeping in transferdb)
[...]
```

At 14:52 we check again the `/tmp` directory and there is no new temporary file

```plaintext
[crab3@crab-preprod-tw01 Publisher]$ ls -lrt /tmp/
total 52
-rw-------. 1 root  root     0 Nov  1  2020 yum.log
-rwx------. 1 root  root   836 Nov  1  2020 ks-script-DkFkRX
drwxr-xr-x. 2 root  root     6 Nov 13  2020 hsperfdata_root
drwxr-xr-x. 3 crab3 crab3   29 Mar  2 19:49 filebeat2
drwxr-xr-x. 3 crab3 crab3   29 Mar 18 19:01 filebeat
-rw-------. 1 crab3 crab3 4813 Mar 21 16:25 status-cache-5odh7m7v.pkl
-rw-------. 1 crab3 crab3 4855 Mar 22 17:56 status-cache-b25xdyhf.pkl
-rw-------. 1 crab3 crab3 4810 Mar 22 17:56 status-cache-f6muq0xj.pkl
-rw-------. 1 crab3 crab3 4807 Mar 22 18:26 status-cache-luhkn989.pkl
-rw-------. 1 crab3 crab3 4677 Mar 23 12:26 status-cache-tw2c8b2v.pkl
-rw-------. 1 crab3 crab3 4810 Mar 23 12:26 status-cache-mtor5h41.pkl
drwx------. 2 crab3 crab3    6 Mar 23 14:28 crab3
```
