### PR TITLE
test - add config for 12_6

### DIFF
--- a/test/testingConfigs
+++ b/test/testingConfigs
@@ -1,3 +1,4 @@
+CMSSW_release=CMSSW_12_6_0_pre4;SCRAM_ARCH=slc7_amd64_gcc10;inputDataset=/GenericTTbar/HC-CMSSW_9_2_6_91X_mcRun1_realistic_v2-v2/AODSIM;master=no;
 CMSSW_release=CMSSW_12_0_1;SCRAM_ARCH=slc7_amd64_gcc900;inputDataset=/GenericTTbar/HC-CMSSW_9_2_6_91X_mcRun1_realistic_v2-v2/AODSIM;master=no;
 CMSSW_release=CMSSW_11_3_4;SCRAM_ARCH=slc7_amd64_gcc900;inputDataset=/GenericTTbar/HC-CMSSW_9_2_6_91X_mcRun1_realistic_v2-v2/AODSIM;master=no;
 CMSSW_release=CMSSW_10_6_26;SCRAM_ARCH=slc7_amd64_gcc700;inputDataset=/GenericTTbar/HC-CMSSW_9_2_6_91X_mcRun1_realistic_v2-v2/AODSIM;master=yes;


### PR DESCRIPTION
In order to be able to run jenkins tests on cmsssw 12_6, we need to add a new row to `test/testConfigs`.

I tested this in my repo, albeit using 12_6_0_pre2 instead of 12_6_0_pre4: https://github.com/mapellidario/CRABServer/issues/24

It feels a pretty innocuous change, I will merge this myself