### PR TITLE
jobwrapper - fixing bug in calling cmsset_default

### DIFF
--- a/scripts/submit_env.sh
+++ b/scripts/submit_env.sh
@@ -37,31 +37,30 @@ setup_local_env () {
 setup_cmsset() {
     ### source the CMSSW stuff using either OSG or LCG style entry env. or CVMFS
     echo "======== CMS environment load starting at $(TZ=GMT date) ========"
-    CMSSET_DEFAULT_PATH=""
     if [ -f "$VO_CMS_SW_DIR"/cmsset_default.sh ]
     then  #   LCG style --
         echo "WN with a LCG style environment, thus using VO_CMS_SW_DIR=$VO_CMS_SW_DIR"
-        CMSSET_DEFAULT_PATH=$VO_CMS_SW_DIR/cmsset_default.sh
+        . $VO_CMS_SW_DIR/cmsset_default.sh
     elif [ -f "$OSG_APP"/cmssoft/cms/cmsset_default.sh ]
     then  #   OSG style --
         echo "WN with an OSG style environment, thus using OSG_APP=$OSG_APP"
-        CMSSET_DEFAULT_PATH=$OSG_APP/cmssoft/cms/cmsset_default.sh CMSSW_3_3_2
+        . $OSG_APP/cmssoft/cms/cmsset_default.sh CMSSW_3_3_2
     elif [ -f "$CVMFS"/cms.cern.ch/cmsset_default.sh ]
     then
         echo "WN with CVMFS environment, thus using CVMFS=$CVMFS"
-        CMSSET_DEFAULT_PATH=$CVMFS/cms.cern.ch/cmsset_default.sh
+        . $CVMFS/cms.cern.ch/cmsset_default.sh
     elif [ -f /cvmfs/cms.cern.ch/cmsset_default.sh ]
     then  # ok, lets call it CVMFS then
-        CVMFS=/cvmfs/cms.cern.ch
+        export CVMFS=/cvmfs/cms.cern.ch
         echo "WN missing VO_CMS_SW_DIR/OSG_APP/CVMFS environment variable, forcing it to CVMFS=$CVMFS"
-        CMSSET_DEFAULT_PATH=$CVMFS/cmsset_default.sh
+        . $CVMFS/cmsset_default.sh
     else
         echo "Error during job bootstrap: VO_CMS_SW_DIR, OSG_APP, CVMFS or /cvmfs were not found." >&2
         echo "  Because of this, we can't load CMSSW. Not good." >&2
         exit 11003
     fi
-    . $CMSSET_DEFAULT_PATH
-    echo -e "========  CMS environment load finished at $(TZ=GMT date) ========\n"
+    echo "CRAB job bootstrap: thinks it found the correct CMSSW setup script"
+    echo -e "======== CMS environment load finished at $(TZ=GMT date) ========\n"
 }
 
 setup_python_comp() {


### PR DESCRIPTION
This PR fixes a bug introduced in #7441 

### status

tested on preprod, with `./start.sh -g`, this [job](https://cmsweb.cern.ch:8443/scheddmon/059/dmapelli/221130_105619:dmapelli_crab_20221130_115614/job_out.1.0.txt) now looks ok:

```plaintext
======== CMS environment load starting at Wed Nov 30 11:03:46 GMT 2022 ========
WN with an OSG style environment, thus using OSG_APP=/cmsuf/data/app
CRAB job bootstrap: thinks it found the correct CMSSW setup script
======== CMS environment load finished at Wed Nov 30 11:03:47 GMT 2022 ========
```

### description of the problem

I wanted to have a simple way of printing the path of cmsset_default.sh for quicker debugging. I introduced the variable `CMSSET_DEFAULT_PATH` and set it to the absolute path path of cmsset_default.sh.

However, I did not think about the implications of having an extra argument in the case of OSG: the line

```bash
CMSSET_DEFAULT_PATH=$OSG_APP/cmssoft/cms/cmsset_default.sh CMSSW_3_3_2
```

makes bash fail with 

```plaintext
======== CMS environment load starting at Wed Nov 30 10:05:07 GMT 2022 ========
WN with an OSG style environment, thus using OSG_APP=/cvmfs/oasis.opensciencegrid.org
./submit_env.sh: line 48: CMSSW_3_3_2: command not found
./submit_env.sh: line 63: .: filename argument required
.: usage: . filename [arguments]
```

### solution

I should not introduce changes lightly in the jobwrapper, so I just copied the code from WMAgent again:

https://github.com/dmwm/WMCore/blob/21220f03ee386a471573b82507e82684dabe979a/etc/submit_py3.sh#L97-L121

