### PR TITLE
New config for request GPU nodes, Site.requireAccelerator

### DIFF
--- a/src/python/CRABInterface/RESTWorkerWorkflow.py
+++ b/src/python/CRABInterface/RESTWorkerWorkflow.py
@@ -156,7 +156,7 @@ def fixupTask(task):
     # with older task
     user_config_default = {
         'partialdataset': False,
-        'require_accelerator': False,
+        'requireaccelerator': False,
     }
     if result['tm_user_config']:
         result['tm_user_config'] = json.loads(result['tm_user_config'])

--- a/src/python/CRABInterface/RESTWorkerWorkflow.py
+++ b/src/python/CRABInterface/RESTWorkerWorkflow.py
@@ -154,8 +154,18 @@ def fixupTask(task):
     # load json data of tm_user_config column
     # Hard code default value of tm_user_config for backward compatibility
     # with older task
+    user_config_default = {
+        'partialdataset': False,
+        'require_accelerator': False,
+    }
     if result['tm_user_config']:
         result['tm_user_config'] = json.loads(result['tm_user_config'])
+        # patch user_config that does not have keys
+        for k in user_config_default.keys():
+            # set default value to new field if it not exists
+            if not result['tm_user_config'].get(k, None):
+                result['tm_user_config'][k] = user_config_default[k]
+    # in case tm_user_config is None
     else:
-        result['tm_user_config'] = {'partialdataset': False}
+        result['tm_user_config'] = user_config_default
     return result

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -174,6 +174,7 @@ periodic_remove = ((JobStatus =?= 5) && (time() - EnteredCurrentStatus > 7*60)) 
                                 ifThenElse(DiskUsage >  %(max_disk_space)s, "Removed due to disk usage", \
                                   ifThenElse(time() > CRAB_TaskEndTime, "Removed due to reached CRAB_TaskEndTime", \
                                   "Removed due to job being held"))))))
+%(accelerator_jdl)s
 %(extra_jdl)s
 queue
 """
@@ -183,6 +184,8 @@ SPLIT_ARG_MAP = {"Automatic": "minutes_per_job",
                  "FileBased": "files_per_job",
                  "EventAwareLumiBased": "events_per_job",}
 
+# hardcode accelerator (gpu) sites
+acceleratorsites = set([ 'T1_DE_KIT', 'T2_CH_CERN', 'T2_CH_CSCS', 'T2_UK_London_IC', 'T2_US_Florida', 'T2_US_MIT', 'T2_US_Purdue', 'T2_US_Vanderbilt', 'T2_US_Wisconsin', 'T3_UK_London_QMUL', 'T3_US_NotreDame' ])
 
 def getCreateTimestamp(taskname):
     return "_".join(taskname.split(":")[:1])
@@ -497,6 +500,11 @@ class DagmanCreator(TaskAction):
         info['accounting_group_user'] = info['userhn']
         info = transform_strings(info)
         info['faillimit'] = task['tm_fail_limit']
+        # hardcoding accelerator to GPU (SI currently only have nvidia GPU)
+        if task['tm_user_config']['require_accelerator']:
+            info['accelerator_jdl'] = '+RequiresGPU=1\nrequest_GPUs=1'
+        else:
+            info['accelerator_jdl'] = ''
         info['extra_jdl'] = '\n'.join(literal_eval(task['tm_extrajdl']))
 
         # info['jobarch_flatten'].split("_")[0]: extracts "slc7" from "slc7_amd64_gcc10"
@@ -780,6 +788,7 @@ class DagmanCreator(TaskAction):
 
         blocksWithNoLocations = set()
         blocksWithBannedLocations = set()
+        blocksWithNoAcceleratorLocations = set()
         allblocks = set()
 
         siteWhitelist = set(kwargs['task']['tm_site_whitelist'])
@@ -868,6 +877,18 @@ class DagmanCreator(TaskAction):
                 blocksWithBannedLocations = blocksWithBannedLocations.union(jgblocks)
                 continue
 
+            # Intersect with sites that only have accelerator (currently we only have nvidia GPU)
+            if kwargs['task']['tm_user_config']['require_accelerator']:
+                availablesites &= acceleratorsites
+                if availablesites:
+                    msg = "'Site.requireAccelerator is True. CRAB will submit %s block(s)'s jobs to %s site(s)."
+                    msg = msg % (jgblocks, list(availablesites))
+                    self.logger.warning(msg)
+                    self.uploadWarning(msg, kwargs['task']['user_proxy'], kwargs['task']['tm_taskname'])
+                else:
+                    blocksWithNoAcceleratorLocations = blocksWithNoAcceleratorLocations.union(jgblocks)
+                    continue
+
             # NOTE: User can still shoot themselves in the foot with the resubmit blacklist
             # However, this is the last chance we have to warn the users about an impossible task at submit time.
             available = set(availablesites)
@@ -915,10 +936,12 @@ class DagmanCreator(TaskAction):
 
         if not dagSpecs:
             msg = "No jobs created for task %s." % (kwargs['task']['tm_taskname'])
-            if blocksWithNoLocations or blocksWithBannedLocations:
+            if blocksWithNoLocations or blocksWithBannedLocations or blocksWithNoAcceleratorLocations:
                 msg = "The CRAB server backend refuses to send jobs to the Grid scheduler. "
                 msg += "No locations found for dataset '%s'. " % (kwargs['task']['tm_input_dataset'])
                 msg += "(or at least for the part of the dataset that passed the lumi-mask and/or run-range selection).\n"
+            if blocksWithNoAcceleratorLocations or kwargs['task']['tm_user_config']['require_accelerator']:
+                msg += "Some blocks have locations but no accelerator nodes on that sites (Site.requireAccelerator=True).\n"
             if blocksWithBannedLocations:
                 msg += " Found %s (out of %s) blocks present only at blacklisted sites." %\
                        (len(blocksWithBannedLocations), len(allblocks))
@@ -932,7 +955,10 @@ class DagmanCreator(TaskAction):
             msg += " because they are only present at blacklisted and/or not-whitelisted sites.\n"
             msg += " List is: %s.\n" % (sorted(list(blocksWithBannedLocations)))
             msg += getBlacklistMsg()
-        if blocksWithNoLocations or blocksWithBannedLocations:
+        if blocksWithNoAcceleratorLocations:
+            msg += " because they are only present at non-accelerator sites.\n"
+            msg += " List is: %s.\n" % (sorted(list(blocksWithNoAcceleratorLocations)))
+        if blocksWithNoLocations or blocksWithBannedLocations or blocksWithNoAcceleratorLocations:
             msg += " Dataset processing will be incomplete because %s (out of %s) blocks" %\
                    (len(blocksWithNoLocations) + len(blocksWithBannedLocations), len(allblocks))
             msg += " are only present at blacklisted and/or not whitelisted site(s)"

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -184,8 +184,6 @@ SPLIT_ARG_MAP = {"Automatic": "minutes_per_job",
                  "FileBased": "files_per_job",
                  "EventAwareLumiBased": "events_per_job",}
 
-# hardcode accelerator (gpu) sites
-acceleratorsites = set([ 'T1_DE_KIT', 'T2_CH_CERN', 'T2_CH_CSCS', 'T2_UK_London_IC', 'T2_US_Florida', 'T2_US_MIT', 'T2_US_Purdue', 'T2_US_Vanderbilt', 'T2_US_Wisconsin', 'T3_UK_London_QMUL', 'T3_US_NotreDame' ])
 
 def getCreateTimestamp(taskname):
     return "_".join(taskname.split(":")[:1])
@@ -761,8 +759,12 @@ class DagmanCreator(TaskAction):
         os.chmod("CMSRunAnalysis.sh", 0o755)
 
         # This config setting acts as a global black list
-        global_blacklist = set(self.getBlacklistedSites())
+        global_blacklist = set(self.loadJSONFromFileInScratchDir('blacklistedSites.txt'))
         self.logger.debug("CRAB site blacklist: %s", list(global_blacklist))
+
+        # Get accleratorsites from GetAcceleratorSite recurring action.
+        acceleratorsites = set(self.loadJSONFromFileInScratchDir('acceleratorSites.txt'))
+        self.logger.debug("Accelerator site from pilot pool: %s", list(acceleratorsites))
 
         # This is needed for Site Metrics
         # It should not block any site for Site Metrics and if needed for other activities

--- a/src/python/TaskWorker/Actions/Recurring/GetAcceleratorSite.py
+++ b/src/python/TaskWorker/Actions/Recurring/GetAcceleratorSite.py
@@ -7,9 +7,14 @@ import htcondor
 from TaskWorker.Actions.Recurring.BaseRecurringAction import BaseRecurringAction
 
 class GetAcceleratorSite(BaseRecurringAction):
+    """
+    Recurring action to get the list of accelerator sites from glidein pool,
+    then saving to `scratchDir/acceleratorSites.json`
+    """
     pollingTime = 1  # testing #60 * 12 #minutes
 
     def _execute(self, config, task):  # pylint: disable=unused-argument
+        # get glidein url from taskworker config
         collector_url = config.TaskWorker.glideinPool
         collector = htcondor.Collector(collector_url)
         try:
@@ -20,8 +25,8 @@ class GetAcceleratorSite(BaseRecurringAction):
             traceback.print_exc()
             self.logger.error('Cannot fetch accelerator site from collector %s.', collector_url)
             return
-        sites = sorted({x.get('GLIDEIN_CMSSite') for x in result})
-        saveLocation = os.path.join(config.TaskWorker.scratchDir, "acceleratorSites.txt")
+        sites = list({x.get('GLIDEIN_CMSSite') for x in result})
+        saveLocation = os.path.join(config.TaskWorker.scratchDir, "acceleratorSites.json")
         tmpLocation = saveLocation + ".tmp"
         with open(tmpLocation, 'w', encoding='utf-8') as fd:
             json.dump(sites, fd)

--- a/src/python/TaskWorker/Actions/Recurring/GetAcceleratorSite.py
+++ b/src/python/TaskWorker/Actions/Recurring/GetAcceleratorSite.py
@@ -11,7 +11,7 @@ class GetAcceleratorSite(BaseRecurringAction):
     Recurring action to get the list of accelerator sites from glidein pool,
     then saving to `scratchDir/acceleratorSites.json`
     """
-    pollingTime = 1  # testing #60 * 12 #minutes
+    pollingTime = 60 * 12  # minutes
 
     def _execute(self, config, task):  # pylint: disable=unused-argument
         # get glidein url from taskworker config

--- a/src/python/TaskWorker/Actions/Recurring/GetAcceleratorSite.py
+++ b/src/python/TaskWorker/Actions/Recurring/GetAcceleratorSite.py
@@ -1,0 +1,55 @@
+import json
+import shutil
+import os
+import traceback
+
+import htcondor
+from TaskWorker.Actions.Recurring.BaseRecurringAction import BaseRecurringAction
+
+
+class GetAcceleratorSite(BaseRecurringAction):
+    pollingTime = 1 # testing #60 * 12 #minutes
+
+
+
+    def _execute(self, config, task):  # pylint: disable=unused-argument
+        collector_host = 'vocms0207.cern.ch'
+        htcondor.param['COLLECTOR_HOST'] = collector_host
+        collector = htcondor.Collector()
+        try:
+            result = collector.query(htcondor.AdTypes.Any,
+                                     'mytype=="glidefactory" && stringlistmember("CMSGPU", GLIDEIN_Supported_VOs)',
+                                     ['GLIDEIN_CMSSite'])
+        except Exception:
+            traceback.print_exc()
+            self.logger.error('Cannot fetch accelerator site from collector %s.',collector_host)
+            return
+        sites = sorted({x.get('GLIDEIN_CMSSite') for x in result})
+        saveLocation = os.path.join(config.TaskWorker.scratchDir, "acceleratorSites.txt")
+
+        tmpLocation = saveLocation + ".tmp"
+        with open(tmpLocation, 'w', encoding='utf-8') as fd:
+            json.dump(sites, fd)
+        shutil.move(tmpLocation, saveLocation)
+
+if __name__ == '__main__':
+    # Simple main to execute the action standalone.
+    # You just need to set the task worker environment and desired twconfig.
+    import logging
+    import sys
+
+    # read config in root git dir
+    twconfig = '../../../../../TaskWorkerConfig.py'
+
+    logger = logging.getLogger()
+    handler = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter("%(asctime)s:%(levelname)s:%(module)s %(message)s", datefmt="%a, %d %b %Y %H:%M:%S %Z(%z)")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+
+    from WMCore.Configuration import loadConfigurationFile
+    cfg = loadConfigurationFile(twconfig)
+
+    trs = GetAcceleratorSite(cfg.TaskWorker.logsDir)
+    trs._execute(cfg, None)  # pylint: disable=protected-access

--- a/src/python/TaskWorker/Actions/TaskAction.py
+++ b/src/python/TaskWorker/Actions/TaskAction.py
@@ -75,8 +75,9 @@ class TaskAction(object):
         if os.path.isfile(fileLocation):
             with open(fileLocation, 'r', encoding='utf-8') as fd:
                 try:
-                    sites = json.load(fd)
+                    return json.load(fd)
                 except ValueError as e:
                     self.logger.error("Failed to load json from file %s. Error message: %s", fileLocation, e)
-                    return []
-        return sites
+                    return {}
+        # return empty dict when file does not exist.
+        return {}

--- a/src/python/TaskWorker/Actions/TaskAction.py
+++ b/src/python/TaskWorker/Actions/TaskAction.py
@@ -70,15 +70,13 @@ class TaskAction(object):
             self.logger.error("Error deleting warnings: %s", str(hte))
             self.logger.warning("Can not delete warnings from REST interface.")
 
-
-    def getBlacklistedSites(self):
-        bannedSites = []
-        fileLocation = os.path.join(self.config.TaskWorker.scratchDir, "blacklistedSites.txt")
+    def loadJSONFromFileInScratchDir(self, path):
+        fileLocation = os.path.join(self.config.TaskWorker.scratchDir, path)
         if os.path.isfile(fileLocation):
-            with open(fileLocation) as fd:
+            with open(fileLocation, 'r', encoding='utf-8') as fd:
                 try:
-                    bannedSites = json.load(fd)
+                    sites = json.load(fd)
                 except ValueError as e:
                     self.logger.error("Failed to load json from file %s. Error message: %s", fileLocation, e)
                     return []
-        return bannedSites
+        return sites


### PR DESCRIPTION
Part of https://github.com/dmwm/CRABServer/issues/6989

In client side, users only put new configuration option `Site.requireAccelerator` to request GPU nodes, and CRAB will handle JDL for them.

CRAB will submit jobs to sites that have GPU only. The list of the site is hardcode (extract from [CMS Submission Infrastructure: GPU monitors](https://monit-grafana.cern.ch/d/2qoPfS0Mz/cms-submission-infrastructure-gpus-monitor?orgId=11)). Fine-grain selecting GPU flavor will come in next PR after I get more info about what users need.

I choose  `requireAccelerator`  configuration name to make it more generic. In the future, sites may have nvidia/amd/intel or FPGA, and we can let users choose later when we have more than nvidia GPU.

To prevent jobs from idle and never matching GPU node, in `DagmanCreator.py`, I have code filter out non-GPU sites at `availablesites` variable and put some msg to make it more clear that sites are filtered out because users select GPU sites.

I did not test the skipping block yet. I cannot find a dataset+site that has an incomplete dataset.