### PR TITLE
requirements.txt - WMCore v2.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@
 # Format:
 # Dependency==version          
 
-wmcver==2.0.1
+wmcver==2.0.2
 


### PR DESCRIPTION
This new WMCore version allows us to use the new REQUIRED_OS map added in https://github.com/dmwm/WMCore/pull/11060

Since we also updated the cmsweb image in TW dockerfile, we may even create a new tag and test in preprod