### PR TITLE
Fix default values when TW fetch task, change default to None

### DIFF
--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -565,7 +565,7 @@ class RESTUserWorkflow(RESTEntity):
             'partialdataset': True if partialdataset else False,
             'requireaccelerator': True if requireaccelerator else False,
             'acceleratorparams': acceleratorparams if acceleratorparams else None,
-            'inputblocks': inputblocks if inputblocks else [],
+            'inputblocks': inputblocks if inputblocks else None,
         }
 
         return self.userworkflowmgr.submit(workflow=workflow, activity=activity, jobtype=jobtype, jobsw=jobsw, jobarch=jobarch,

--- a/src/python/CRABInterface/RESTWorkerWorkflow.py
+++ b/src/python/CRABInterface/RESTWorkerWorkflow.py
@@ -153,11 +153,12 @@ def fixupTask(task):
 
     # load json data of tm_user_config column
     # Hard code default value of tm_user_config for backward compatibility
-    # with older task
+    # with tasks submit from the old REST
     user_config_default = {
         'partialdataset': False,
         'requireaccelerator': False,
         'accceleratorparams': None,
+        'inputblocks': None,
     }
     if result['tm_user_config']:
         result['tm_user_config'] = json.loads(result['tm_user_config'])


### PR DESCRIPTION
I forget to put new default values in [RESTWorkerWorkflow](https://github.com/novicecpp/CRABServer/blob/9f6fd04c5061a3dce9a38718d4363be1142dfbc6/src/python/CRABInterface/RESTWorkerWorkflow.py#L157) for new `inputblocks` user config.
I think I can do it better but have no idea right now.

Also, change default from `[]` to `None`, follow practice from pylint (explanation from [stackoverflow](https://stackoverflow.com/questions/26320899/why-is-the-empty-dictionary-a-dangerous-default-value-in-python)).