### PR TITLE
fix bug on RESTWorkerWorkflow when fetch task from older REST #

### DIFF
--- a/src/python/CRABInterface/RESTWorkerWorkflow.py
+++ b/src/python/CRABInterface/RESTWorkerWorkflow.py
@@ -119,7 +119,7 @@ def fixupTask(task):
         fixedCurr = current if (current is None or isinstance(current, str)) else current.read()
         result[field] = fixedCurr
 
-    # fliter_evaluate values
+    # liter_evaluate values
     for field in ['tm_site_whitelist', 'tm_site_blacklist', 'tm_split_args', 'tm_outfiles', 'tm_tfile_outfiles',
                   'tm_edm_outfiles', 'tm_user_infiles', 'tm_arguments', 'tm_scriptargs',
                   'tm_user_files']:


### PR DESCRIPTION
Fix PR https://github.com/dmwm/CRABServer/pull/7296

I forgot to check compatibility with tasks that save by old REST.
New tasks in `tm_user_config` always have `"{"partialdataset": <True/False>}"`, but older one is just null in database. Oracle DBAPI convert null to None and raise error when crab code try to execute `.read()`.

I move this code in to `fixupTask()` (I just read it today what it do) to make it easier to get LOB data and convert to json.
