### PR TITLE
Make measure time and size loging in same format

### DIFF
--- a/src/python/CRABInterface/RESTBaseAPI.py
+++ b/src/python/CRABInterface/RESTBaseAPI.py
@@ -24,7 +24,7 @@ from CRABInterface.RESTCache import RESTCache
 from CRABInterface.DataFileMetadata import DataFileMetadata
 from CRABInterface.DataWorkflow import DataWorkflow
 from CRABInterface.DataUserWorkflow import DataUserWorkflow
-from ServerUtilities import get_size, MeasureTime
+from ServerUtilities import measure_size, MeasureTime
 
 #In case the log level is not specified in the configuration we use the NullHandler and we do not print messages
 #The NullHandler is included as of python 3.1
@@ -146,15 +146,7 @@ class RESTBaseAPI(DatabaseRESTApi):
                             tmp = _FakeLOB(new_row[i].read())
                             new_row[i] = tmp
                     ret.append(new_row)
-                # Temporary add strlen and MeasureTime to see how much difference
-                # between get_size and strlen and and how long does it take in
-                    # production env.
-                with MeasureTime() as size_time:
-                    size = get_size(ret)
-                with MeasureTime() as strlen_time:
-                    strlen = len(str(ret))
-                self.logger.info('query_size=%d strlen=%d query_size_time=%.6f strlen_time=%.6f',
-                                 size, strlen, size_time.perf_counter, strlen_time.perf_counter)
+                measure_size(ret, self.logger)
                 all_rows = iter(ret)  # return as iterable object
         return all_rows
 

--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -918,8 +918,16 @@ class MeasureTime:
         self.readout = 'tot={:.4f} proc={:.4f} thread={:.4f}'.format(
                  self.perf_counter, self.process_time, self.thread_time )
         if self.logger:
-            self.logger.info("MeasureTime:seconds - modulename=%s label='%s' - %s",
+            self.logger.info("MeasureTime:seconds - modulename=%s label='%s' %s",
                     self.modulename, self.label, self.readout)
+
+
+def measure_size(obj, logger=None):
+    with MeasureTime() as size_time:
+        obj_size = get_size(obj)
+    if logger:
+        logger.info('MeasureSize:bytes - obj_size=%d get_size_time=%.6f', obj_size, size_time.perf_counter)
+    return obj_size
 
 
 def get_size(obj, seen=None):


### PR DESCRIPTION
Make measure size output log same format as `MeasureTime` . 

New log will look like this.
```
2022-07-19 01:46:38,169:FYOnteLbENPV:INFO:ServerUtilities:MeasureTime:seconds - modulename=CRABInterface.RESTBaseAPI label='RESTBaseAPI.execute' tot=0.0009 proc=0.0008 thread=0.0001
2022-07-19 01:46:38,171:FYOnteLbENPV:INFO:ServerUtilities:MeasureTime:seconds - modulename=CRABInterface.RESTBaseAPI label='RESTBaseAPI.executemany' tot=0.0007 proc=0.0003 thread=0.0001
2022-07-19 01:46:38,208:LPaomRBQFtYO:INFO:ServerUtilities:MeasureTime:seconds - modulename=CRABInterface.RESTBaseAPI label='RESTBaseAPI.query_load_all_rows' tot=0.0014 proc=0.0009 thread=0.0008
2022-07-19 01:46:38,207:LPaomRBQFtYO:INFO:RESTBaseAPI:MeasureSize:bytes - modulename=CRABInterface.RESTBaseAPI label='RESTBaseAPI.query_load_all_rows' obj_size=10100 get_size_time=0.000227
```
And, later parse in logstash https://github.com/novicecpp/CMSKubernetes/commit/364ea8ae9aa2660848fc88dcbea8c305ce15ec7a