### PR TITLE
Add trace to crab log #7281

### DIFF
--- a/src/python/CRABInterface/RESTBaseAPI.py
+++ b/src/python/CRABInterface/RESTBaseAPI.py
@@ -96,9 +96,25 @@ class RESTBaseAPI(DatabaseRESTApi):
         logger = logging.getLogger('CRABLogger')
         if loglevel:
             hdlr = logging.handlers.TimedRotatingFileHandler(logfile, when='D', interval=1, backupCount=keptDays)
-            formatter = logging.Formatter('%(asctime)s:%(levelname)s:%(module)s:%(message)s')
+            formatter = logging.Formatter('%(asctime)s:%(trace_id)s:%(levelname)s:%(module)s:%(message)s')
             hdlr.setFormatter(formatter)
+            # add trace_id to log with filter class
+            f = TraceIDFilter()
+            hdlr.addFilter(f)
+
             logger.addHandler(hdlr)
             logger.setLevel(loglevel)
         else:
             logger.addHandler( NullHandler() )
+
+
+class TraceIDFilter(logging.Filter):
+    """
+    Add trace_id to log record and use it in formatter.
+    """
+    def filter(self, record):
+        try:
+            record.trace_id = cherrypy.request.db['handle']['trace']
+        except KeyError:
+            record.trace_id = ""
+        return True

--- a/src/python/CRABInterface/RESTBaseAPI.py
+++ b/src/python/CRABInterface/RESTBaseAPI.py
@@ -114,7 +114,7 @@ class TraceIDFilter(logging.Filter):
     """
     def filter(self, record):
         try:
-            record.trace_id = cherrypy.request.db['handle']['trace']
+            record.trace_id = cherrypy.request.db['handle']['trace'].replace('RESTSQL:','')
         except KeyError:
             record.trace_id = ""
         return True

--- a/src/python/CRABInterface/RESTBaseAPI.py
+++ b/src/python/CRABInterface/RESTBaseAPI.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import logging
+import traceback
 
 import cherrypy
 from subprocess import getstatusoutput
@@ -115,6 +116,7 @@ class TraceIDFilter(logging.Filter):
     def filter(self, record):
         try:
             record.trace_id = cherrypy.request.db['handle']['trace'].replace('RESTSQL:','')
-        except KeyError:
+        except Exception:  # pylint: disable=broad-except
+            traceback.print_exc()
             record.trace_id = ""
         return True


### PR DESCRIPTION
First PR of https://github.com/dmwm/CRABServer/issues/7281

Add SQL trace from WMCore to every log line of CRAB REST log (using `cherrypy.request.db['handle']['trace']` variable).
In summary, create new `loggging.Filter` to add new variable to record object to use in formatter, and attach filter to CRABLogger's handler to apply in every log lines. 
Reference from [official python3 logging cookbook](https://docs.python.org/3/howto/logging-cookbook.html#using-filters-to-impart-contextual-information) about add context (variable) in `logging.Filter`.

In case there is no `cherrypy.request.db['handle']['trace']` variable (I do not know if there is any case), it will emit empty string instead.

Logs will look like this:
```
2022-06-02 11:47:31,922:jCDGFcMxXJQZ:DEBUG:DataFileMetadata:Calling jobmetadata for task 220516_154634:tseethon_crab_20220516_174431 and filetype EDM
```