### PR TITLE
add RucioDataDiscovery fix #7538

### DIFF
--- a/src/python/CRABInterface/DataUserWorkflow.py
+++ b/src/python/CRABInterface/DataUserWorkflow.py
@@ -139,6 +139,9 @@ class DataUserWorkflow(object):
            :arg str list userfiles: The files to process instead of a DBS-based dataset.
            :arg str scheddname: Schedd name used for debugging.
            :arg str collector: Collector name used for debugging.
+           :arg int dryrun: enable dry run mode (initialize but do not submit request).
+           :arg str ignoreglobalblacklist: flag to ignore site blacklist from SiteSupport
+           :arg dict userconfig: a dictionary of config.params which do not have a separate DB column
            :returns: a dict which contaians details of the request"""
 
         return self.workflow.submit(*args, **kwargs)

--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -1,7 +1,6 @@
 import copy
 import time
 import logging
-import datetime
 import json
 from ast import literal_eval
 
@@ -97,7 +96,7 @@ class DataWorkflow(object):
                runs, lumis, totalunits, adduserfiles, oneEventMode=False, maxjobruntime=None, numcores=None, maxmemory=None, priority=None, lfn=None,
                ignorelocality=None, saveoutput=None, faillimit=10, userfiles=None, scriptexe=None, scriptargs=None,
                scheddname=None, extrajdl=None, collector=None, dryrun=False, nonvaliddata=False, inputdata=None, primarydataset=None,
-               debugfilename=None, submitipaddr=None, ignoreglobalblacklist=False, user_config={}):
+               debugfilename=None, submitipaddr=None, ignoreglobalblacklist=False, user_config=None):
         """Perform the workflow injection
 
            :arg str workflow: workflow name requested by the user;
@@ -146,6 +145,8 @@ class DataWorkflow(object):
            :arg str scheddname: Schedd Name used for debugging.
            :arg str collector: Collector Name used for debugging.
            :arg int dryrun: enable dry run mode (initialize but do not submit task).
+           :arg str ignoreglobalblacklist: flag to ignore site blacklist from SiteSupport
+           :arg dict userconfig: a dictionary of config.params which do not have a separate DB column
            :returns: a dict which contaians details of the request"""
 
         backend_urls = copy.deepcopy(self.centralcfg.centralconfig.get("backend-urls", {}))

--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -258,7 +258,7 @@ class DataWorkflow(object):
             #just one row is picked up by the previous query
             row = self.Task.ID_tuple(*next(row))
         except StopIteration:
-            raise ExecutionError("Impossible to find task %s in the database." % workflow)
+            raise ExecutionError("Impossible to find task %s in the database." % workflow) from StopIteration
 
         submissionTime = getEpochFromDBTime(row.start_time)
 
@@ -384,7 +384,7 @@ class DataWorkflow(object):
             #just one row is picked up by the previous query
             row = self.Task.ID_tuple(*next(row))
         except StopIteration:
-            raise ExecutionError("Impossible to find task %s in the database." % workflow)
+            raise ExecutionError("Impossible to find task %s in the database." % workflow) from StopIteration
         warnings = literal_eval(row.task_warnings.read() if row.task_warnings else '[]') #there should actually is a default, but just in case
         if killwarning:
             warnings += [killwarning]

--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -126,7 +126,7 @@ class RESTUserWorkflow(RESTEntity):
             msg = "Invalid CRAB configuration parameter %s." % (param)
             msg += " The combined string '%s-%s<%s>' should not have more than 166 characters" % (group_user_prefix, extrastr, param)
             msg += " and should match the regular expression %s" % (userProcDSParts['publishdataname'])
-            raise InvalidParameter(msg)
+            raise InvalidParameter(msg) from AssertionError
 
 
     ## Basically copy and pasted from _checkPublishDataName which will be eventually removed
@@ -178,7 +178,7 @@ class RESTUserWorkflow(RESTEntity):
             msg = "Invalid CRAB configuration parameter %s." % (param)
             msg += " The combined string '%s-%s<%s>' should not have more than 166 characters" % (username, extrastr, param)
             msg += " and should match the regular expression %s" % (userProcDSParts['publishdataname'])
-            raise InvalidParameter(msg)
+            raise InvalidParameter(msg) from AssertionError
 
 
     @staticmethod
@@ -205,7 +205,7 @@ class RESTUserWorkflow(RESTEntity):
             msg = "Invalid 'primarydataset' parameter."
             msg += " The parameter should not have more than 99 characters"
             msg += " and should match the regular expression [a-zA-Z][a-zA-Z0-9\-_]*"
-            raise InvalidParameter(msg)
+            raise InvalidParameter(msg) from AssertionError
 
 
     def _checkASODestination(self, site):
@@ -370,7 +370,7 @@ class RESTUserWorkflow(RESTEntity):
                     if not RX_RUCIOSCOPE.match(scope):
                         raise InvalidParameter(f"Invalid Rucio scope: {scope}")
                     if not RX_DATASET.match(containerName):
-                        raise InvalidParameter(f"Invalid dataset name: {dataset}")
+                        raise InvalidParameter(f"Invalid dataset name: {containerName}")
                 else:
                     validate_str("inputdata", param, safe, RX_DATASET, optional=True)
             else:

--- a/src/python/CRABInterface/RESTUserWorkflow.py
+++ b/src/python/CRABInterface/RESTUserWorkflow.py
@@ -18,7 +18,7 @@ from CRABInterface.RESTExtensions import authz_owner_match
 from CRABInterface.Regexps import (RX_TASKNAME, RX_ACTIVITY, RX_JOBTYPE, RX_GENERATOR, RX_LUMIEVENTS, RX_CMSSW, RX_ARCH, RX_DATASET,
     RX_CMSSITE, RX_SPLIT, RX_CACHENAME, RX_CACHEURL, RX_LFN, RX_USERFILE, RX_VOPARAMS, RX_DBSURL, RX_LFNPRIMDS, RX_OUTFILES,
     RX_RUNS, RX_LUMIRANGE, RX_SCRIPTARGS, RX_SCHEDD_NAME, RX_COLLECTOR, RX_SUBRESTAT, RX_JOBID, RX_ADDFILE,
-    RX_ANYTHING, RX_USERNAME, RX_DATE, RX_MANYLINES_SHORT, RX_CUDA_VERSION, RX_BLOCK)
+    RX_ANYTHING, RX_USERNAME, RX_DATE, RX_MANYLINES_SHORT, RX_CUDA_VERSION, RX_BLOCK, RX_RUCIODID, RX_RUCIOSCOPE)
 from CRABInterface.Utilities import CMSSitesCache, conn_handler, getDBinstance, validate_dict
 from ServerUtilities import checkOutLFN, generateTaskName
 
@@ -362,7 +362,17 @@ class RESTUserWorkflow(RESTEntity):
             ## we can uncomment the 1st line below and delete the next 4 lines.
             #validate_str("inputdata", param, safe, RX_DATASET, optional=True)
             if safe.kwargs['jobtype'] == 'Analysis' and not safe.kwargs['userfiles'] and 'inputdata' in param.kwargs:
-                validate_str("inputdata", param, safe, RX_DATASET, optional=True)
+                inputDataFromRucio = ':' in param.kwargs['inputdata']  # scope:name format
+                if inputDataFromRucio:
+                    validate_str("inputdata", param, safe, RX_RUCIODID, optional=True)
+                    scope = safe.kwargs["inputdata"].split(':')[0]
+                    containerName = safe.kwargs["inputdata"].split(':')[1]
+                    if not RX_RUCIOSCOPE.match(scope):
+                        raise InvalidParameter(f"Invalid Rucio scope: {scope}")
+                    if not RX_DATASET.match(containerName):
+                        raise InvalidParameter(f"Invalid dataset name: {dataset}")
+                else:
+                    validate_str("inputdata", param, safe, RX_DATASET, optional=True)
             else:
                 validate_str("inputdata", param, safe, RX_ANYTHING, optional=True)
 
@@ -371,7 +381,10 @@ class RESTUserWorkflow(RESTEntity):
             ## the LFN of the output/log files and for publication. We want to have it well
             ## defined even if publication and/or transfer to storage are off.
             if safe.kwargs['inputdata']:
-                param.kwargs['primarydataset'] = safe.kwargs['inputdata'].split('/')[1]
+                if inputDataFromRucio:
+                    param.kwargs['primarydataset'] = containerName.split('/')[1]
+                else:
+                    param.kwargs['primarydataset'] = safe.kwargs['inputdata'].split('/')[1]
             if not param.kwargs.get('primarydataset', None):
                 if safe.kwargs['jobtype'] == 'PrivateMC':
                     param.kwargs['primarydataset'] = "CRAB_PrivateMC"
@@ -559,6 +572,11 @@ class RESTUserWorkflow(RESTEntity):
            :arg str extrajdl: extra Job Description Language parameters to be added.
            :arg str collector: Collector Name used for debugging.
            :arg int dryrun: enable dry run mode (initialize but do not submit request).
+           :arg str ignoreglobalblacklist: flag to ignore site blacklist from SiteSupport
+           :arg str partialdataset: to submit even if dataset is partially on disk
+           :arg str requireaccelerator: to require jobs to run on CPU with hardwre accelerators
+           :arg dict acceleratorparams: key:value pairs to define which exact accelerators
+           :arg str list inputblocks: the blocks to process instead of the full dataset
            :returns: a dict which contaians details of the request"""
 
         user_config = {

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -58,6 +58,8 @@ RX_JOBID     = re.compile(r"^\d+(-\d+){0,1}$")
 RX_RUNS      = re.compile(r"^\d+$")
 RX_LUMIRANGE = re.compile(r"^\d+,\d+(,\d+,\d+)*$")
 RX_RUCIORULE = re.compile(r"^(?=.{32}$)[A-Za-z0-9]*$")
+RX_RUCIODID =  re.compile(r"^.*:.*$")  # Rucio has no limitations: scope:name is a valid DID
+RX_RUCIOSCOPE = re.compile(r"^(cms)|(logs)|(user\.[a-z0-9-_]{1,20})$|(group\.[a-z0-9-_]{1,19})$")
 
 # Supports two formats for backward compatibility:
 # '1,4,6,8,9,10...' (old format which is still present in old postjobs)

--- a/src/python/TaskWorker/Actions/Handler.py
+++ b/src/python/TaskWorker/Actions/Handler.py
@@ -4,7 +4,6 @@ import time
 import logging
 import tempfile
 import traceback
-from http.client import HTTPException
 
 from RESTInteractions import CRABRest
 from RucioUtils import getNativeRucioClient
@@ -20,6 +19,7 @@ from TaskWorker.Actions.MakeFakeFileSet import MakeFakeFileSet
 from TaskWorker.Actions.DagmanSubmitter import DagmanSubmitter
 from TaskWorker.Actions.DBSDataDiscovery import DBSDataDiscovery
 from TaskWorker.Actions.UserDataDiscovery import UserDataDiscovery
+from TaskWorker.Actions.RucioDataDiscovery import RucioDataDiscovery
 from TaskWorker.Actions.DagmanResubmitter import DagmanResubmitter
 from TaskWorker.WorkerExceptions import WorkerHandlerException, TapeDatasetException, TaskWorkerException
 
@@ -157,6 +157,8 @@ def handleNewTask(resthost, dbInstance, config, task, procnum, *args, **kwargs):
     if task['tm_job_type'] == 'Analysis':
         if task.get('tm_user_files'):
             handler.addWork(UserDataDiscovery(config=config, crabserver=crabserver, procnum=procnum))
+        elif ':' in task.get('tm_input_dataset'):  # Rucio DID is scope:name
+            handler.addWork(RucioDataDiscovery(config=config, crabserver=crabserver, procnum=procnum, rucioClient=rucioClient))
         else:
             handler.addWork(DBSDataDiscovery(config=config, crabserver=crabserver, procnum=procnum, rucioClient=rucioClient))
     elif task['tm_job_type'] == 'PrivateMC':

--- a/src/python/TaskWorker/Actions/Handler.py
+++ b/src/python/TaskWorker/Actions/Handler.py
@@ -79,15 +79,15 @@ class TaskHandler(object):
         try:
             output = work.execute(nextinput, task=self._task, tempDir=self.tempDir)
         except TapeDatasetException as tde:
-            raise TapeDatasetException(str(tde))
+            raise TapeDatasetException(str(tde)) from tde
         except TaskWorkerException as twe:
-            self.logger.debug(str(traceback.format_exc())) #print the stacktrace only in debug mode
-            raise WorkerHandlerException(str(twe), retry=twe.retry) #TaskWorker error, do not add traceback to the error propagated to the REST
+            self.logger.debug(str(traceback.format_exc()))  # print the stacktrace only in debug mode
+            raise WorkerHandlerException(str(twe), retry=twe.retry) from twe  # TaskWorker error, do not add traceback
         except Exception as exc:
             msg = "Problem handling %s because of %s failure, traceback follows\n" % (self.taskname, str(exc))
             msg += str(traceback.format_exc())
             self.logger.error(msg)
-            raise WorkerHandlerException(msg) #Errors not foreseen. Print everything!
+            raise WorkerHandlerException(msg) from exc  # Errors not foreseen. Print everything!
         finally:
             #TODO: we need to do that also in Worker.py otherwise some messages might only be in the TW file but not in the crabcache.
             logpath = self.config.TaskWorker.logsDir+'/tasks/%s/%s.log' % (self._task['tm_username'], self.taskname)

--- a/src/python/TaskWorker/Actions/RucioDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/RucioDataDiscovery.py
@@ -67,7 +67,7 @@ class RucioDataDiscovery(DataDiscovery):
         except Exception as ex:
             # dataset not found is a known use case
             if str(ex).find('No Dids found'):
-                raise TaskWorkerException(f"Did not find container {rucioContainer} in scope {rucioScope}:")
+                raise TaskWorkerException(f"Did not find container {rucioContainer} in scope {rucioScope}:") from ex
             raise
         if not blocks:
             raise TaskWorkerException(f"Rucio DID {rucioScope}:{rucioContainer} not existing or empty")
@@ -92,9 +92,9 @@ class RucioDataDiscovery(DataDiscovery):
                 for item in response:
                     if 'T2_UA_KIPT' in item['rse']:
                         continue  # skip Ucrainan T2 until further notice
-                    if 'Tape' in rse:
+                    if 'Tape' in item['rse']:
                         continue  # skip tape locations
-                    if 'T3_CH_CERN_OpenData' in rse:
+                    if 'T3_CH_CERN_OpenData' in item['rse']:
                         continue  # ignore OpenData until it is accessible by CRAB
                     if item['state'].upper() == 'AVAILABLE':  # means all files in the block are on disk
                         replicas.add(item['rse'])

--- a/src/python/TaskWorker/Actions/RucioDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/RucioDataDiscovery.py
@@ -1,0 +1,239 @@
+from __future__ import print_function
+import os
+import logging
+import copy
+from http.client import HTTPException
+
+import sys
+
+from TaskWorker.WorkerExceptions import TaskWorkerException
+from TaskWorker.Actions.DataDiscovery import DataDiscovery
+from RucioUtils import getNativeRucioClient
+
+class RucioDataDiscovery(DataDiscovery):
+    """Performing the data discovery through CMS Rucio service.
+    """
+
+    # disable pylint warning in next line since they refer to conflict with the main()
+    # at the bottom of this file which is only used for testing
+    def __init__(self, config, crabserver='', procnum=-1, rucioClient=None): # pylint: disable=redefined-outer-name
+        DataDiscovery.__init__(self, config, crabserver, procnum)
+        self.rucioClient = rucioClient
+
+    def execute(self, *args, **kwargs):
+        """
+        This is a convenience wrapper around the executeInternal function
+        """
+
+        # we don't want to leak X509 credentials to other modules
+        # so use a context manager to set an ad hoc env and restore as soon as
+        # executeInternal is over, even if it raises exception
+
+        with self.config.TaskWorker.envForCMSWEB:
+            result = self.executeInternal(*args, **kwargs)
+
+        return result
+
+    def executeInternal(self, *args, **kwargs):
+
+        self.logger.info("Data discovery with Rucio") ## to be changed into debug
+
+        self.taskName = kwargs['task']['tm_taskname']           # pylint: disable=W0201
+        self.username = kwargs['task']['tm_username']           # pylint: disable=W0201
+        self.userproxy = kwargs['task']['user_proxy']           # pylint: disable=W0201
+
+        if kwargs['task']['tm_split_algo'] != 'FileBased':
+            msg = "Data.splitting must be set to 'FileBased' when using Rucio for DataDiscovery."
+            raise TaskWorkerException(msg)
+        if kwargs['task']['tm_use_parent']:
+            msg = "Parent processing needs lumi info from DBS.\nCan't work when using Rucio for DataDiscovery."
+            raise TaskWorkerException(msg)
+        if kwargs['task']['tm_secondary_input_dataset']:
+            msg = "Secondary dataset processing needs lumi info from DBS.\nCan't work when using Rucio for DataDiscovery."
+            raise TaskWorkerException(msg)
+
+        rucioDID = kwargs['task']['tm_input_dataset']
+        rucioContainer = rucioDID.split(':')[1]
+        rucioScope = rucioDID.split(':')[0]
+
+        # when using Rucio for data discovery there is no lumi info and no secondary dataset
+        # and it makes no difference USER dataset or not, the only thing that matter
+        # is the correct scope for the given DBS dataset name i.e. Rucio container
+
+        try:
+            # Get the list of blocks for the locations.
+            datasets = self.rucioClient.list_content(rucioScope, rucioContainer)
+            blocks = [ds['name'] for ds in datasets]
+        except Exception as ex:
+            # dataset not found is a known use case
+            if str(ex).find('No Dids found'):
+                raise TaskWorkerException(f"Did not find container {rucioContainer} in scope {rucioScope}:")
+            raise
+        if not blocks:
+            raise TaskWorkerException(f"Rucio DID {rucioScope}:{rucioContainer} not existing or empty")
+
+        ## Create a map for block's locations: for each block get the list of locations.
+        ## locationsMap is a dictionary, key=blockName, value=list of PhedexNodes, example:
+        ## {'/JetHT/Run2016B-PromptReco-v2/AOD#b10179dc-3723-11e6-9aa5-001e67abf228': [u'T1_IT_CNAF_Buffer', u'T2_US_Wisconsin', u'T1_IT_CNAF_MSS', u'T2_BE_UCL'],
+        ## '/JetHT/Run2016B-PromptReco-v2/AOD#89b03ca6-1dc9-11e6-b567-001e67ac06a0': [u'T1_IT_CNAF_Buffer', u'T2_US_Wisconsin', u'T1_IT_CNAF_MSS', u'T2_BE_UCL']}
+
+
+        # TODO move to a utility function common with DBSDataDiscovery
+        # something like
+        # (locationsMap, dataSize) = self.locateData(blocks, rucioScope)
+
+        self.logger.info(f"Looking up data location with Rucio in {rucioScope}: scope.")
+        locationsMap = {}
+        totalSizeBytes = 0
+        try:
+            for blockName in blocks:
+                replicas = set()
+                response = self.rucioClient.list_dataset_replicas(scope=rucioScope, name=blockName, deep=True)
+                for item in response:
+                    if 'T2_UA_KIPT' in item['rse']:
+                        continue  # skip Ucrainan T2 until further notice
+                    if 'Tape' in rse:
+                        continue  # skip tape locations
+                    if 'T3_CH_CERN_OpenData' in rse:
+                        continue  # ignore OpenData until it is accessible by CRAB
+                    if item['state'].upper() == 'AVAILABLE':  # means all files in the block are on disk
+                        replicas.add(item['rse'])
+                        sizeBytes = item['bytes']
+                if replicas:  # only fill map for blocks which have at least one location
+                    locationsMap[blockName] = replicas
+                    totalSizeBytes += sizeBytes
+        except Exception as e:
+            msg = f"Rucio lookup failed with\n{str(e)}"
+            self.logger.warning(msg)
+            locationsMap = None
+
+        self.logger.debug(f"Dataset size in GBytes: {totalSizeBytes/1e9}")
+
+        if not locationsMap:
+            self.logger.warning(f"No locations found with Rucio for {rucioDID}")
+            raise TaskWorkerException(
+                "CRAB server could not get data locations from Rucio.\n" +
+                "This is could be a temporary Rucio glitch, please try to submit a new task (resubmit will not work)" + \
+                " and contact the experts if the error persists."
+                )
+
+        blocksWithLocation = locationsMap.keys()
+        skipped = len(blocksWithLocation) != len(blocks)
+        if skipped:
+            msg = f"{skipped} blocks will not be processed because they have no (or not complete) disk replica"
+            self.uploadWarning(msg, kwargs['task']['user_proxy'], kwargs['task']['tm_taskname'])
+
+        try:
+            # Here's DBS3Reader.listDatsetFileDetails re-implemented via Rucio API
+            # DBSDataDiscovery has:
+            # filedetails = self.dbs.listDatasetFileDetails(inputDataset, getParents=True, getLumis=needLumiInfo, validFileOnly=0)
+            # filedetails is {lfn1:detail1, lfn2:detail2,...}
+            # where for each file we have something like (from comments in DBS3Reader.py)
+            #             { 'NumberOfEvents': 545,
+            #               'BlockName': '/HighPileUp/Run2011A-v1/RAW#dd6e0796-cbcc-11e0-80a9-003048caaace',
+            #               'Lumis': {173658: [8, 12, 9, 14, 19, 109, 105]},
+            #               'Parents': [],
+            #               'Checksum': '22218315',
+            #               'Adler32': 'a41a1446',
+            #               'Md5' : '23415' , # not listed in DBS3Reaser comments, but rquired in WMCore pff...
+            #               'FileSize': 286021145,
+            #               'ValidFile': 1
+            #             }
+            # since RucioDataDiscovery only supports FileBased splitting, we can
+            # safely put dummy values for lumis and events, also there's no parentage in Rucio
+            filedetails = {}
+            detail = {  # a template
+                # to be filled
+                'BlockName': 'to be filled', 'Adler32': 'anAdler', 'FileSize': 0,
+                # to maintain compatibility with downstream code that deals with data from DBS as well
+                'ValidFile': 1, 'NumberOfEvents': 0, 'Lumis': {}, 'Parents': [],
+                'Checksum': 'aChecksum', 'Md5': 'anMd5'}
+            for dataset in blocksWithLocation:  #  DBS block = Rucio dataset
+                detail['BlockName'] = dataset
+                dids = self.rucioClient.list_files(rucioScope, dataset)
+                for did in dids:
+                    lfn = did['name']
+                    detail['FileSize'] = did['bytes']
+                    detail['Adler32'] = did['adler32']
+                    filedetails[lfn] = copy.deepcopy(detail)
+        except Exception as ex: #TODO should we catch HttpException instead?
+            self.logger.exception(ex)
+            raise TaskWorkerException("CRAB could not contact Rucio to get file list.\n"+\
+                                "This could be a temporary glitch. Try to submit a new task (resubmit will not work)"+\
+                                " and contact the experts if the error persists.\nError reason: %s" % str(ex))
+        if not filedetails:
+            raise TaskWorkerException("Cannot find any file inside the dataset. Check dataset scope and name\n" +\
+                                "Aborting submission. Submitting your task again will not help.")
+
+        ## Format the output creating the data structures required by WMCore. Filters out invalid files,
+        ## files whose block has no location, and figures out the PSN
+        result = self.formatOutput(task=kwargs['task'], requestname=self.taskName,
+                                   datasetfiles=filedetails, locations=locationsMap,
+                                   tempDir=kwargs['tempDir'])
+
+        if not result.result:
+            # the following message is wrong. failure inside formatOutput can fail for varied reasons
+            msg = "Cannot find any valid file inside the input container."
+            msg += f"\nPlease check {rucioDID}"
+            msg += "\nAborting submission. Resubmitting your task will not help."
+            raise TaskWorkerException(msg)
+
+        self.logger.debug("Got %s files", len(result.result.getFiles()))
+
+        return result
+
+if __name__ == '__main__':
+    ###
+    # Usage: python3 RucioDataDiscovery.py rucioScope dbsDataset
+    #
+    # Example: python3 /data/repos/CRABServer/src/python/TaskWorker/Actions/RucioDataDiscovery.py cms /MuonEG/Run2016B-23Sep2016-v3/MINIAOD
+    ###
+    scope = sys.argv[1]
+    container = sys.argv[2]
+    did = f"{scope}:{container}"
+
+    logging.basicConfig(level=logging.DEBUG)
+    from WMCore.Configuration import ConfigurationEx
+    from ServerUtilities import newX509env
+
+    config = ConfigurationEx()
+    config.section_("Services")
+    config.section_("TaskWorker")
+
+    # will user service cert as defined for TW
+    if "X509_USER_CERT" in os.environ:
+        config.TaskWorker.cmscert = os.environ["X509_USER_CERT"]
+    else:
+        config.TaskWorker.cmscert = '/data/certs/servicecert.pem'
+    if "X509_USER_KEY" in os.environ:
+        config.TaskWorker.cmskey = os.environ["X509_USER_KEY"]
+    else:
+        config.TaskWorker.cmskey = '/data/certs/servicekey.pem'
+
+    config.TaskWorker.envForCMSWEB = newX509env(X509_USER_CERT=config.TaskWorker.cmscert,
+                                                X509_USER_KEY=config.TaskWorker.cmskey)
+
+    config.TaskWorker.instance = 'prod'
+
+    config.Services.Rucio_host = 'https://cms-rucio.cern.ch'
+    config.Services.Rucio_account = 'crab_server'
+    config.Services.Rucio_authUrl = 'https://cms-rucio-auth.cern.ch'
+    config.Services.Rucio_caPath = '/etc/grid-security/certificates/'
+    rucioClient = getNativeRucioClient(config=config, logger=logging.getLogger())
+
+    fileset = RucioDataDiscovery(config=config, rucioClient=rucioClient)
+    fileset.execute(task={'tm_nonvalid_input_dataset': 'T', 'tm_use_parent': 0, 'user_proxy': 'None',
+                          'tm_input_dataset': did, 'tm_split_algo': 'FileBased',
+                          'tm_taskname': 'pippo1', 'tm_username': config.Services.Rucio_account,
+                          }, tempDir='')
+
+#===============================================================================
+#    Some interesting datasets for testing
+#    dataset = '/DoubleMuon/Run2018B-PromptReco-v2/AOD'       # on tape
+#    dataset = '/DoubleMuon/Run2018B-02Apr2020-v1/NANOAOD'    # isNano
+#    dataset = '/DoubleMuon/Run2018B-17Sep2018-v1/MINIAOD'    # parent of above NANOAOD (for secondaryDataset lookup)
+#    dataset = '/MuonEG/Run2016B-07Aug17_ver2-v1/AOD'         # no Nano on disk (at least atm)
+#    dataset = '/MuonEG/Run2016B-v1/RAW'                      # on tape
+#    dataset = '/MuonEG/Run2016B-23Sep2016-v3/MINIAOD'        # no NANO on disk (MINIAOD should always be on disk)
+#    dataset = '/GenericTTbar/belforte-Stefano-Test-bb695911428445ed11a1006c9940df69/USER' # USER dataset on prod/phys03
+#===============================================================================


### PR DESCRIPTION
RucioDataDiscovery will be put in the list of Actions for the submitted task by Actions/Handler.py whenever the new parameter `rucioscope` is set to a string in `tm_user_config` dictionary.
RucioDataDiscover will raise a fatal exception if the task was submitted with a splitting algorithm different from `FileBased` but should otherwise support all features DBSDataDiscovery: blacklists, whitelists, taperecall.
