### PR TITLE
jenknis - script for building and pushing the test docker image

### DIFF
--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM cmssw/cmsweb:20210315
+FROM registry.cern.ch/cmsweb/cmsweb:20220601-stable
 
 RUN yum install -y gfal2-util gfal2-all uberftp python3
 
@@ -11,4 +11,5 @@ COPY testingScripts ${WORK_DIR}/testingScripts
 RUN chmod 777 ${WORK_DIR}/testingScripts
 WORKDIR ${WORK_DIR}/testingScripts
 
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/bin/bash", "-l", "-c"]
+CMD ["/bin/bash"]

--- a/test/container/build.sh
+++ b/test/container/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# 0. check parameters
+echo "(DEBUG) input parameters:"
+# IMAGE_TAG is the only variable used inside this script
+echo "(DEBUG)   \- IMAGE_TAG: ${IMAGE_TAG}"
+# GH_REPO and BRANCH are used by the jenkins bash script wrapper
+echo "(DEBUG)   \- GH_REPO: ${GH_REPO}"
+echo "(DEBUG)   \- BRANCH: ${BRANCH}"
+echo "(DEBUG) end"
+
+
+# 1. build and push the image
+dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+echo $dir
+
+# the next line is necessary when running the script from jenkins.
+# if you build the image manually, just login to registry.cern.ch
+# with your usualy CLI token.
+docker login registry.cern.ch --username $HARBOR_CMSCRAB_USERNAME --password-stdin <<< $HARBOR_CMSCRAB_PASSWORD
+
+docker build -t registry.cern.ch/cmscrab/crabtesting:$IMAGE_TAG $dir
+docker push registry.cern.ch/cmscrab/crabtesting:$IMAGE_TAG 
+docker rmi registry.cern.ch/cmscrab/crabtesting:$IMAGE_TAG 
+


### PR DESCRIPTION
Fixes #7234

### status

Ready to be merged

### description

The docker build was breaking simply because we were using an old base docker image. It was enough to witch to a newer cmsweb image to fix the build .

Moreover, I added a small shell script to build and push the docker image, then I created the jenkins job https://cmssdt.cern.ch/dmwm-jenkins/view/CRAB/job/CRABServer_BuildTestImage/ to run this script.

I tested the jenkins job and everything looks good:

```plaintext
> docker run --rm -it registry.cern.ch/cmscrab/crabtesting:220620 "cat ./statusTracking.py | grep 'remove failed'"
            # remove failed probe jobs (job id of X-Y kind) if any from count
```

Eventually, I changed the jenkins job https://cmssdt.cern.ch/dmwm-jenkins/job/COPYCAT_CRABServer_ExecuteTests/ to select the tag of the test docker image via an input parameter and set the default to the most recent `registry.cern.ch/cmscrab/crabtesting:220620`