### PR TITLE
Update task state to FAILED when TaskWorkerException occur

### DIFF
--- a/src/python/TaskWorker/Actions/PreDAG.py
+++ b/src/python/TaskWorker/Actions/PreDAG.py
@@ -43,7 +43,6 @@ from RESTInteractions import CRABRest
 from RucioUtils import getNativeRucioClient
 from TaskWorker.Actions.Splitter import Splitter
 from TaskWorker.Actions.DagmanCreator import DagmanCreator
-from TaskWorker.Actions.PostJob import PostJob
 from TaskWorker.WorkerExceptions import TaskWorkerException
 from TaskWorker.Worker import failTask
 
@@ -66,6 +65,7 @@ class PreDAG(object):
         self.logger.addHandler(handler)
         self.logger.setLevel(logging.DEBUG)
         self.logger.propagate = False
+        self.crabserver = None
 
     def setupCRABRest(self):
         """

--- a/src/python/TaskWorker/Actions/PreDAG.py
+++ b/src/python/TaskWorker/Actions/PreDAG.py
@@ -295,8 +295,6 @@ class PreDAG(object):
             for g in split_result.result[0]:
                 msg = "Created jobgroup with length {0}".format(len(g.getJobs()))
                 self.logger.info(msg)
-            if 'force_failed_autosplit' in task['tm_taskname']:
-                raise TaskWorkerException("force raise exception on automatic splitting task")
         except TaskWorkerException as e:
             retmsg = "Splitting failed with:\n{0}".format(e)
             failTaskMsg = f"PreDAG error: {retmsg}"

--- a/src/python/TaskWorker/Actions/PreDAG.py
+++ b/src/python/TaskWorker/Actions/PreDAG.py
@@ -38,11 +38,14 @@ import classad
 
 from WMCore.DataStructs.LumiList import LumiList
 
-from ServerUtilities import getLock, newX509env, MAX_IDLE_JOBS, MAX_POST_JOBS
+from ServerUtilities import getLock, newX509env, MAX_IDLE_JOBS, MAX_POST_JOBS, parseJobAd
+from RESTInteractions import CRABRest
 from RucioUtils import getNativeRucioClient
 from TaskWorker.Actions.Splitter import Splitter
 from TaskWorker.Actions.DagmanCreator import DagmanCreator
+from TaskWorker.Actions.PostJob import PostJob
 from TaskWorker.WorkerExceptions import TaskWorkerException
+from TaskWorker.Worker import failTask
 
 class PreDAG(object):
     """ Main class that implement all the necessary features
@@ -63,6 +66,29 @@ class PreDAG(object):
         self.logger.addHandler(handler)
         self.logger.setLevel(logging.DEBUG)
         self.logger.propagate = False
+
+    def setupCRABRest(self):
+        """
+        Setup CRABRest object and add it to self.crabserver.
+        rest_host and db_instance are come from parsing job ad
+        (copy some code from PostJob.py). Get user proxy from
+        X509_USER_PROXY environment variable.
+        """
+        job_ad_file_name = os.environ.get("_CONDOR_JOB_AD", ".job.ad")
+        if not os.path.exists(job_ad_file_name) or not os.stat(job_ad_file_name).st_size:
+            self.logger.error("Missing job ad!")
+            sys.exit(1)
+        try:
+            job_ad = parseJobAd(job_ad_file_name)
+        except Exception as ex:
+            self.logger.exception("Error parsing job ad: %s", str(ex))
+            sys.exit(1)
+        rest_host = str(job_ad['CRAB_RestHost'])
+        db_instance = str(job_ad['CRAB_DbInstance'])
+        proxy = os.environ['X509_USER_PROXY']
+        self.crabserver = CRABRest(rest_host, proxy, proxy, retry=20,
+                                   logger=self.logger, userAgent='CRABSchedd')
+        self.crabserver.setDbInstance(db_instance)
 
     def readJobStatus(self):
         """Read the job status(es) from the cache_status file and save the relevant info into self.statusCacheInfo"""
@@ -155,6 +181,9 @@ class PreDAG(object):
         completed = set(self.completedJobs(stage=self.stage))
         if len(completed) < self.completion:
             return 4
+
+        # init CRABRest self.crabserver
+        self.setupCRABRest()
 
         self.readProcessedJobs()
         unprocessed = completed - self.processedJobs
@@ -266,10 +295,13 @@ class PreDAG(object):
             for g in split_result.result[0]:
                 msg = "Created jobgroup with length {0}".format(len(g.getJobs()))
                 self.logger.info(msg)
+            if 'force_failed_autosplit' in task['tm_taskname']:
+                raise TaskWorkerException("force raise exception on automatic splitting task")
         except TaskWorkerException as e:
             retmsg = "Splitting failed with:\n{0}".format(e)
+            failTaskMsg = f"PreDAG error: {retmsg}"
             self.logger.error(retmsg)
-#            self.set_dashboard_state('FAILED')
+            failTask(task['tm_taskname'], self.crabserver, failTaskMsg, self.logger, 'FAILED')
             return 1
         try:
             parent = self.prefix if self.stage == 'tail' else None
@@ -284,7 +316,9 @@ class PreDAG(object):
         except TaskWorkerException as e:
             retmsg = "DAG creation failed with:\n{0}".format(e)
             self.logger.error(retmsg)
-#            self.set_dashboard_state('FAILED')
+            failTaskMsg = f"PreDAG error: {retmsg}"
+            self.logger.error(retmsg)
+            failTask(task['tm_taskname'], self.crabserver, failTaskMsg, self.logger, 'FAILED')
             return 1
         self.saveProcessedJobs(unprocessed)
         return 0
@@ -351,7 +385,6 @@ class PreDAG(object):
         task['tm_split_args']['lumis'] = lumis
 
         return True
-
 
 if __name__ == '__main__':
     sys.exit(PreDAG().execute(sys.argv[1:]))


### PR DESCRIPTION
Fix https://github.com/dmwm/CRABServer/issues/5983

Update task state to FAILED when TaskWorkerException using [failTask()](https://github.com/dmwm/CRABServer/blob/9df0542eae377b76b315dcb8292c642ba57578ba/src/python/TaskWorker/Worker.py#L48).

I cannot reproduce the actual task because the user config and sandbox are long gone. So, I force raising exception inside the "try" splitting step [like this](https://github.com/dmwm/CRABServer/commit/20cddde1326012171404252b236fa050d3f68069) and check result in `crab status` command:

https://cmsweb-test12.cern.ch/crabserver/ui/task/230124_135939%3Atseethon_crab_autosplit_hc_test12_20230124_145936

![Screenshot from 2023-01-25 12-18-23](https://user-images.githubusercontent.com/2346664/214557080-8dc20929-074e-4dc9-82e3-5f1e5dff90b2.png)
