### PR TITLE
Use python3 for every command inside the jobwrapper

### DIFF
--- a/scripts/CMSRunAnalysis.sh
+++ b/scripts/CMSRunAnalysis.sh
@@ -14,7 +14,7 @@ sigterm() {
   ls -lnh
   if [ ! -e logCMSSWSaved.txt ];
   then
-    python -c "import CMSRunAnalysis; logCMSSW()"
+    python3 -c "import CMSRunAnalysis; CMSRunAnalysis.logCMSSW()"
   fi
 }
 

--- a/scripts/gWMS-CMSRunAnalysis.sh
+++ b/scripts/gWMS-CMSRunAnalysis.sh
@@ -44,6 +44,7 @@ function chirp_exit_code {
     #and is successfully loaded. It is taken from the EXIT_STATUS variable
     #instead (which contains the short exit coce)
 
+    echo "======== Figuring out long exit code of the job for condor_chirp at $(TZ=GMT date)========"
     #check if the command condor_chirp exists
     command -v condor_chirp > /dev/null 2>&1
     if [ $? -ne 0 ]; then
@@ -51,7 +52,6 @@ function chirp_exit_code {
         return
     fi
     #check if exitCode is in there and report it
-    echo "======== Figuring out long exit code of the job for condor_chirp ========"
     #any error or exception will be printed to stderr and cause $? <> 0
     LONG_EXIT_CODE=$(python << END
 from __future__ import print_function

--- a/scripts/task_process/task_proc_wrapper.sh
+++ b/scripts/task_process/task_proc_wrapper.sh
@@ -13,7 +13,7 @@ function manage_transfers {
     log "Running transfers.py"
 
     if [[ -f task_process/transfers.txt ]]; then
-        DEST_LFN=`python -c 'import sys, json; print json.loads( open("task_process/transfers.txt").readlines()[0] )["destination_lfn"]' `
+        DEST_LFN=`python3 -c 'import sys, json; print json.loads( open("task_process/transfers.txt").readlines()[0] )["destination_lfn"]' `
 
         if [[ $DEST_LFN =~ ^/store/user/rucio/* ]]; then
         timeout 15m env PYTHONPATH=$PYTHONPATH:$RucioPy3 python3 task_process/RUCIO_Transfers.py


### PR DESCRIPTION
Fixes #7509

### status

condor_chirp is broken when running slc6 jobs: still work in progress

### description

I noticed a problem with the python used to retrieve the exit code in #7509 . It's caused by the new jobwrapper, since it does not load into the path any executable called "python", but only `python3`. 

I also looked around and fixed all the instances that I could find of ambiguous `python` instead of `python3`.

### future work

We still have many `#!/usr/bin/python` and `#!/usr/bin/env python` that should become `#!/usr/bin/env python3`. I will do it at a later time. They are likely not causing any problem because we are not calling directly the `.py` files, but always using `python3 <myfile>.py`. Still, it's better to be consistent.
