### PR TITLE
use ARCH_TO_OS mapping from WMCore

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -29,6 +29,7 @@ import classad
 
 import WMCore.WMSpec.WMTask
 from WMCore.Services.CRIC.CRIC import CRIC
+from WMCore.WMRuntime.Tools.Scram import ARCH_TO_OS
 
 DAG_HEADER = """
 
@@ -491,14 +492,11 @@ class DagmanCreator(TaskAction):
         info = transform_strings(info)
         info['faillimit'] = task['tm_fail_limit']
         info['extra_jdl'] = '\n'.join(literal_eval(task['tm_extrajdl']))
-        if info['jobarch_flatten'].startswith("slc5_"):
-            info['opsys_req'] = '+REQUIRED_OS="rhel6"'
-        elif info['jobarch_flatten'].startswith("slc6_"):
-            info['opsys_req'] = '+REQUIRED_OS="rhel6"'
-        elif info['jobarch_flatten'].startswith("slc7_"):
-            info['opsys_req'] = '+REQUIRED_OS="rhel7"'
-        else:
-            info['opsys_req'] = '+REQUIRED_OS="any"'
+
+        # info['jobarch_flatten'].split("_")[0]: extracts "slc7" from "slc7_amd64_gcc10"
+        required_os_list = ARCH_TO_OS.get(info['jobarch_flatten'].split("_")[0])
+        # ARCH_TO_OS.get("slc7") gives a list with one item only: ['rhel7']
+        info['opsys_req'] = '+REQUIRED_OS="{}"'.format(required_os_list[0] if required_os_list else "any")
 
         info.setdefault("additional_environment_options", '')
         info.setdefault("additional_input_file", "")


### PR DESCRIPTION
Fixes #7188 

### status

- tested on my laptop, [1]
- not-tested inside CRAB

The PR [11060](https://github.com/dmwm/WMCore/pull/11060) has been merged into dmwm/WMCore. however, I would wait merging this until WMCore makes a release.

### description

Stefano, are the changes suggested in this PR what you had in mind? Or would you prefer a complete review of all this function as suggested in 
https://github.com/dmwm/CRABServer/blob/8529c9769645c68f2cc034311bb96ceff23c1eda/src/python/TaskWorker/Actions/DagmanCreator.py#L481 
?

### logs

[1]

```plaintext
> python3
Python 3.10.3 (main, Mar 18 2022, 00:00:00) [GCC 11.2.1 20220127 (Red Hat 11.2.1-9)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> ARCH_TO_OS = {'slc5': ['rhel6'],
...               'slc6': ['rhel6'],
...               'slc7': ['rhel7'],
...               'cc8': ['rhel8'], 'cs8': ['rhel8'], 'alma8': ['rhel8']}
>>> ARCH_TO_OS.get("slc7_amd64_gcc10".split("_")[0])
['rhel7']
>>> ARCH_TO_OS.get("aaaaslc7_amd64_gcc10".split("_")[0])
>>> required_os = ARCH_TO_OS.get("slc7_amd64_gcc10".split("_")[0]) 
>>> required_os
['rhel7']
>>> '+REQUIRED_OS="{}"'.format(required_os[0] if required_os else "any")
'+REQUIRED_OS="rhel7"'
>>> required_os = ARCH_TO_OS.get("aaaslc7_amd64_gcc10".split("_")[0]) 
>>> '+REQUIRED_OS="{}"'.format(required_os[0] if required_os else "any")
'+REQUIRED_OS="any"'
>>> 
```