### PR TITLE
runContainer.sh - default to registry.cern.ch instead of dockerhub 

### DIFF
--- a/src/script/Container/runContainer.sh
+++ b/src/script/Container/runContainer.sh
@@ -49,7 +49,7 @@ done
 
 DOCKER_VOL="-v /data/container/:/data/hostdisk/ -v /data/srv/tmp/:/data/srv/tmp/ -v /cvmfs/cms.cern.ch/SITECONF:/cvmfs/cms.cern.ch/SITECONF -v /etc/grid-security/:/etc/grid-security/ -v /data/certs/:/data/certs/ -v /var/run/nscd/socket:/var/run/nscd/socket "
 DOCKER_OPT="-e SERVICE=${SERVICE} -w /data/srv/${DIRECTORY} "
-docker run --name ${SERVICE} -d -ti --net host --privileged $DOCKER_OPT $DOCKER_VOL ${TW_REPO:-cmssw}/crabtaskworker:${TW_VERSION}
+docker run --name ${SERVICE} -d -ti --net host --privileged $DOCKER_OPT $DOCKER_VOL ${TW_REPO:-registry.cern.ch/cmscrab}/crabtaskworker:${TW_VERSION}
 
 echo -e "Sleeping for 3 seconds.\nRunning containers:"
 sleep 3 && docker ps


### PR DESCRIPTION
Together with [1], this should be enough to distribute the script with `registry.cern.ch` enabled by default.

Changes tested with a dryrun (putting `echo` in front of the `docker run` command) on crab-dev-tw01.

[1]: https://gitlab.cern.ch/ai/it-puppet-hostgroup-vocmsglidein/-/blob/ec6ebc26c41dcc03b1406013213c9b0070c8ad7e/code/manifests/profiles/crabtaskworker.pp#L261