### PR TITLE
jobwr - hardcode SITECONFIG_PATH for cmssw 12_6_X

### DIFF
--- a/scripts/CMSRunAnalysis.py
+++ b/scripts/CMSRunAnalysis.py
@@ -638,6 +638,7 @@ if __name__ == "__main__":
         preCmd = 'export X509_USER_PROXY=%s; ' % os.getenv('X509_USER_PROXY')
         # needed for root problem with $HOME/.root.mimes, #6801
         preCmd += 'export HOME=${HOME:-$PWD}; '
+        preCmd += 'export SITECONFIG_PATH=/cvmfs/cms.cern.ch/SITECONF/local; '
         # needed for accessing EOS at RAL (Echo). See https://ggus.eu/index.php?mode=ticket_info&ticket_id=155272
         if os.getenv('XrdSecGSISRVNAMES'):
             preCmd += 'export XrdSecGSISRVNAMES=%s; ' % os.getenv('XrdSecGSISRVNAMES')

--- a/scripts/CMSRunAnalysis.py
+++ b/scripts/CMSRunAnalysis.py
@@ -638,6 +638,7 @@ if __name__ == "__main__":
         preCmd = 'export X509_USER_PROXY=%s; ' % os.getenv('X509_USER_PROXY')
         # needed for root problem with $HOME/.root.mimes, #6801
         preCmd += 'export HOME=${HOME:-$PWD}; '
+        # temporary quick fix for #7413, CMSSW 12_6 requires new env variable
         preCmd += 'export SITECONFIG_PATH=/cvmfs/cms.cern.ch/SITECONF/local; '
         # needed for accessing EOS at RAL (Echo). See https://ggus.eu/index.php?mode=ticket_info&ticket_id=155272
         if os.getenv('XrdSecGSISRVNAMES'):


### PR DESCRIPTION
Fixes #7413

I tested this in `test11` and looks ok:

- https://cmsweb.cern.ch:8443/scheddmon/059/dmapelli/221003_163429:dmapelli_crab_20221003_183426/job_out.1.0.txt

I will deploy to production soon. Reminder for future me: if you run this PR with `./start.sh -g`, then you also need to run `./updateRuntime.sh`! that applies to any change to files which are sent to the sched or WN, job wrapper, cmscp.py, Pre/Post scripts etc.