### PR TITLE
cicd - fix when tag is not on latest commit of a branch

### DIFF
--- a/cicd/build/jenkins_build_rpm.sh
+++ b/cicd/build/jenkins_build_rpm.sh
@@ -55,7 +55,10 @@ sed -i -e "s/### RPM cms crabtaskworker.*/### RPM cms crabtaskworker ${RELEASE_T
 sed -i -e "s/^\( *%define crabrepo  *\)[^ ]*\(.*\)*$/\1${CRABSERVER_REPO}\2/" -- crabtaskworker.spec crabserver.spec
 sed -i -e "s/^\( *%define wmcrepo  *\)[^ ]*\(.*\)*$/\1${WMCORE_REPO}\2/" -- crabtaskworker.spec crabserver.spec
 sed -i -e "s/^\( *%define wmcver  *\)[^ ]*\(.*\)*$/\1${WMCORE_TAG}\2/" -- crabtaskworker.spec crabserver.spec
-sed -i -e "/github.com\/%{crabrepo}\/CRABServer.git?obj/s/master/${BRANCH}/" -- crabtaskworker.spec crabserver.spec
+# we do not need to replace the branch name in the github URLs in the specfiles, for example here:
+# https://github.com/cms-sw/cmsdist/blob/aa4897a3d70514b0973008d693e3a6e1009afe4d/crabserver.spec#L22
+# i.e. we can leave `obj=master` whatever the value of $BRANCH is.
+# read https://github.com/dmwm/CRABServer/issues/7357 for more info.
 
 echo "(DEBUG) diff cms-sw/cmsdist/crabserver.spec"
 diff -u crabserver.spec.bak crabserver.spec


### PR DESCRIPTION
Fixes #7357 

### status

tested

### description

This PR removes a tweak to the `crabserver.spec` and `crabtaskworker.spec` specfiles, since it is not necessary and only causes troubles.

I tested that this PR does not cause problems for `cmsBuild` when we have a branch name that is not `master` [1].

Moreover, the following images have successfully been built with the version of the script proposed by this PR

- [x] `registry.cern.ch/cmsweb/crabserver:v3.220725` (tag from a specific commit), which looks ok [2]
- [x] `registry.cern.ch/cmscrab/crabtaskworker:v3.220725`  (tag from a specific commit) which looks ok [3]
- [x] `registry.cern.ch/cmsweb/crabserver:crab_novicecpp_v3.221301.3`, from https://cmssdt.cern.ch/dmwm-jenkins/job/CRABServer_BuildImage/40/console (since @novicecpp did not complain, I assume this is ok!)
- [x] rebuild of `registry.cern.ch/cmsweb/crabserver:v3.220630` and `registry.cern.ch/cmscrab/crabtaskworker:v3.220630` (tag from a branch), triggered manually re-delivering the webhook from github. this looks ok (similar checks as the ones for the images above, omitted for brevity)

### furher ideas

Since with this PR we allow the `$BRANCH` variable in our CI scripts to hold both branch names and commit ids, we can rename it to `$COMMIT_REFERENCE`. This would require some proper renaming of the scripts and of the jenkins jobs parameters. If we deem this necessary or cleaner, I can do it in my spare time.

### more info

[1]


```bash
> mkdir crab
> cd crab
> git init
> git pull --tags https://github.com/dmwm/CRABServer.git refs/heads/python3
remote: Enumerating objects: 26749, done.
remote: Counting objects: 100% (217/217), done.
remote: Compressing objects: 100% (149/149), done.
remote: Total 26749 (delta 127), reused 126 (delta 68), pack-reused 26532
Receiving objects: 100% (26749/26749), 16.79 MiB | 28.19 MiB/s, done.
Resolving deltas: 100% (17978/17978), done.
From https://github.com/dmwm/CRABServer
 * branch              python3                 -> FETCH_HEAD
 * [new tag]           0.0.1                   -> 0.0.1
 * [new tag]           1203a                   -> 1203a
 * [new tag]           1203b                   -> 1203b
 [...]
  * [new tag]           v3.220707               -> v3.220707
 * [new tag]           v3.220713               -> v3.220713
 * [new tag]           v3.220725               -> v3.220725
 * [new tag]           v3.restpy3.0            -> v3.restpy3.0
 * [new tag]           v3.restpy3.1            -> v3.restpy3.1
 * [new tag]           v3.restpy3.211101.1     -> v3.restpy3.211101.1
 > git reset --hard v3.220725
HEAD is now at 6f133bf4 improve comments
```

[2] 

```bash
[_crabserver@88af215812c9 data]$ source /data/srv/current/sw.crab_6f133bf4e360e712ba1f7e5f962fd29c0cfcc50e/slc7_amd64_gcc630/cms/crabserver/v3.220725-eaa17b7b53b8ce66fa9fe34f4a8a25bb/etc/profile.d/init.sh
[_crabserver@88af215812c9 data]$ which python3
/data/srv/HG2208c-ce9416d2d06b70b669584e9659f90f07/sw.crab_6f133bf4e360e712ba1f7e5f962fd29c0cfcc50e/slc7_amd64_gcc630/external/python3/3.8.2-comp/bin/python3
[_crabserver@88af215812c9 data]$ python3
Python 3.8.2 (default, Jan 22 2021, 17:57:37)
[GCC 6.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>
```

and contains change from https://github.com/dmwm/CRABServer/commit/e765269ed859e12736c2075f32c81de5fb2451d5

```bash
[_crabserver@88af215812c9 data]$ sed -n 149p /data/srv/current/sw.crab_6f133bf4e360e712ba1f7e5f962fd29c0cfcc50e/slc7_amd64_gcc630/cms/crabserver/v3.220725-eaa17b7b53b8ce66fa9fe34f4a8a25bb/lib/python3.8/site-packages/CRABInterface/RESTBaseAPI.py
                measure_size(ret, logger=self.logger, modulename=__name__, label="RESTBaseAPI.query_load_all_rows")
```

Notice that a new directory in the `cmsrep` repository has been created: https://cmsrep.cern.ch/cmssw/repos/comp.crab_6f133bf4e360e712ba1f7e5f962fd29c0cfcc50e/slc7_amd64_gcc630/latest/  , which is reflected in this directory name in the docker image

```bash
[_crabserver@392ae3dedd85 data]$ ls /data/srv/current/ | grep -E "^sw.crab_.*"
sw.crab_6f133bf4e360e712ba1f7e5f962fd29c0cfcc50e
```

The commit ID properly replaced the branch name.

[3]

contains changes from https://github.com/dmwm/CRABServer/commit/6f133bf4e360e712ba1f7e5f962fd29c0cfcc50e

```plaintext
[crab3@e41fbf93315a TaskManager]$ sed -n '83,85p' /data/srv/Publisher/current/slc7_amd64_gcc630/cms/crabtaskworker/v3.220725-adc397ebbfbbf3dce198e2b8d4230db5/lib/python3.8/site-packages/Publisher/TaskPublish.py
    Returns a 2-element ntuple : (exitcode, message)
    exit codes:  0 OK, 1 taking too long, 2 failed, 3 unknown status, 4, inconsistent status
    those are just historical things, code which uses this method only checks if exitcode is 0
```