### PR TITLE
crabserver ui - properly open task info on dev2/test11/devtwo instance

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -61,6 +61,7 @@
 									<option value="prod">prod</option>
 									<option value="preprod">preprod</option>
 									<option value="dev">dev</option>
+									<option value="devtwo">devtwo</option>
 								</select>
 							</div>
 

--- a/src/script/task_info.js
+++ b/src/script/task_info.js
@@ -820,6 +820,13 @@ $(document).ready(function() {
                 transferInfo = "https://" + document.domain + "/crabserver/dev/fileusertransfers?subresource=getTransferStatus&taskname="
                 docInfo = "https://" + document.domain + "/crabserver/dev/fileusertransfers?subresource=getById&id="
                 break;
+            case "devtwo":
+                taskInfoUrl = "https://" + document.domain + "/crabserver/devtwo/task?subresource=search&workflow=";
+                taskStatusUrl = "https://" + document.domain + "/crabserver/devtwo/workflow?workflow=";
+                webDirProxyApiUrl = "https://" + document.domain + "/crabserver/devtwo/task?subresource=webdirprx&workflow="
+                transferInfo = "https://" + document.domain + "/crabserver/devtwo/fileusertransfers?subresource=getTransferStatus&taskname="
+                docInfo = "https://" + document.domain + "/crabserver/devtwo/fileusertransfers?subresource=getById&id="
+                break;
             default:
                 break;
         }
@@ -832,6 +839,9 @@ $(document).ready(function() {
                 break;
             case "cmsweb-testbed.cern.ch":
                 $("#db-selector-box").val("preprod");
+                break;
+            case "cmsweb-test11.cern.ch":
+                $("#db-selector-box").val("devtwo");
                 break;
             default:
                 $("#db-selector-box").val("dev")
@@ -851,6 +861,8 @@ $(document).ready(function() {
                 return "prod";
             case "cmsweb-testbed.cern.ch":
                 return "preprod";
+            case "cmsweb-test11.cern.ch":
+                return "devtwo";
             default:
                 return "dev";
         }


### PR DESCRIPTION
#### status

I tested this on test11 and it works. It feels safe enough that I will merge it myself if I do not hear any objection in the next few days.

#### problem description

While working with `test11`/`dev2`/`devtwo` instance,  I noticed that from the crabserver UI web page we could not load task information.

This PR is related to #7230 

#### solution

I edited `index.html` and `task_info.js` so that clicking on the help url returned from `crab status` open the correct webpage also when using dev2/test11/devtwo instance.

For example, after applying this PR, the link https://cmsweb-test11.cern.ch/crabserver/ui/task/220727_124006:dmapelli_crab_20220727_144002 shows

![image](https://user-images.githubusercontent.com/16376695/181277472-13e02370-d403-476e-a996-56a6bf482ef2.png)

fyi: @novicecpp we may want to add a pointer to this PR in the documentation page about creating a new DB instance.
