### PR TITLE
CMSRunAnalysis.py - it is now py3 compatible

### DIFF
--- a/scripts/CMSRunAnalysis.py
+++ b/scripts/CMSRunAnalysis.py
@@ -4,6 +4,8 @@ CMSRunAnalysis.py - the runtime python portions to launch a CRAB3 / cmsRun job.
 """
 from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
 import os
 import re
 import sys
@@ -16,7 +18,7 @@ import pickle
 import signal
 import os.path
 import logging
-import commands
+import subprocess
 import traceback
 from ast import literal_eval
 from optparse import OptionParser, BadOptionError, AmbiguousOptionError
@@ -385,7 +387,7 @@ def prepSandbox(opts):
     print("==== Sandbox untarring STARTING at %s ====" % time.asctime(time.gmtime()))
 
     #The user sandbox.tar.gz has to be unpacked no matter what (even in DEBUG mode)
-    print(commands.getoutput('tar xfm %s' % opts.archiveJob))
+    print(subprocess.getoutput('tar xfm %s' % opts.archiveJob))
     print("==== Sandbox untarring FINISHED at %s ====" % time.asctime(time.gmtime()))
 
     #move the pset in the right place
@@ -409,7 +411,7 @@ def extractUserSandbox(archiveJob, cmsswVersion):
     # will be executed from the job working directory, so we move "up"
     # the PSet which is also in the user sandbox
     os.chdir(cmsswVersion)
-    print(commands.getoutput('tar xfm %s ' % os.path.join('..', archiveJob)))
+    print(subprocess.getoutput('tar xfm %s ' % os.path.join('..', archiveJob)))
     os.rename('PSet.py','../PSet.py')
     os.rename('PSet.pkl','../PSet.pkl')
     os.chdir('..')
@@ -671,7 +673,7 @@ if __name__ == "__main__":
                 # e.g. from xroot https://github.com/dmwm/CRABServer/issues/6640#issuecomment-909362639
                 print("Sanitize FJR")
                 cmd = 'cat -v FrameworkJobReport.xml > sane; mv sane FrameworkJobReport.xml'
-                print(commands.getoutput(cmd))
+                print(subprocess.getoutput(cmd))
                 # parse FJR
                 rep = Report("cmsRun")
                 rep.parse('FrameworkJobReport.xml', "cmsRun")
@@ -701,7 +703,7 @@ if __name__ == "__main__":
         # e.g. from xroot https://github.com/dmwm/CRABServer/issues/6640#issuecomment-909362639
         print("Sanitize FJR")
         cmd = 'cat -v FrameworkJobReport.xml > sane; mv sane FrameworkJobReport.xml'
-        print(commands.getoutput(cmd))
+        print(subprocess.getoutput(cmd))
         # parse FJR
         rep = Report("cmsRun")
         rep.parse('FrameworkJobReport.xml', "cmsRun")


### PR DESCRIPTION
Fixes #7210 

#### status

tested, this seems to fix the issue we found with `commands.getoutput`, but now we are facing another problem down the line [1]. I will need to perform some more careful testing...

I need to perform some other tests before considering this safe to merge.

#### description

In py3, `getoutput` has been moved from `commands` to `subprocess`. This change has been ported back to py2 via `python-future`, https://python-future.org/compatible_idioms.html#commands-subprocess-modules

Similar changes have been applied to WMCore:

- [ ] https://github.com/dmwm/WMCore/blob/f3b5f6a891f19190f66c3ef789f71226ba75fff8/src/python/WMCore/WMRuntime/Scripts/UnpackUserTarball.py#L25
- [ ] https://github.com/dmwm/WMCore/blob/1bb206d606c4acc09c29a19c08a057a51de2c235/src/python/WMCore/Storage/Plugins/FNALImpl.py#L18

#### more info

[1]

<details><Summary> We encountered problems with the future environments</summary>

```plaintext
# slc6_amd64_gcc700
python3 CMSRunAnalysis.py -r /afs/cern.ch/user/d/dmapelli/crab/temp/20220411-preparelocal-2 -a sandbox.tar.gz --sourceURL=https://cmsweb-testbed.cern.ch/S3/crabcache_preprod --jobNumber=1 --cmsswVersion=CMSSW_12_2_1 --scramArch=slc7_amd64_gcc10 --inputFile=job_input_file_list_1.txt --runAndLumis=job_lumis_1.json --lheInputFiles=False --firstEvent=None --firstLumi=None --lastEvent=None --firstRun=None --seeding=AutomaticSeeding --scriptExe=None --eventsPerLumi=None --maxRuntime=-1 '--scriptArgs=[]' -o '{}'
Traceback (most recent call last):
  File "CMSRunAnalysis.py", line 8, in <module>
    import re
  File "/cvmfs/cms.cern.ch/slc6_amd64_gcc700/external/python3/3.6.4/lib/python3.6/re.py", line 122, in <module>
    import enum
  File "/cvmfs/cms.cern.ch/slc6_amd64_gcc700/external/python3/3.6.4/lib/python3.6/enum.py", line 2, in <module>
    from types import MappingProxyType, DynamicClassAttribute
  File "/cvmfs/cms.cern.ch/slc6_amd64_gcc700/external/python3/3.6.4/lib/python3.6/types.py", line 171, in <module>
    import functools as _functools
  File "/cvmfs/cms.cern.ch/slc6_amd64_gcc700/external/python3/3.6.4/lib/python3.6/functools.py", line 21, in <module>
    from collections import namedtuple
  File "/cvmfs/cms.cern.ch/slc6_amd64_gcc700/external/python3/3.6.4/lib/python3.6/collections/__init__.py", line 32, in <module>
    from reprlib import recursive_repr as _recursive_repr
  File "/cvmfs/cms.cern.ch/COMP/slc7_amd64_gcc630/external/py2-future/0.18.2/lib/python2.7/site-packages/reprlib/__init__.py", line 7, in <module>
    raise ImportError('This package should not be accessible on Python 3. '
ImportError: This package should not be accessible on Python 3. Either you are trying to run from the python-future src folder or your installation of python-future is corrupted.
+ jobrc=1
+ set +x
== The job had an exit code of 1
======== CMSRunAnalysis.py FINISHING at Mon Apr 11 15:26:56 GMT 2022 ========
>

# slc7_amd64_gcc630
+ python3 CMSRunAnalysis.py -r /afs/cern.ch/user/d/dmapelli/crab/temp/20220411-preparelocal-2 -a sandbox.tar.gz --sourceURL=https://cmsweb-testbed.cern.ch/S3/crabcache_preprod --jobNumber=1 --cmsswVersion=CMSSW_12_2_1 --scramArch=slc7_amd64_gcc10 --inputFile=job_input_file_list_1.txt --runAndLumis=job_lumis_1.json --lheInputFiles=False --firstEvent=None --firstLumi=None --lastEvent=None --firstRun=None --seeding=AutomaticSeeding --scriptExe=None --eventsPerLumi=None --maxRuntime=-1 '--scriptArgs=[]' -o '{}'
Traceback (most recent call last):
  File "CMSRunAnalysis.py", line 8, in <module>
    import re
  File "/cvmfs/cms.cern.ch/COMP/slc7_amd64_gcc630/external/python3/3.8.2-comp/lib/python3.8/re.py", line 125, in <module>
    import functools
  File "/cvmfs/cms.cern.ch/COMP/slc7_amd64_gcc630/external/python3/3.8.2-comp/lib/python3.8/functools.py", line 17, in <module>
    from collections import namedtuple
  File "/cvmfs/cms.cern.ch/COMP/slc7_amd64_gcc630/external/python3/3.8.2-comp/lib/python3.8/collections/__init__.py", line 27, in <module>
    from reprlib import recursive_repr as _recursive_repr
  File "/cvmfs/cms.cern.ch/COMP/slc7_amd64_gcc630/external/py2-future/0.18.2/lib/python2.7/site-packages/reprlib/__init__.py", line 7, in <module>
    raise ImportError('This package should not be accessible on Python 3. '
ImportError: This package should not be accessible on Python 3. Either you are trying to run from the python-future src folder or your installation of python-future is corrupted.
+ jobrc=1
+ set +x
== The job had an exit code of 1
======== CMSRunAnalysis.py FINISHING at Mon Apr 11 15:25:09 GMT 2022 ========
>
>
```
</details>