### PR TITLE
rpm build - improve build from private repos

### DIFF
--- a/cicd/build/jenkins_build_rpm.sh
+++ b/cicd/build/jenkins_build_rpm.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -x
+
+echo "(DEBUG) git version: " $(git --version)
 echo "(DEBUG) variables from upstream jenkin job (github-webhook):"
 # echo "(DEBUG)   \- REPOSITORY: $REPOSITORY" # (not used)
 # echo "(DEBUG)   \- EVENT: $EVENT" # (not used)
@@ -9,10 +12,13 @@ echo "(DEBUG)   \- RELEASE_TAG: $RELEASE_TAG"  # v3.211111, py3.220124
 echo "(DEBUG)   \- CRABSERVER_REPO: $CRABSERVER_REPO"  # dmwm, belforte, mapellidario, ...
 echo "(DEBUG)   \- WMCORE_REPO: $WMCORE_REPO"  # dmwm, belforte, mapellidario, ...
 echo "(DEBUG)   \- WMCORE_TAG: $WMCORE_TAG"  # <empty>, 1.5.7, ...
-# echo "(DEBUG)   \- BRANCH: $BRANCH" # (empty, not used)
+echo "(DEBUG)   \- BRANCH: $BRANCH" # <empty>, master, ...
 echo "(DEBUG)   \- PAYLOAD: $PAYLOAD"
 # example of PAYLOAD: https://dmapelli.web.cern.ch/public/crab/20220127/crabserver_github_release_payload_example.json
 echo "(DEBUG) end"
+
+if [[ -z $CRABSERVER_REPO ]]; then echo '$CRABSERVER_REPO' "is empty, exiting"; exit 1; fi
+if [[ -z $WMCORE_REPO ]]; then echo '$WMCORE_REPO' "is empty, exiting"; exit 1; fi
 
 #do a clean up
 docker system prune -af
@@ -20,29 +26,61 @@ docker system prune -af
 #clone directories
 git clone -b V00-33-XX https://github.com/cms-sw/pkgtools.git
 git clone https://github.com/cms-sw/cmsdist.git && cd cmsdist && git checkout comp_gcc630
-git clone https://github.com/dmwm/CRABServer.git
+git clone https://github.com/$CRABSERVER_REPO/CRABServer.git
 
 if [[ -n  ${PAYLOAD} ]]; then
-   #get CRABServer branch name from the payload, if the payload is not empty
+   #if the payload is not empty, get CRABServer branch name from the payload. 
    #the payload is not empty when this job is triggered by github-webhook,
    #if this job is launched manually, then the branch will have the value set
    #as input env variable.
    #paylod has a lot of information, but we are only interested in extracting this info: <...>"target_commitish": "python3"<...>
    #regex would extract 'python3' as a BRANCH name
    export BRANCH=$(echo "${PAYLOAD}" | grep -oP '(?<="target_commitish":\s")([^\s]+)(?=", ")')
+else
+  # when the payload is empty, it means that this job is launched manually.
+  if [[ -z $BRANCH ]] && [[ -z $RELEASE_TAG ]]; then echo "Both BRANCH and RELEASE_TAG are empty, exit"; exit 1; fi
+  if [[ -z $BRANCH ]] && [[ -n $RELEASE_TAG ]]; then
+    # $RELEASE_TAG non empty: we extract the branch name from the $RELEASE_TAG
+    cd CRABServer
+    echo "(DEBUG) git branch -a --contains tags/$RELEASE_TAG: $(git branch -a --contains tags/$RELEASE_TAG)"
+    export BRANCH=$(git branch -a --contains tags/$RELEASE_TAG | sed "s/*//g" | sed "s/ //g" | grep origin | awk -F "/" '{print $3}')
+    cd ..
+  fi
+  if [[ -n $BRANCH ]] && [[ -z $RELEASE_TAG ]]; then
+    # $BRANCH non empty: we use the latest commit hash as $RELEASE_TAG
+    echo "this could work in theory, but currently breaks pkgtools/cmsBuild"
+    echo "at line: https://github.com/cms-sw/pkgtools/blob/V00-34-XX/cmsBuild#L553"
+    echo "exiting"
+    exit 1
+    ## if they update cmsBuild, then we can do it with the next lines
+    # cd CRABServer
+    # git checkout $BRANCH
+    # export RELEASE_TAG=$(git log --format="%H" -n 1)
+    # cd ..
+  fi
+fi
+if [[ -z $RELEASE_TAG ]]; then echo '$RELEASE_TAG' "is empty, exiting"; exit 1; fi
+if [[ -z $BRANCH ]]; then echo '$BRANCH' "is empty, exiting"; exit 1; fi
+if [[ ! $BRANCH =~ ^[a-zA-Z0-9_]*$ ]]; then 
+  # $BRANCH can contain only alfanumeric characters and the underscore "_". for example, the dash "-" is not allowed
+  # otherwise, cms-build will fail and no rpm will be uploaded to the repository.
+  echo 'ERROR! $BRANCH does not match the regex ^[a-zA-Z0-9_]*$'
+  echo '       cmsBuild would fail uploading the rpm to the repo with: '
+  echo "       > ERROR: Tmp upload repository name 'crab_20220816-jobwr-sq-0' contains invalid characters. Allowed characters are: a-zA-Z0-9_"
+  echo '       Therefore, we are aborting.'
+  exit 1
 fi
 echo "BRANCH=${BRANCH}" >> $WORKSPACE/properties_file
-
-cd CRABServer
-git checkout ${BRANCH}
-cd ..
 
 #select the WMCore tag
 if [ ${WMCORE_REPO} == "dmwm" ]; then
    WMCORE_TAG=$(grep -oP "wmcver==\K.*" CRABServer/requirements.txt)
 fi
+if [[ -z $WMCORE_TAG ]]; then echo '$WMCORE_TAG' "is empty, exiting"; exit 1; fi
+
 
 echo "(DEBUG) env variables that could have been updated from the default:"
+echo "(DEBUG)   \- RELEASE_TAG: $RELEASE_TAG"  # v3.211111, py3.220124
 echo "(DEBUG)   \- BRANCH (crabserver): $BRANCH"
 echo "(DEBUG)   \- WMCORE_TAG: $WMCORE_TAG"
 


### PR DESCRIPTION
First step in completing #7451 

### status

- [x] Ready to be merged. Every image built with Jenkins in the last ~10days have been using these changes [1]
- [ ] I have an open question about the next steps.

### description

We use the jenkins job https://cmssdt.cern.ch/dmwm-jenkins/job/CRABServer_BuildOnRelease/ to build rpms and then docker images for crabserver and crabtaskworker.

Already implemented:

- build images when a new release on dmwm/CRABServer is created
- build images manually, providing repo + `branchname` + tag pointing to `branchname`

What this PR achieves

- [x] build an image with repo + tag, `branchname` is extracted with git commands.

What this PR can not achieve

- [ ] build an image with repo + `branchname`, using a random string as tag, for example the has of the latest commit in branchname. 
    - this requires changing this line https://github.com/cms-sw/pkgtools/blob/935c3175178ce011ba2bd64ec435ef6c393e239f/cmsBuild#L553 
    - this can be done, but requires some discussion with Shahzad

Question for @novicecpp and @belforte: are we ok with the current changes only or do we want to ask Shahzad to change how tags are retrieved in `cms-sw/pkgtools/cmsBuild`?

---

[1] https://cmssdt.cern.ch/dmwm-jenkins/job/CRABServer_BuildOnRelease/jobConfigHistory/showDiffFiles?timestamp1=2022-11-09_18-19-23&timestamp2=2022-11-21_14-18-42