### PR TITLE
REST - new endpoint counttasksbyuserandstatus

### DIFF
--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -182,6 +182,16 @@ class RESTTask(RESTEntity):
 
         return rows
 
+    def counttasksbyuserandstatus(self, **kwargs):
+        """Count jobs for every user and status in the last :minutes
+           curl -X GET 'https://cmsweb-test11.cern.ch/crabserver/dev/task?subresource=counttasksbyuserandstatus&minutes=100'\
+                        --cert $X509_USER_PROXY --key $X509_USER_PROXY
+        """
+        if 'minutes' not in kwargs or not kwargs['minutes']:
+            raise InvalidParameter("The parameter minutes is mandatory for the tasksbystatus api")
+        rows = self.api.query(None, None, self.Task.CountLastTasksByUserAndStatus_sql, minutes=kwargs["minutes"])
+
+        return rows
 
     def lastfailures(self, **kwargs):
         """Retrieves all jobs of the specified user with the specified status

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -86,7 +86,7 @@ RX_SUBRESTAT = re.compile(r"^(errors|report2|logs|data|logs2|data2|resubmit|resu
 
 #subresources of the ServerInfo (/info) and Task (/task) resources
 RX_SUBRES_SI = re.compile(r"^(delegatedn|backendurls|version|bannedoutdest|scheddaddress|ignlocalityblacklist)$")
-RX_SUBRES_TASK = re.compile(r"^(allinfo|allusers|summary|search|taskbystatus|getpublishurl|addwarning|deletewarnings|addwebdir|addoutputdatasets|addddmreqid|webdir|webdirprx|counttasksbystatus|lastfailures|updateschedd|updatepublicationtime)$")
+RX_SUBRES_TASK = re.compile(r"^(allinfo|allusers|summary|search|taskbystatus|getpublishurl|addwarning|deletewarnings|addwebdir|addoutputdatasets|addddmreqid|webdir|webdirprx|counttasksbystatus|counttasksbyuserandstatus|lastfailures|updateschedd|updatepublicationtime)$")
 
 #subresources of Cache resource
 RX_SUBRES_CACHE = re.compile(r"^(upload|download|retrieve|list|used)$")

--- a/src/python/Databases/TaskDB/Oracle/Task/Task.py
+++ b/src/python/Databases/TaskDB/Oracle/Task/Task.py
@@ -32,6 +32,8 @@ class Task(object):
     TaskByStatus_sql = "SELECT tm_task_status,tm_taskname FROM tasks WHERE tm_task_status = :taskstatus AND tm_username=:username_"
     #get all the tasks in a certain state in the last :minutes minutes
     CountLastTasksByStatus = "SELECT tm_task_status, count(*) FROM tasks WHERE tm_start_time > SYS_EXTRACT_UTC(SYSTIMESTAMP) - (:minutes/1440)  GROUP BY tm_task_status"
+    #get all the tasks in a certain state submitted by which user in the last :minutes minutes
+    CountLastTasksByUserAndStatus_sql = "SELECT tm_username, tm_task_status, count(*) FROM tasks WHERE tm_start_time > SYS_EXTRACT_UTC(SYSTIMESTAMP) - (:minutes/1440)  group by tm_username, tm_task_status order by count(*) desc"
     #get all the task failures sorted by username in the last :minutes minutes
     LastFailures = "SELECT tm_username, tm_taskname, tm_task_failure from tasks WHERE tm_start_time > SYS_EXTRACT_UTC(SYSTIMESTAMP) - (:minutes/1440) and (tm_task_status='FAILED' \
                     OR tm_task_status='SUBMITFAILED' OR tm_task_status='KILLFAILED' OR tm_task_status='RESUBMITFAILED') \


### PR DESCRIPTION
Fixes #7580 

### status

tested on test11 with `devtwo` and `prod` DB

```plaintext
> curl --cert $X509_USER_PROXY --key $X509_USER_PROXY "https://cmsweb-test11.cern.ch:8443/crabserver/prod/task?subresource=counttasksbyuserandstatus&minutes=60"
{"desc": {"columns": ["tm_username", "tm_task_status", "count(*)"]}, "result": [
 ["alebihan", "SUBMITTED", 48]
,["azacharo", "SUBMITTED", 30]
,["asotorod", "SUBMITTED", 11]
,["sciaba", "SUBMITTED", 7]
,["sanayak", "SUBMITTED", 5]
,["evourlio", "SUBMITTED", 4]
,["azacharo", "TAPERECALL", 3]
,["dmroy", "SUBMITTED", 2]
,["msergeev", "SUBMITTED", 1]
,["iparaske", "KILLED", 1]
,["cgalloni", "SUBMITTED", 1]
,["ckowal", "SUBMITTED", 1]
,["bgreenbe", "SUBMITTED", 1]
]}
```

### details

simply added a new query and subresource