### PR TITLE
Switching crablog's handlers between file and stdout using env var

### DIFF
--- a/src/python/CRABInterface/RESTBaseAPI.py
+++ b/src/python/CRABInterface/RESTBaseAPI.py
@@ -3,6 +3,7 @@ import logging
 import logging.handlers
 import traceback
 import socket
+import os
 
 import cherrypy
 from subprocess import getstatusoutput
@@ -166,10 +167,7 @@ class RESTBaseAPI(DatabaseRESTApi):
         """
         logger = logging.getLogger('CRABLogger')
         if loglevel:
-            if logfile:
-                hdlr = logging.handlers.TimedRotatingFileHandler(logfile, when='D', interval=1, backupCount=keptDays)
-                formatter = logging.Formatter('%(asctime)s:%(trace_id)s:%(levelname)s:%(module)s:%(message)s')
-            else:
+            if os.environ.get('CRABSERVER_LOGSTDOUT') == 't':
                 # Use hostname as pod name
                 podname = socket.gethostname()
                 hdlr = logging.StreamHandler()
@@ -181,7 +179,11 @@ class RESTBaseAPI(DatabaseRESTApi):
                 h = cherrypy.log._get_builtin_handler(cherrypy.log.error_log, 'screen')
                 h.setFormatter(logfmt)
                 hdlr.setFormatter(formatter)
-                # add trace_id to log with filter class
+            else:
+                hdlr = logging.handlers.TimedRotatingFileHandler(logfile, when='D', interval=1, backupCount=keptDays)
+                formatter = logging.Formatter('%(asctime)s:%(trace_id)s:%(levelname)s:%(module)s:%(message)s')
+                hdlr.setFormatter(formatter)
+            # add trace_id to log with filter class
             f = TraceIDFilter()
             hdlr.addFilter(f)
             logger.addHandler(hdlr)

--- a/src/python/CRABInterface/RESTBaseAPI.py
+++ b/src/python/CRABInterface/RESTBaseAPI.py
@@ -164,7 +164,7 @@ class RESTBaseAPI(DatabaseRESTApi):
         When `CRABSERVER_LOGSTDOUT` environment variable is set to `t`
         (usually via k8s-manifests), we setup log handler to stream log to
         stdout/stderr instead. Cherrypy and CRAB log message will have
-        "Type=cherrypylog" and "Type=crablog" suffix respectively.
+        "Podname=<podname> Type=<cherrypylog/crablog>" suffix.
         """
         logger = logging.getLogger('CRABLogger')
         if loglevel:

--- a/src/python/CRABInterface/RESTBaseAPI.py
+++ b/src/python/CRABInterface/RESTBaseAPI.py
@@ -161,9 +161,10 @@ class RESTBaseAPI(DatabaseRESTApi):
         ChildName is the specific name of the logger (child of CRABLogger). Using childs in that way we can configure
         the logging in a flexible way (a module logs at DEBUG level to a file, another module logs at INFO level to stdout, etc)
 
-        In case `logfile=None`, we setup logger to stream to stdout/stderr
-        instead. Cherrypy and CRAB log message will have "Type=cherrypylog"
-        and "Type=crablog" suffix respectively.
+        When `CRABSERVER_LOGSTDOUT` environment variable is set to `t`
+        (usually via k8s-manifests), we setup log handler to stream log to
+        stdout/stderr instead. Cherrypy and CRAB log message will have
+        "Type=cherrypylog" and "Type=crablog" suffix respectively.
         """
         logger = logging.getLogger('CRABLogger')
         if loglevel:


### PR DESCRIPTION
*Tested in `test12`. Will test in preprod again before merge.*

Use environment variable `CRABSERVER_LOGSTDOUT` to switch crablog's handlers, instead of checking `data.loggingFile` from `config.py`:
- `CRABSERVER_LOGSTDOUT=t` will output crablog to stdout.
- else to file using `TimedRotatingFileHandler` (previous behavior).

This will allow us to **deploy only k8s manifest, without changing content of `config.py`** to make log-to-stdout work properly. Make it more easy to operate when you hurry to roll everything back or after you are done rollback and want to deploy it again, without keep forget to apply `config.py`. 

Env name and value come from new manifest [crabserver.yaml](https://github.com/dmwm/CMSKubernetes/blob/eca72978f74ea49f020a31eee866bd96f0ba7ef2/kubernetes/cmsweb/services/crabserver.yaml#L65-L66) which also use in the [run.sh](https://github.com/dmwm/CMSKubernetes/blob/eca72978f74ea49f020a31eee866bd96f0ba7ef2/docker/crabserver/run.sh#L73).

Also, put `setFormatter` back to `TimedRotatingFileHandler` that I forget to add it in https://github.com/dmwm/CRABServer/pull/7496.