### PR TITLE
Allow blocks taperecall for any Tier if inputblocks provided

### DIFF
--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -474,7 +474,7 @@ class DBSDataDiscovery(DataDiscovery):
                 self.logger.warning(msg)
                 self.uploadWarning(msg, self.userproxy, self.taskName)
             elif dataTier in getattr(self.config.TaskWorker, 'tiersToRecall', []):
-                msg = "Task could not be submitted because not all blocks of dataset %s are on DISK" % inputDataset
+                msg = f"Task could not be submitted because not all blocks of dataset {inputDataset} are on DISK"
                 msg += "\nWill try to request a full disk copy for you. See"
                 msg += "\n https://twiki.cern.ch/twiki/bin/view/CMSPublic/CRAB3FAQ#crab_submit_fails_with_Task_coul"
                 self.requestTapeRecall(blockList=blocksWithLocation, system='Rucio', msgHead=msg)
@@ -483,21 +483,21 @@ class DBSDataDiscovery(DataDiscovery):
                 maxTierToBlockRecallSizeTB = getattr(self.config.TaskWorker, 'maxTierToBlockRecallSizeTB', 0)
                 maxTierToBlockRecallSize = maxTierToBlockRecallSizeTB * 1e12
                 if blocksSizeToRecall < maxTierToBlockRecallSize:
-                    msg = "Task could not be submitted because blocks specified in Data.inputBlocks are not on disk."
+                    msg = "Task could not be submitted because blocks specified in 'Data.inputBlocks' are not on disk."
                     msg += "\nWill try to request disk copy for you. See"
                     msg += "\n https://twiki.cern.ch/twiki/bin/view/CMSPublic/CRAB3FAQ#crab_submit_fails_with_Task_coul"
                     self.requestTapeRecall(blockList=blocksWithLocation, system='Rucio', msgHead=msg)
                 else:
                     msg = "Some blocks are on TAPE only and will not be processed."
-                    msg += f"\nThere is no automatic recall from TAPE for data tier '{datatier}' if 'Data.inputBlocks' is provided,"
+                    msg += f"\nThere is no automatic recall from TAPE for data tier '{dataTier}' if 'Data.inputBlocks' is provided,"
                     msg += f"\nbut the recall size ({blocksSizeToRecall/1e12:.3f} TB) is larger than the maximum allowed size ({maxTierToBlockRecallSizeTB} TB)."
-                    msg += '\nIf you need these blocks, contact Data Transfer team via %s' % FEEDBACKMAIL
+                    msg += f"\nIf you need these blocks, contact Data Transfer team via {FEEDBACKMAIL}"
                     self.logger.warning(msg)
                     self.uploadWarning(msg, self.userproxy, self.taskName)
             else:
                 msg = "Some blocks are on TAPE only and will not be processed."
-                msg += "\nThere is no automatic recall from tape for data tier '%s' if 'Data.inputBlocks' is not provided." % dataTier
-                msg += '\nIf you need the full dataset, contact Data Transfer team via %s' % FEEDBACKMAIL
+                msg += f"\nThere is no automatic recall from tape for data tier '{dataTier}' if 'Data.inputBlocks' is not provided."
+                msg += f"\nIf you need the full dataset, contact Data Transfer team via {FEEDBACKMAIL}"
                 self.logger.warning(msg)
                 self.uploadWarning(msg, self.userproxy, self.taskName)
 

--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -469,7 +469,7 @@ class DBSDataDiscovery(DataDiscovery):
                 else:
                     msg = "Some blocks are on TAPE only and will not be processed."
                     msg += f"\nThere is no automatic recall from TAPE for data tier '{dataTier}' if 'Data.inputBlocks' is provided,"
-                    msg += f"\nbut the recall size ({sizeToRecall/1e12:.3f} TB) is larger than the maximum allowed size ({maxTierToBlockRecallSizeTB} TB)."
+                    msg += f"\nbut the recall size ({totalSizeBytes/1e12:.3f} TB) is larger than the maximum allowed size ({maxTierToBlockRecallSizeTB} TB)."
                     msg += f"\nIf you need these blocks, contact Data Transfer team via {FEEDBACKMAIL}"
                     self.logger.warning(msg)
                     self.uploadWarning(msg, self.userproxy, self.taskName)

--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -89,10 +89,11 @@ class DBSDataDiscovery(DataDiscovery):
                 msg += "\nhttps://twiki.cern.ch/twiki/bin/view/CMSPublic/CRAB3FAQ"
                 raise TaskWorkerException(msg)
 
-    def requestTapeRecall(self, blockList, sizeToRecall, system='Dynamo', msgHead=''):   # pylint: disable=W0102
+    def requestTapeRecall(self, blockList, sizeToRecall, system='Rucio', msgHead=''):   # pylint: disable=W0102
         """
         :param blockList: a list of blocks to recall from Tape to Disk
-        :param system: a string identifying the DDM system to use 'Dynamo' or 'Rucio' or 'None'
+        :param sizeToRecall: an integer of blockList's total size in bytes.
+        :param system: a string identifying the DDM system to use 'Rucio' or 'None'
         :param msgHead: a string with the initial part of a message to be used for exceptions
         :return: nothing: Since data on tape means no submission possible, this function will
             always raise a TaskWorkerException to stop the action flow.
@@ -241,9 +242,6 @@ class DBSDataDiscovery(DataDiscovery):
             msg += "\nPlease, check DAS (https://cmsweb.cern.ch/das) and make sure the dataset is accessible on DISK."
             raise TaskWorkerException(msg)
 
-        if system == 'Dynamo':
-            raise NotImplementedError
-
     def execute(self, *args, **kwargs):
         """
         This is a convenience wrapper around the executeInternal function
@@ -366,7 +364,7 @@ class DBSDataDiscovery(DataDiscovery):
                 msg = "No locations found with Rucio for this dataset"
                 self.logger.warning(msg)
 
-        self.logger.debug("Dataset size in bytes: %s", totalSizeBytes)
+        self.logger.debug("Dataset size in GBytes: %s", totalSizeBytes/1e9)
 
         if not locationsFoundWithRucio:
             self.logger.info("No locations found with Rucio for %s", inputDataset)


### PR DESCRIPTION
Fix https://github.com/dmwm/CRABServer/issues/7528

I have changed what we agree in https://github.com/dmwm/CRABServer/issues/7528#issuecomment-1425955091,
from **Allow to recall blocks in the new list of dataTier (e.g. RAW, RECO)**,
to **Allow to recall any number of blocks if it not in `tiersToRecall`  as long as 1) `inputblocks` provided 2) not exceed the limit**.
(The limitation can config via `config.TaskWorker.maxTierToBlockRecallSizeTB`)

This way there is no need to maintain possible dataTier and it make if-else of taperecall's decision more simpler.

Also, simply remove [DBSDataDiscovery.py#L453-L460](https://github.com/dmwm/CRABServer/blob/9e822e562a3200c2eacebb5f93d66ca2b17d3583/src/python/TaskWorker/Actions/DBSDataDiscovery.py#L453-L460) and let it fall through the if-else below.