### PR TITLE
tw, pub - explicit allow openssl 1.0.2

### DIFF
--- a/src/script/Deployment/Publisher/start.sh
+++ b/src/script/Deployment/Publisher/start.sh
@@ -62,6 +62,8 @@ ln -s /data/hostdisk/${SERVICE}/nohup.out nohup.out
 
 #==== START THE SERVICE
 
+export CRYPTOGRAPHY_ALLOW_OPENSSL_102=true
+
 case $MODE in
   current)
   # current mode: run current instance

--- a/src/script/Deployment/TaskWorker/start.sh
+++ b/src/script/Deployment/TaskWorker/start.sh
@@ -62,6 +62,8 @@ ln -s /data/hostdisk/${SERVICE}/nohup.out nohup.out
 
 #==== START THE SERVICE
 
+export CRYPTOGRAPHY_ALLOW_OPENSSL_102=true
+
 case $MODE in
     current)
     # current mode: run current instance


### PR DESCRIPTION
fixes #7475 

#### status

- [x] TW tested in preprod: manually changed `start.sh` script.
  - i have seen it failing and the change fixed it
- [x] PUB tested in preprod: manually changed `start.sh` script. 
  - since I fixed TW and publisher at the same time, and since when TW failed there was nothing to publish, i did not see pub failing
  - however, it is veery likely that it would have failed.
  - in any case, with this change in, publisher works: https://cmsweb-testbed.cern.ch/crabserver/ui/task/221124_161149%3Admapelli_crab_20221124_171146 6 files from this task have been published (the other 4 jobs failed with 8001)