### PR TITLE
FTS_Transfers.py - adapt to new rucio api

### DIFF
--- a/scripts/task_process/FTS_Transfers.py
+++ b/scripts/task_process/FTS_Transfers.py
@@ -410,9 +410,9 @@ def submit(rucioClient, ftsContext, toTrans, crabserver):
                 "third_party_copy_write",
             )
             dst_pfn_template = rucioClient.lfns2pfns(dst_rse, [dst_did],
-                                                     operation="write", scheme=dst_scheme)
+                                                     operation="third_party_copy_write", scheme=dst_scheme)
             src_pfn_template = rucioClient.lfns2pfns(src_rse, [src_did],
-                                                     operation="read", scheme=src_scheme)
+                                                     operation="third_party_copy_read", scheme=src_scheme)
             dst_pfn_prefix = '/'.join(dst_pfn_template[dst_did].split("/")[:-2])
             src_pfn_prefix = '/'.join(src_pfn_template[src_did].split("/")[:-2])
         except Exception as ex:

--- a/src/python/RucioUtils.py
+++ b/src/python/RucioUtils.py
@@ -45,7 +45,7 @@ def getWritePFN(rucioClient=None, siteName='', lfn='', logger=None):
     did = 'cms:' + lfn
     # we prefer to do ASO via FTS which uses 3rd party copy, fall back to protocols defined
     # for other operations in case that fails, order matters here !
-    for operation in ['third_party_copy', 'write', 'read']:
+    for operation in ['third_party_copy_write', 'write', 'third_party_copy_read', 'read']:
         try:
             logger.warning('Try Rucio lfn2pn with operation %s', operation)
             didDict = rucioClient.lfns2pfns(siteName, [did], operation=operation)

--- a/src/python/RucioUtils.py
+++ b/src/python/RucioUtils.py
@@ -29,7 +29,8 @@ def getNativeRucioClient(config=None, logger=None):
 
     return nativeClient
 
-def getWritePFN(rucioClient=None, siteName='', lfn='', logger=None):
+def getWritePFN(rucioClient=None, siteName='', lfn='', 
+                operations=['third_party_copy_write', 'write'], logger=None):
     """
     convert a single LFN into a PFN which can be used for Writing via Rucio
     Rucio supports the possibility that at some point in the future sites may
@@ -45,7 +46,11 @@ def getWritePFN(rucioClient=None, siteName='', lfn='', logger=None):
     did = 'cms:' + lfn
     # we prefer to do ASO via FTS which uses 3rd party copy, fall back to protocols defined
     # for other operations in case that fails, order matters here !
-    for operation in ['third_party_copy_write', 'write', 'third_party_copy_read', 'read']:
+    # "third_party_copy_write": provides the PFN to be used with FTS
+    # "write": provides the PFN to be used with gfal
+    # 2022-08: dario checked with felipe that every sane RSE has non-zero value
+    # for the third_party_copy_write column, which means that it is available.
+    for operation in operations:
         try:
             logger.warning('Try Rucio lfn2pn with operation %s', operation)
             didDict = rucioClient.lfns2pfns(siteName, [did], operation=operation)

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -609,8 +609,12 @@ class DagmanCreator(TaskAction):
             tempDest = os.path.join(temp_dest, counter)
             directDest = os.path.join(dest, counter)
             if lastDirectDest != directDest:
+                # Since we want to compute the PFN for the direct stageout,
+                # we only care about 'write', which should be used with plain gfal.
+                # there is no need to get the PFN for 'third_party_copy_write',
+                # which should be used with FTS.
                 lastDirectPfn = getWritePFN(self.rucioClient, siteName=task['tm_asyncdest'], lfn=directDest,
-                                            logger=self.logger)
+                                            operations=['write'], logger=self.logger)
                 lastDirectDest = directDest
             pfns = ["log/cmsRun_{0}.log.tar.gz".format(count)] + remoteOutputFiles
             pfns = ", ".join(["%s/%s" % (lastDirectPfn, pfn) for pfn in pfns])

--- a/src/python/TaskWorker/Actions/StageoutCheck.py
+++ b/src/python/TaskWorker/Actions/StageoutCheck.py
@@ -93,7 +93,10 @@ class StageoutCheck(TaskAction):
             filename = re.sub("[:-_]", "", self.task['tm_taskname']) + '_crab3check.tmp'
             try:
                 lfn = os.path.join(self.task['tm_output_lfn'], filename)
-                pfn = getWritePFN(self.rucioClient, siteName=self.task['tm_asyncdest'], lfn=lfn, logger=self.logger)
+                # when checking the stageout, we are interested if we can use FTS for ASO.
+                # therefore, we are interested in 'third_party_copy_write' only.
+                # we should not get a PFN for 'write', which should be used for plain gfal.
+                pfn = getWritePFN(self.rucioClient, siteName=self.task['tm_asyncdest'], lfn=lfn, operations=['third_party_copy_write'], logger=self.logger)
                 cpCmd += append + os.path.abspath(filename) + " " + pfn
                 rmCmd += " " + pfn
                 createDummyFile(filename, self.logger)


### PR DESCRIPTION
Related to #7364 

Supersedes #7365 

#### description

following up on this comment https://github.com/dmwm/CRABServer/issues/7364#issuecomment-1220361768

We need to change the `operation` argument when we call `from rucio.client import Client; Client.lfns2pfns()`. We can not pass `third_party_copy` anymore. We need to use `third_party_copy_(read|write)` or `(read|write)` depending on the case.

See this comment for more info: https://github.com/dmwm/CRABServer/issues/7364#issuecomment-1220875530