### PR TITLE
make sure didDict is defined

### DIFF
--- a/src/python/RucioUtils.py
+++ b/src/python/RucioUtils.py
@@ -58,6 +58,7 @@ def getWritePFN(rucioClient=None, siteName='', lfn='',
         except Exception as ex:
             msg = 'Rucio lfn2pfn resolution for %s failed with:\n%s\nTry next one.'
             logger.warning(msg, operation, str(ex))
+            didDict = None
     if not didDict:
         msg = 'lfn2pfn resolution with Rucio failed for site: %s  LFN: %s' % (siteName, lfn)
         msg += ' with exception :\n%s' % str(ex)


### PR DESCRIPTION
avoid error below in case call to rucio.lfns2pfns fails
```
File “/data/repos/CRABServer/src/python/RucioUtils.py”, line 61, in getWritePFN if not didDict: UnboundLocalError: local variable ‘didDict’ referenced before assignment
```
references: 
https://cms-talk.web.cern.ch/t/unknown-i-o-error-when-running-crab/15999/5
https://cms-talk.web.cern.ch/t/unknown-i-o-error-when-running-crab/15999/8