### PR TITLE
rest - fix how a child loads a parent logger

### DIFF
--- a/src/python/CRABInterface/RESTCache.py
+++ b/src/python/CRABInterface/RESTCache.py
@@ -65,7 +65,7 @@ class RESTCache(RESTEntity):
 
     def __init__(self, app, api, config, mount, extconfig):
         RESTEntity.__init__(self, app, api, config, mount)
-        self.logger = logging.getLogger("CRABLogger:RESTCache")
+        self.logger = logging.getLogger("CRABLogger.RESTCache")
         # get S3 connection secrets from the CRABServerAuth file in the same way
         # as done for DB connection secrets. That file needs to contain an "s3"
         # dictionary with keys: access_key, secret_key

--- a/src/python/CRABInterface/RESTServerInfo.py
+++ b/src/python/CRABInterface/RESTServerInfo.py
@@ -18,7 +18,7 @@ class RESTServerInfo(RESTEntity):
     def __init__(self, app, api, config, mount, centralcfg):
         RESTEntity.__init__(self, app, api, config, mount)
         self.centralcfg = centralcfg
-        self.logger = logging.getLogger("CRABLogger:RESTServerInfo")
+        self.logger = logging.getLogger("CRABLogger.RESTServerInfo")
         #used by the client to get the url where to update the cache (cacheSSL)
 
     def validate(self, apiobj, method, api, param, safe ):


### PR DESCRIPTION
### status

tested, by adding a `self.logger.info()` in RESTCache.py and seeing its output where it should have been.

### description

as mentioned in [1], the correct way of loading a parent logger should be using the dot, not the column

> Each instance has a name, and they are conceptually arranged in a namespace hierarchy using dots (periods) as separators. For example, a logger named ‘scan’ is the parent of loggers ‘scan.text’, ‘scan.html’ and ‘scan.pdf’.

I assume this was not spotted before because we currently do not have any `self.logger.$loglevel()` in these two REST classes.


[1] https://docs.python.org/3/howto/logging.html#advanced-logging-tutorial