### PR TITLE
DataWorkflow - second attempt at fixing kill() after aso cleanup

### DIFF
--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -390,8 +390,6 @@ class DataWorkflow(object):
         warnings = str(warnings)
 
         if row.task_status in ['SUBMITTED', 'KILLFAILED', 'RESUBMITFAILED', 'FAILED', 'KILLED', 'TAPERECALL']:
-            #Set arguments first so in case of failure we don't do any "damage"
-            self.api.modify(self.Task.SetArgumentsTask_sql, taskname = [workflow])
             self.api.modify(self.Task.SetStatusWarningTask_sql, status = ["NEW"], command = ["KILL"], taskname = [workflow], warnings = [str(warnings)])
         elif row.task_status == 'NEW' and row.task_command == 'SUBMIT':
             #if the task has just been submitted and not acquired by the TW


### PR DESCRIPTION
Fixes #7321 

#### status

tested in preprod [1], running my branch with `start.sh -g`.

Since we already agreed on this solution and since the tests look promising, I would merge this soon.

#### description

This PR addresses the issue described at #7321, which has been introduced by #7297, which was meant to address #7291.

The rationale for the changes in this PR is described in this comment https://github.com/dmwm/CRABServer/issues/7321#issuecomment-1169798532

#### more info

<details><summary>[1]</summary>

I successfulyl managed to kill a couple of tasks:

- `220628_145148:dmapelli_crab_20220628_165145`
- `220629_113548:dmapelli_crab_20220629_133545`

I will paste the logs only for one of these.

```plaitnext
> crab status
CRAB project directory:         /afs/cern.ch/user/d/dmapelli/crab/submit/1-analysis/crab_projects/crab_20220629_133545
Task name:                      220629_113548:dmapelli_crab_20220629_133545
Grid scheduler - Task Worker:   crab3@vocms0199.cern.ch - crab-preprod-tw01
Status on the CRAB server:      KILLED
Task URL to use for HELP:       https://cmsweb-testbed.cern.ch/crabserver/ui/task/220629_113548%3Admapelli_crab_20220629_133545
Dashboard monitoring URL:       https://monit-grafana.cern.ch/d/cmsTMDetail/cms-task-monitoring-task-view?orgId=11&var-user=dmapelli&var-task=220629_113548%3Admapelli_crab_20220629_133545&from=1656498948000&to=now
Warning:                        The following sites from the user site whitelist are blacklisted by the CRAB server: ['T2_UK_SGrid_Bristol']. Since the CRAB server blacklist has precedence, these sites are not considered in the user whitelist.
Warning:                        The following sites appear in both the user site blacklist and whitelist: ['T2_ES_IFCA']. Since the whitelist has precedence, these sites are not considered in the blacklist.
Status on the scheduler:        SUBMITTED

Jobs status:                    idle                    100.0% (10/10)

No publication information available yet
Log file is /afs/cern.ch/user/d/dmapelli/crab/submit/1-analysis/crab_projects/crab_20220629_133545/crab.log
```

the log from crabserver looks ok

```plaintext
[29/Jun/2022:13:37:15]  RESTSQL:tuMDmwzxVORf ENTER cmsweb_analysis_preprod@int2r CRABInterface.RESTBaseAPI.RESTBaseAPI (DELETE preprod workflow) inuse=0 idle=1 - Podname=crabserver-7545b9b448-rncz6 Type=cherrypylog
[29/Jun/2022:13:37:15]  RESTSQL:tuMDmwzxVORf (previously QemgSaAMuLvj) connected, client: 19.11.0.0.0, server: 19.13.0.0.0, stmtcache: 50 - Podname=crabserver-7545b9b448-rncz6 Type=cherrypylog
[29/Jun/2022:13:37:15]  RESTSQL:tuMDmwzxVORf ping - Podname=crabserver-7545b9b448-rncz6 Type=cherrypylog
[29/Jun/2022:13:37:15]  RESTSQL:tuMDmwzxVORf check [select sysdate from dual] - Podname=crabserver-7545b9b448-rncz6 Type=cherrypylog
[29/Jun/2022:13:37:15]  RESTSQL:tuMDmwzxVORf connection established - Podname=crabserver-7545b9b448-rncz6 Type=cherrypylog
[29/Jun/2022:13:37:15]  DEBUG: authz operator {'dn': '/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=dmapelli/CN=817881/CN=Dario Mapelli', 'method': 'X509Proxy', 'login': 'dmapelli', 'name': 'Dario Mapelli', 'roles': {'admin': {'site': set(), 'group': {'reqmgr'}}, 'data-manager': {'site': set(), 'group': {'reqmgr'}}, 'operator': {'site': set(), 'group': {'crab3'}}, 'user': {'site': set(), 'group': {'users'}}}} to access resources ['220629_113548:dmapelli_crab_20220629_133545'] - Podname=crabserver-7545b9b448-rncz6 Type=cherrypylog
[29/Jun/2022:13:37:15]  RESTSQL:tuMDmwzxVORf prepare [SELECT tm_taskname, tm_task_status, tm_task_command, tm_user_role, tm_user_group,              tm_task_failure, tm_split_algo, tm_split_args, tm_save_logs, tm_username,              tm_user_dn, tm_arguments, tm_input_dataset, tm_dbs_url, tm_task_warnings, tm_publication, tm_user_webdir,              tm_output_dataset, tm_collector, tm_schedd, tm_dry_run, clusterid, tm_start_time, tw_name              FROM tasks WHERE tm_taskname=:taskname] - Podname=crabserver-7545b9b448-rncz6 Type=cherrypylog
[29/Jun/2022:13:37:15]  RESTSQL:tuMDmwzxVORf execute: () {'taskname': '220629_113548:dmapelli_crab_20220629_133545'} - Podname=crabserver-7545b9b448-rncz6 Type=cherrypylog
[29/Jun/2022:13:37:15]  RESTSQL:tuMDmwzxVORf prepare [UPDATE tasks SET tm_task_status = upper(:status), tm_task_command = upper(:command), tm_task_warnings = :warnings WHERE tm_taskname = :taskname] - Podname=crabserver-7545b9b448-rncz6 Type=cherrypylog
[29/Jun/2022:13:37:15]  RESTSQL:tuMDmwzxVORf executemany: ([{'status': 'NEW', 'command': 'KILL', 'taskname': '220629_113548:dmapelli_crab_20220629_133545', 'warnings': '["The following sites from the user site whitelist are blacklisted by the CRAB server: [\'T2_UK_SGrid_Bristol\']. Since the CRAB server blacklist has precedence, these sites are not considered in the user whitelist.", "The following sites appear in both the user site blacklist and whitelist: [\'T2_ES_IFCA\']. Since the whitelist has precedence, these sites are not considered in the blacklist."]'}],) {} - Podname=crabserver-7545b9b448-rncz6 Type=cherrypylog
[29/Jun/2022:13:37:15]  RESTSQL:tuMDmwzxVORf commit - Podname=crabserver-7545b9b448-rncz6 Type=cherrypylog
[29/Jun/2022:13:37:15] crabserver-7545b9b448-rncz6 188.185.14.61 "DELETE /crabserver/preprod/workflow HTTP/1.1" 200 OK [data: 7320 in 451 out 208458 us ] [auth: OK "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=dmapelli/CN=817881/CN=Dario Mapelli" "" ] [ref: "" "CRABClient/v3.220323" ] - Podname=crabserver-7545b9b448-rncz6 Type=cherrypylog
[29/Jun/2022:13:37:15]  RESTSQL:tuMDmwzxVORf release with rollback - Podname=crabserver-7545b9b448-rncz6 Type=cherrypylog
[29/Jun/2022:13:37:15]  RESTSQL:tuMDmwzxVORf RELEASED cmsweb_analysis_preprod@int2r timeout=300 inuse=0 idle=1 - Podname=crabserver-7545b9b448-rncz6 Type=cherrypylog
```

</details>