### PR TITLE
FTS_Transfers.py - adapt to new rucio api

### DIFF
--- a/scripts/task_process/FTS_Transfers.py
+++ b/scripts/task_process/FTS_Transfers.py
@@ -406,8 +406,8 @@ def submit(rucioClient, ftsContext, toTrans, crabserver):
             dst_scheme, src_scheme, _, _ = find_matching_scheme(
                 {"protocols": rucioClient.get_protocols(dst_rse)},
                 {"protocols": rucioClient.get_protocols(src_rse)},
-                "third_party_copy",
-                "third_party_copy",
+                "third_party_copy_read",
+                "third_party_copy_write",
             )
             dst_pfn_template = rucioClient.lfns2pfns(dst_rse, [dst_did],
                                                      operation="third_party_copy", scheme=dst_scheme)

--- a/scripts/task_process/FTS_Transfers.py
+++ b/scripts/task_process/FTS_Transfers.py
@@ -410,9 +410,9 @@ def submit(rucioClient, ftsContext, toTrans, crabserver):
                 "third_party_copy_write",
             )
             dst_pfn_template = rucioClient.lfns2pfns(dst_rse, [dst_did],
-                                                     operation="third_party_copy", scheme=dst_scheme)
+                                                     operation="write", scheme=dst_scheme)
             src_pfn_template = rucioClient.lfns2pfns(src_rse, [src_did],
-                                                     operation="third_party_copy", scheme=src_scheme)
+                                                     operation="read", scheme=src_scheme)
             dst_pfn_prefix = '/'.join(dst_pfn_template[dst_did].split("/")[:-2])
             src_pfn_prefix = '/'.join(src_pfn_template[src_did].split("/")[:-2])
         except Exception as ex:


### PR DESCRIPTION
related to #7364 

Despite what previously announced, this required two separate fixes.

1. (first commit of this PR) when using `from rucio.rse.rsemanager import find_matching_scheme`, instead of targeting data that contains `    'third_party_copy': 1,`, we need to look for `    'third_party_copy_(read|write)': 1,`.

I tested the proposed changes with Stefano's jupyter notebook https://github.com/belforte/utils/blob/master/notebooks/TestLfns2Pfns.ipynb

```python
client=cli
src_rse = "T2_IT_Legnaro"
dst_rse = "T3_CH_CERNBOX"
dids = ["cms:/store/user/ncsmith/my_file.root"]
dst_scheme, src_scheme, _, _ = find_matching_scheme(
    {"protocols": client.get_protocols(dst_rse)},
    {"protocols": client.get_protocols(src_rse)},
    "third_party_copy_read",
    "third_party_copy_write",
)
print(dst_scheme, src_scheme)
```
```plaintext
DEBUG:urllib3.connectionpool:http://cms-rucio.cern.ch:80 "GET /rses/T3_CH_CERNBOX/protocols?protocol_domain=ALL HTTP/1.1" 200 830
DEBUG:urllib3.connectionpool:http://cms-rucio.cern.ch:80 "GET /rses/T2_IT_Legnaro/protocols?protocol_domain=ALL HTTP/1.1" 200 667
davs davs
```

Notice that `find_matching_scheme` has a weird interface which requires to pass parameters about `destination, source, source, destination`

```python
help(find_matching_scheme)
```
```plaintext
Help on function find_matching_scheme in module rucio.rse.rsemanager:

find_matching_scheme(rse_settings_dest, rse_settings_src, operation_src, operation_dest, domain='wan', scheme=None)
    Find the best matching scheme between two RSEs
    
    :param rse_settings_dest:    RSE settings for the destination RSE.
    :param rse_settings_src:     RSE settings for the src RSE.
    :param operation_src:        Source Operation such as read, write.
    :param operation_dest:       Dest Operation such as read, write.
    :param domain:               Domain such as lan, wan.
    :param scheme:               List of supported schemes.
    :returns:                    Tuple of matching schemes (dest_scheme, src_scheme, dest_scheme_priority, src_scheme_priority).

```


2. (second commit of this PR) apparently also `rucio.client.lfns2pfns()` had a change in the interface. This required changes like

```diff
dst_pfn_template = rucioClient.lfns2pfns(dst_rse, [dst_did],
-                                                     operation="third_party_copy", scheme=dst_scheme)
+                                                     operation="write", scheme=dst_scheme)
```


#### further comments

As Stefano mentioned, there are many possible ways of selecting which protocol to use for FTS transfers and we may come up with something better, however for the time being I would stick with this solution.

As always, despite the urgency, I would test this change in preprod before turning on production CRAB.

Any suggestion is more than welcome! :)