### PR TITLE
Avoid MasterWorker stuck because recurring modules not found

### DIFF
--- a/src/python/TaskWorker/MasterWorker.py
+++ b/src/python/TaskWorker/MasterWorker.py
@@ -247,7 +247,7 @@ class MasterWorker(object):
         try:
             mod = __import__('TaskWorker.Actions.Recurring.%s' % actionName, fromlist=actionName)
         except ModuleNotFoundError:
-            self.logger.error('Recurring Action module "<%s>" not found, skipping', actionName)
+            self.logger.error('Recurring Action module "%s" not found, skipping', actionName)
             return
         return getattr(mod, actionName)(self.config.TaskWorker.logsDir)
 


### PR DESCRIPTION
I found this issue when I try to deploy old taskworker version in test12/devthree where new configuration in [TaskWorkerConfig.py](https://gitlab.cern.ch/ai/it-puppet-hostgroup-vocmsglidein/-/commit/0095f4f8c1b1959bd04eefa9b137d3da633e5095) are applied by puppet.

I am not sure why it stuck instead of exiting with errors (found process still running).

twlog.txt will look like this:
```
2022-10-27 18:39:15,184:INFO:MasterWorker,183:recurringActions: ['RemovetmpDir', 'BanDestinationSites', 'TapeRecallStatus', 'aabbcccccccc']
2022-10-27 18:39:15,184:INFO:MasterWorker,202:Will connect to CRAB service: other
2022-10-27 18:39:15,184:INFO:MasterWorker,209:Will use restHost and dbInstance from config file
2022-10-27 18:39:15,184:INFO:MasterWorker,218:Will connect via URL: https://cmsweb-test12.cern.ch/devthree
2022-10-27 18:39:15,184:DEBUG:MasterWorker,225:Hostcert: /data/certs/servicecert.pem, hostkey: /data/certs/servicekey.pem
2022-10-27 18:39:15,185:ERROR:MasterWorker,252:Recurring Action module "<aabbcccccccc>" not found, skipping
2022-10-27 18:39:15,187:INFO:TapeRecallStatus,51:Retrieving TAPERECALL tasks
2022-10-27 18:39:15,185:ERROR:MasterWorker,252:Recurring Action module "<aabbcccccccc>" not found, skipping
2022-10-27 18:39:15,187:INFO:TapeRecallStatus,51:Retrieving TAPERECALL tasks
2022-10-27 18:39:15,227:INFO:TapeRecallStatus,54:No TAPERECALL task retrieved.
2022-10-27 18:39:15,227:INFO:TapeRecallStatus,54:No TAPERECALL task retrieved.
```