### PR TITLE
Regexps - scramarch: replace 'slc[0-9]{1}' with [a-z]+[0-9]{1,2}

### DIFF
--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -34,7 +34,7 @@ RX_JOBTYPE   = re.compile(r"^(?=.{0,255}$)[A-Za-z]*$")
 RX_GENERATOR = re.compile(r'^(lhe|pythia)$')
 RX_LUMIEVENTS = re.compile(r'^\d+$')
 RX_CMSSW     = re.compile(r"^(?=.{0,255}$)CMSSW[a-zA-Z0-9-_]*$") #using a lookahead (?=.{0,255}$) to check maximum size of the regex
-RX_ARCH      = re.compile(r"^(?=.{0,255}$)slc[0-9]{1}_[a-z0-9]+_gcc[a-z0-9]+(_[a-z0-9]+)?$")
+RX_ARCH      = re.compile(r"^(?=.{0,255}$)[a-z]+[0-9]{1,2}_[a-z0-9]+_gcc[a-z0-9]+(_[a-z0-9]+)?$")
 RX_DATASET   = re.compile(DATASET_RE) #See https://github.com/dmwm/WMCore/issues/6054#issuecomment-135475550
 RX_LFNPRIMDS = re.compile(r"^%(primDS)s$" % lfnParts)
 RX_BLOCK     = re.compile(r"^(/[a-zA-Z0-9\.\-_]{1,100}){3}#[a-zA-Z0-9\.\-_]{1,100}$")


### PR DESCRIPTION
#### status

tested on 4 tasks, ready to merge

#### descrption

Changes the regex for validating the scram architecture. The REST interface that we have in production now allows only `slc*`, but we want to support also `cs8_*` or `alma8_*`.

Reference: https://cms-talk.web.cern.ch/t/crab-submission-for-cs8-alma8-cmssw-release/8566/7