### PR TITLE
Print trace in MeasureTime

### DIFF
--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -909,7 +909,7 @@ class MeasureTime:
         self.thread_time = time.thread_time() - self.thread_time
         self.process_time = time.process_time() - self.process_time
         self.perf_counter = time.perf_counter() - self.perf_counter
-        self.readout = 'tot={:.4f} proc={:.4f} thread={:.4f}'.format(
+        self.readout = 'tot={:.6f} proc={:.6f} thread={:.6f}'.format(
                  self.perf_counter, self.process_time, self.thread_time )
         self.logger.info("MeasureTime in second - modulename=%s label='%s' %s trace=%s",
                  self.modulename, self.label, self.readout, self.trace)

--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -885,18 +885,19 @@ def downloadFromS3ViaPSU(filepath=None, preSignedUrl=None, logger=None):
 
 class MeasureTime:
     """
-    Context manager to measure how long a portion of code takes. 
+    Context manager to measure how long a portion of code takes.
     It is intended to be used as:
 
     logger = logging.getLogger()
     with MeasureTime(logger, modulename=__name__, label="myfuncname") as _:
         myfuncname()
-    
+
     """
-    def __init__(self, logger, modulename="", label=""):
+    def __init__(self, logger, modulename="", label="", trace=""):
         self.logger = logger
         self.modulename = modulename
         self.label = label
+        self.trace = trace
 
     def __enter__(self):
         self.perf_counter = time.perf_counter()
@@ -910,5 +911,5 @@ class MeasureTime:
         self.perf_counter = time.perf_counter() - self.perf_counter
         self.readout = 'tot={:.4f} proc={:.4f} thread={:.4f}'.format(
                  self.perf_counter, self.process_time, self.thread_time )
-        self.logger.info("MeasureTime:seconds - modulename=%s label='%s' - %s", 
-                 self.modulename, self.label, self.readout)
+        self.logger.info("MeasureTime in second - modulename=%s label='%s' %s trace=%s",
+                 self.modulename, self.label, self.readout, self.trace)


### PR DESCRIPTION
Add `trace` argument to `MeasureTime.__init__()` to match the log lines in `CRAB*` log with `crabserver*` togather.
`trace` value can get it from `cherrypy.request['db']['trace']`. When use we should log only 12 random char in trace variable, by `cherrypy.request['db']['trace'].replace('RESTSQL:','')`.

Also, change format of log too (change description, move key-value after dash, 6 decimal places). New log will look like 
```
2022-05-24 22:55:51,841:INFO:ServerUtilities:MeasureTime in second - modulename=CRABInterface.RESTBaseAPI label='query_load_all_rows' tot=0.0025 proc=0.0012 thread=0.0012 trace=TQAeYgmvpinx
```

Note:
- I think ` - ` is bad separator for grok in logstash. But I have no better idea.
- Trace should emit by logger, so we don't need to pass trace to MeasureTime or other log message every time we print out.