### PR TITLE
cicd - can select crabserver and wmcore repos

### DIFF
--- a/cicd/build/jenkins_build_docker.sh
+++ b/cicd/build/jenkins_build_docker.sh
@@ -3,10 +3,15 @@
 set -euo pipefail
 set -x
 
+if [ -z ${IMAGE_TAG} ]; then
+  IMAGE_TAG=${RELEASE_TAG}
+fi
+
 echo "(DEBUG) variables from upstream jenkin job (CRABServer_BuildImage_20220127):"
 echo "(DEBUG)   \- BRANCH: ${BRANCH}"
 echo "(DEBUG)   \- RELEASE_TAG: ${RELEASE_TAG}"
 echo "(DEBUG)   \- RPM_RELEASETAG_HASH: ${RPM_RELEASETAG_HASH}"
+echo "(DEBUG)   \- IMAGE_TAG: $IMAGE_TAG"
 echo "(DEBUG) jenkin job's env variables:"
 echo "(DEBUG)   \- WORKSPACE: $WORKSPACE"
 echo "(DEBUG) end"
@@ -28,11 +33,11 @@ echo "(DEBUG) end"
 # use cmscrab robot account credentials
 docker login registry.cern.ch --username $HARBOR_CMSCRAB_USERNAME --password-stdin <<< $HARBOR_CMSCRAB_PASSWORD
 
-docker build . -t registry.cern.ch/cmscrab/crabtaskworker:${RELEASE_TAG} --network=host \
+docker build . -t registry.cern.ch/cmscrab/crabtaskworker:${IMAGE_TAG} --network=host \
         --build-arg RELEASE_TAG=${RELEASE_TAG} \
         --build-arg RPM_RELEASETAG_HASH=${RPM_RELEASETAG_HASH}
-docker push registry.cern.ch/cmscrab/crabtaskworker:${RELEASE_TAG}
-docker rmi registry.cern.ch/cmscrab/crabtaskworker:${RELEASE_TAG}
+docker push registry.cern.ch/cmscrab/crabtaskworker:${IMAGE_TAG}
+docker rmi registry.cern.ch/cmscrab/crabtaskworker:${IMAGE_TAG}
 
 #build and push crabserver image
 cd $WORKSPACE
@@ -48,4 +53,4 @@ echo "(DEBUG) end"
 
 # relogin to using cmsweb robot account
 docker login registry.cern.ch --username $HARBOR_CMSWEB_USERNAME --password-stdin <<< $HARBOR_CMSWEB_PASSWORD
-CMSK8STAG=${RELEASE_TAG} ./build.sh "crabserver"
+CMSK8STAG=${IMAGE_TAG} ./build.sh "crabserver"

--- a/cicd/build/jenkins_build_rpm.sh
+++ b/cicd/build/jenkins_build_rpm.sh
@@ -6,6 +6,9 @@ echo "(DEBUG) variables from upstream jenkin job (github-webhook):"
 # echo "(DEBUG)   \- ACTION: $ACTION" # (not used)
 # echo "(DEBUG)   \- TITLE: $TITLE" # (not used)
 echo "(DEBUG)   \- RELEASE_TAG: $RELEASE_TAG"  # v3.211111, py3.220124
+echo "(DEBUG)   \- CRABSERVER_REPO: $CRABSERVER_REPO"  # dmwm, belforte, mapellidario, ...
+echo "(DEBUG)   \- WMCORE_REPO: $WMCORE_REPO"  # dmwm, belforte, mapellidario, ...
+echo "(DEBUG)   \- WMCORE_TAG: $WMCORE_TAG"  # <empty>, 1.5.7, ...
 # echo "(DEBUG)   \- BRANCH: $BRANCH" # (empty, not used)
 echo "(DEBUG)   \- PAYLOAD: $PAYLOAD"
 # example of PAYLOAD: https://dmapelli.web.cern.ch/public/crab/20220127/crabserver_github_release_payload_example.json
@@ -19,30 +22,38 @@ git clone -b V00-33-XX https://github.com/cms-sw/pkgtools.git
 git clone https://github.com/cms-sw/cmsdist.git && cd cmsdist && git checkout comp_gcc630
 git clone https://github.com/dmwm/CRABServer.git
 
-#get CRABServer branch name from the payload
-#paylod has a lot of information, but we are only interested in extracting this info: <...>"target_commitish": "python3"<...>
-#regex would extract 'python3' as a BRANCH name
-export BRANCH=$(echo "${PAYLOAD}" | grep -oP '(?<="target_commitish":\s")([^\s]+)(?=", ")')
+if [[ -n  ${PAYLOAD} ]]; then
+   #get CRABServer branch name from the payload, if the payload is not empty
+   #the payload is not empty when this job is triggered by github-webhook,
+   #if this job is launched manually, then the branch will have the value set
+   #as input env variable.
+   #paylod has a lot of information, but we are only interested in extracting this info: <...>"target_commitish": "python3"<...>
+   #regex would extract 'python3' as a BRANCH name
+   export BRANCH=$(echo "${PAYLOAD}" | grep -oP '(?<="target_commitish":\s")([^\s]+)(?=", ")')
+fi
 echo "BRANCH=${BRANCH}" >> $WORKSPACE/properties_file
-echo "(DEBUG) new env variable defined:"
-echo "(DEBUG)   \- BRANCH: $BRANCH"
-echo "(DEBUG) end"
 
 cd CRABServer
 git checkout ${BRANCH}
 cd ..
 
-#get latest WMCore tag
-WMCORE_TAG=$(grep -oP "wmcver==\K.*" CRABServer/requirements.txt)
-echo "(DEBUG) new env variable defined:"
-echo "(DEBUG)   \- WMCORE_TAG: $WMCORE_TAG"
-echo "(DEBUG) end"
+#select the WMCore tag
+if [ ${WMCORE_REPO} == "dmwm" ]; then
+   WMCORE_TAG=$(grep -oP "wmcver==\K.*" CRABServer/requirements.txt)
+fi
 
+echo "(DEBUG) env variables that could have been updated from the default:"
+echo "(DEBUG)   \- BRANCH (crabserver): $BRANCH"
+echo "(DEBUG)   \- WMCORE_TAG: $WMCORE_TAG"
+
+##### All the required env variables are set at this point. Do not set any input below this line
 #update .spec files with new CRABServer and  WMCore tags; update from which branch RPMs should be built
 cp crabserver.spec crabserver.spec.bak 
 cp crabtaskworker.spec crabtaskworker.spec.bak 
 sed -i -e "s/### RPM cms crabserver.*/### RPM cms crabserver ${RELEASE_TAG}/g" -- crabserver.spec
 sed -i -e "s/### RPM cms crabtaskworker.*/### RPM cms crabtaskworker ${RELEASE_TAG}/g" -- crabtaskworker.spec
+sed -i -e "s/^\( *%define crabrepo  *\)[^ ]*\(.*\)*$/\1${CRABSERVER_REPO}\2/" -- crabtaskworker.spec crabserver.spec
+sed -i -e "s/^\( *%define wmcrepo  *\)[^ ]*\(.*\)*$/\1${WMCORE_REPO}\2/" -- crabtaskworker.spec crabserver.spec
 sed -i -e "s/^\( *%define wmcver  *\)[^ ]*\(.*\)*$/\1${WMCORE_TAG}\2/" -- crabtaskworker.spec crabserver.spec
 sed -i -e "/github.com\/%{crabrepo}\/CRABServer.git?obj/s/master/${BRANCH}/" -- crabtaskworker.spec crabserver.spec
 
@@ -78,3 +89,20 @@ if [ "${RELEASE_TAG}" == "${RPM_RELEASETAG}" ]; then
 else
    echo "ERROR: RMP build/upload failed"
 fi
+
+# we use the inputs to build a unique docker image tag, so that we only pass
+# this value to the downstream job, not all the inputs.
+IMAGE_TAG=""
+if [ ${CRABSERVER_REPO} == "dmwm" ]; then
+  IMAGE_TAG=${RELEASE_TAG}
+else
+  IMAGE_TAG="crab_"${CRABSERVER_REPO}"_"${RELEASE_TAG}
+fi
+if [ ${WMCORE_REPO} != "dmwm" ]; then
+  IMAGE_TAG=${IMAGE_TAG}"-wmc_"${WMCORE_REPO}"_"${WMCORE_TAG}
+fi
+echo "IMAGE_TAG=${IMAGE_TAG}" >> $WORKSPACE/properties_file
+
+echo "(DEBUG) new env variable:"
+echo "(DEBUG)   \- IMAGE_TAG: $IMAGE_TAG"
+echo "(DEBUG) end"


### PR DESCRIPTION
#### status

tested


action items on Dario after we merge this:

- [ ] change the script of the job to point to dmwm/CRABServer/master and not mapellidario/CRABServer/$mybranch
- [x] rename the jenkins jobs
- [x] point github-webhook to the new jenkins jobs name

#### description

Edited the build scripts so that we can build docker images selecting generic CRABServer repo/tag and WMCore repo/tag.

When we create a tag in dmwm/CRABServer:

- we run https://cmssdt.cern.ch/dmwm-jenkins/job/github-webhook
- which calls https://cmssdt.cern.ch/dmwm-jenkins/job/20220513_CRABServer_BuildOnRelease (to be renamed)
  - it will use dmwm/CRABServer and dmwm/WMCore repos
  - it will take the dmwm/WMCore tag from dmwm/CRABServer/$branchname/requirements.txt
- which calls https://cmssdt.cern.ch/dmwm-jenkins/view/CRAB/job/20220513_CRABServer_BuildImage (to be renamed)

When we want to build an image with generic parameters:

- call https://cmssdt.cern.ch/dmwm-jenkins/job/20220513_CRABServer_BuildOnRelease (to be renamed) setting all the parameters you want
- which calls https://cmssdt.cern.ch/dmwm-jenkins/view/CRAB/job/20220513_CRABServer_BuildImage (to be renamed)
- beware: if you change the crab or the wmcore repo, the docker image will reflect it. for example, changing both creates images with tag [crab_mapellidario_v3.220513.dario-wmc_mapellidario_2.0.3.pre7crab1](https://registry.cern.ch/harbor/projects/1771/repositories/crabserver/artifacts/sha256:56e3ab148eadee3e32cbd0e330050cd6111c177294972dcaa33d7938c6256149). I am open to better ideas on how to avoid collisions and reflect in the docker image tag name what it contains!





