### PR TITLE
jobwrapper - added cmscp.sh

### DIFF
--- a/bin/htcondor_make_runtime.sh
+++ b/bin/htcondor_make_runtime.sh
@@ -19,6 +19,7 @@ CRABSERVERREPO=dmwm
 
 [[ -d $STARTDIR ]] || mkdir -p $STARTDIR
 
+cp $BASEDIR/../scripts/cmscp.sh $STARTDIR || exit 3
 cp $BASEDIR/../scripts/submit_env.sh $STARTDIR || exit 3
 cp $BASEDIR/../scripts/gWMS-CMSRunAnalysis.sh $STARTDIR || exit 3
 

--- a/scripts/cmscp.sh
+++ b/scripts/cmscp.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+exec 2>&1
+
+
+source ./submit_env.sh
+
+# from ./submit_env.sh
+setup_cmsset
+
+# from ./submit_env.sh
+setup_python_comp
+
+echo "======== Stageout at $(TZ=GMT date) STARTING ========"
+# Note we prevent buffering of stdout/err -- this is due to observed issues in mixing of out/err for stageout plugins
+PYTHONUNBUFFERED=1 $pythonCommand cmscp.py

--- a/scripts/submit_env.sh
+++ b/scripts/submit_env.sh
@@ -22,6 +22,11 @@ save_env() {
 
 }
 
+load_startup_env() {
+    # load the startup environment, as it is saved at the beginning of the job.
+    .  $JOBSTARTDIR/startup_environment.sh
+}
+
 setup_local_env () {
     # when running a job locally, we need to set manually some variables that 
     # are set for us when running on the global pool.

--- a/setup.py
+++ b/setup.py
@@ -274,7 +274,7 @@ setup(name='crabserver',
       #base directory for all the packages
       package_dir={'': 'src/python'},
       data_files=['scripts/%s' % x for x in \
-                        ['CMSRunAnalysis.sh', 'cmscp.py',
+                        ['CMSRunAnalysis.sh', 'cmscp.py', 'cmscp.sh',
                          'gWMS-CMSRunAnalysis.sh', 'submit_env.sh', 
                          'dag_bootstrap_startup.sh',
                          'dag_bootstrap.sh', 'AdjustSites.py']] + getWebDir(),

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -534,6 +534,7 @@ class DagmanCreator(TaskAction):
         info['additional_input_file'] += ", run_and_lumis.tar.gz"
         info['additional_input_file'] += ", input_files.tar.gz"
         info['additional_input_file'] += ", submit_env.sh"
+        info['additional_input_file'] += ", cmscp.sh"
 
         info['max_disk_space'] = MAX_DISK_SPACE
 
@@ -1154,6 +1155,7 @@ class DagmanCreator(TaskAction):
         #transform_location = getLocation(kw['task']['tm_transformation'], 'CAFUtilities/src/python/transformation/CMSRunAnalysis/')
         transform_location = getLocation('CMSRunAnalysis.sh', 'CRABServer/scripts/')
         cmscp_location = getLocation('cmscp.py', 'CRABServer/scripts/')
+        cmscpsh_location = getLocation('cmscp.sh', 'CRABServer/scripts/')
         gwms_location = getLocation('gWMS-CMSRunAnalysis.sh', 'CRABServer/scripts/')
         env_location = getLocation('submit_env.sh', 'CRABServer/scripts/')
         dag_bootstrap_location = getLocation('dag_bootstrap_startup.sh', 'CRABServer/scripts/')
@@ -1162,6 +1164,7 @@ class DagmanCreator(TaskAction):
 
         shutil.copy(transform_location, '.')
         shutil.copy(cmscp_location, '.')
+        shutil.copy(cmscpsh_location, '.')
         shutil.copy(gwms_location, '.')
         shutil.copy(env_location, '.')
         shutil.copy(dag_bootstrap_location, '.')
@@ -1201,7 +1204,7 @@ class DagmanCreator(TaskAction):
         kw['task']['dbinstance'] = self.crabserver.getDbInstance()
         params = {}
 
-        inputFiles = ['gWMS-CMSRunAnalysis.sh', 'submit_env.sh', 'CMSRunAnalysis.sh', 'cmscp.py', 'RunJobs.dag', 'Job.submit', 'dag_bootstrap.sh',
+        inputFiles = ['gWMS-CMSRunAnalysis.sh', 'submit_env.sh', 'CMSRunAnalysis.sh', 'cmscp.py', 'cmscp.sh', 'RunJobs.dag', 'Job.submit', 'dag_bootstrap.sh',
                       'AdjustSites.py', 'site.ad', 'site.ad.json', 'datadiscovery.pkl', 'taskinformation.pkl', 'taskworkerconfig.pkl',
                       'run_and_lumis.tar.gz', 'input_files.tar.gz']
 

--- a/src/script/Deployment/TaskWorker/updateTMRuntime.sh
+++ b/src/script/Deployment/TaskWorker/updateTMRuntime.sh
@@ -47,6 +47,7 @@ filesToCopy="$filesToCopy $CRAB_OVERRIDE_SOURCE/CRABServer/scripts/gWMS-CMSRunAn
 filesToCopy="$filesToCopy $CRAB_OVERRIDE_SOURCE/CRABServer/scripts/submit_env.sh"
 filesToCopy="$filesToCopy $CRAB_OVERRIDE_SOURCE/CRABServer/scripts/CMSRunAnalysis.sh"
 filesToCopy="$filesToCopy $CRAB_OVERRIDE_SOURCE/CRABServer/scripts/cmscp.py"
+filesToCopy="$filesToCopy $CRAB_OVERRIDE_SOURCE/CRABServer/scripts/cmscp.sh"
 
 # clean backup of previous Runtime files
 rm -rf  $CRABTASKWORKER_ROOT/data/PreviousRuntime/*


### PR DESCRIPTION
### status

- [x] tested on test11: https://cmsweb-test11.cern.ch/crabserver/ui/task/230322_124355:dmapelli_crab_jobwr4_20230322_134354

ready to merge. no change on the crabclient is needed.

### description

I decided that I will open multiple PRs with the changes that I am making to the jowr, so that it will be easier to review and manage.

This is the first one and focuses on executing `cmscp.py` inside its own script, `cmscp.sh`, so that we always use only the gwms container environment in gWMS-CMSRunAnalysis.sh.