### PR TITLE
RucioUtils.py:getWritePFN - fix bug in dealing with exception

### DIFF
--- a/src/python/RucioUtils.py
+++ b/src/python/RucioUtils.py
@@ -50,6 +50,7 @@ def getWritePFN(rucioClient=None, siteName='', lfn='',
     # "write": provides the PFN to be used with gfal
     # 2022-08: dario checked with felipe that every sane RSE has non-zero value
     # for the third_party_copy_write column, which means that it is available.
+    ex_str = ""
     for operation in operations:
         try:
             logger.warning('Try Rucio lfn2pn with operation %s', operation)
@@ -58,10 +59,11 @@ def getWritePFN(rucioClient=None, siteName='', lfn='',
         except Exception as ex:
             msg = 'Rucio lfn2pfn resolution for %s failed with:\n%s\nTry next one.'
             logger.warning(msg, operation, str(ex))
+            ex_str += "operation: %s, exception: %s\n" % (operation, ex)
             didDict = None
     if not didDict:
         msg = 'lfn2pfn resolution with Rucio failed for site: %s  LFN: %s' % (siteName, lfn)
-        msg += ' with exception :\n%s' % str(ex)
+        msg += ' with exception(s) :\n%s' % str(ex_str)
         raise TaskWorkerException(msg)
 
     # lfns2pfns returns a dictionary with did as key and pfn as value:


### PR DESCRIPTION
Fixes #7540 

### status

tested:

- [x]  https://cmsweb-test11.cern.ch/crabserver/ui/task/230217_124810%3Admapelli_crab_20230217_134807

```plaintext
...
Failure message from server:    lfn2pfn resolution with Rucio failed for site: T2_CH_CERNBOX  LFN: /store/user/dmapelli/230217124810dmapellicrab20230217134807_crab3check.tmp with exception :
                                operation: third_party_copy_write, exception: RSE does not exist.
                                Details: RSE 'T2_CH_CERNBOX' cannot be found in vo 'def'
...
```

I think this is ready for merge, but I am open to comments and suggestions

### description

I save the string of the exception for every iteration of the loop, not only for the last one. It seems a bit more meaningful.