### PR TITLE
Revert "REST-py3 backward compatibile with publisher-py2 (#6967)"

### DIFF
--- a/src/python/CRABInterface/DataFileMetadata.py
+++ b/src/python/CRABInterface/DataFileMetadata.py
@@ -7,7 +7,6 @@ import json
 import logging
 from ast import literal_eval
 
-from Utils.Utilities import decodeBytesToUnicode
 from Utils.Utilities import makeList
 
 from CRABInterface.Utilities import getDBinstance
@@ -46,69 +45,30 @@ class DataFileMetadata(object):
                     allRows.append(row)
         for row in allRows:
             row = self.FileMetaData.GetFromTaskAndType_tuple(*row)
-            #if lfn==[] or row.lfn in lfn:
-            if True:
-                filedict = {
-                    'taskname': taskname,
-                    'filetype': row.type,
-                    'jobid': row.jobid,
-                     'outdataset': row.outdataset,
-                     'acquisitionera': row.acquisitionera,
-                     'swversion': row.swversion,
-                     'inevents': row.inevents,
-                     'globaltag': row.globaltag,
-                     'publishname': row.publishname,
-                     'location': row.location,
-                     'tmplocation': row.tmplocation,
-                     'runlumi': literal_eval(row.runlumi.read()),
-                     'adler32': row.adler32,
-                     'cksum': row.cksum,
-                     'md5': row.md5,
-                     'lfn': row.lfn,
-                     'filesize': row.filesize,
-                     'parents': literal_eval(row.parents.read()),
-                     'state': row.state,
-                     'created': literal_eval(row.parents.read()),  # postpone conversion to str
-                     'tmplfn': row.tmplfn
-                }
-                ## temporary changes for making REST py3 compatible with Publisher py2 - start
-                ## this block of code can be removed after we complete the 
-                ## deployment in production of the services running in python3
-                # we aim at replacing with unicode all the bytes from such a dictionary:
-                # {'taskname': '220113_142727:dmapelli_crab_20220113_152722', 
-                # 'filetype': 'EDM', 
-                # 'jobid': '7', 
-                # 'outdataset': '/GenericTTbar/dmapelli-[...]-94ba0e06145abd65ccb1d21786dc7e1d/USER', 
-                # 'acquisitionera': 'null', 
-                # 'swversion': 'CMSSW_10_6_29', 
-                # 'inevents': 300, 
-                # 'globaltag': 'None', 
-                # 'publishname': '[...]-94ba0e06145abd65ccb1d21786dc7e1d', 
-                # 'location': 'T2_CH_CERN', 
-                # 'tmplocation': 'T2_UK_London_Brunel', 
-                # 'runlumi': {b'1': {b'2521': b'300'}},                  ## THIS CONTAINS BYTES
-                # 'adler32': '31018715', 
-                # 'cksum': 2091402041, 'md5': 'asda', 
-                # 'lfn': '/store/user/dmapelli/GenericTTbar/[...]/220113_142727/0000/output_7.root', 
-                # 'filesize': 651499, 
-                # 'parents': [b'/store/[...]-0CC47A7C34C8.root'],        ## THIS CONTAINS BYTES
-                # 'state': None, 
-                # 'created': "[b'/store/[...]-0CC47A7C34C8.root']",      ## THIS CONTAINS BYTES
-                # 'tmplfn': '/store/user/dmapelli/GenericTTbar/[...]/220113_142727/0000/output_7.root'}
-                for key0, val0 in filedict.items():
-                    if isinstance(val0, list):  # 'parents' and 'created'
-                        filedict[key0]  = [decodeBytesToUnicode(el) for el in val0]
-                    if isinstance(val0, dict):  # 'runlumi'
-                        for key1, val1 in list(val0.items()):
-                            val0.pop(key1)
-                            val0[decodeBytesToUnicode(key1)] = val1
-                            if isinstance(val1, dict):
-                                for key2, val2 in list(val1.items()):
-                                    val1.pop(key2)
-                                    val1[decodeBytesToUnicode(key2)] = decodeBytesToUnicode(val2)
-                ## temporary changes for making REST py3 compatible with Publisher py2 - end
-                filedict['created'] = str(filedict['created'])   # convert to str, after removal of bytes
-                yield json.dumps(filedict)
+            filedict = {
+                'taskname': taskname,
+                'filetype': row.type,
+                'jobid': row.jobid,
+                    'outdataset': row.outdataset,
+                    'acquisitionera': row.acquisitionera,
+                    'swversion': row.swversion,
+                    'inevents': row.inevents,
+                    'globaltag': row.globaltag,
+                    'publishname': row.publishname,
+                    'location': row.location,
+                    'tmplocation': row.tmplocation,
+                    'runlumi': literal_eval(row.runlumi.read()),
+                    'adler32': row.adler32,
+                    'cksum': row.cksum,
+                    'md5': row.md5,
+                    'lfn': row.lfn,
+                    'filesize': row.filesize,
+                    'parents': literal_eval(row.parents.read()),
+                    'state': row.state,
+                    'created': str(row.parents),
+                    'tmplfn': row.tmplfn
+            }
+            yield json.dumps(filedict)
 
     def inject(self, **kwargs):
         """ Insert or update a record in the database


### PR DESCRIPTION
Fixes #7239 

### status

tested in `test1`, loading this branch with `./start.sh -g`.

The following command returns "200 OK": 

```plaintext
[_crabserver@crabserver-6b9b7b849f-zcbbw data]$ cmsweb-ping --url="http://localhost:8270/crabserver/preprod/filemetadata?taskname=220512_202133:cmsbot_crab_20220512_222128&filetype=EDM" --authz=/etc/hmac/hmac -verbose 1
```

### description

reverts #6967, with a couple of small cosmetic changes:
- separate the dictionary build from `yield json.dumps()`
- remove `if True` introduced in #7231 