### PR TITLE
Jobwrapper - fix elapsed time computation

### DIFF
--- a/scripts/gWMS-CMSRunAnalysis.sh
+++ b/scripts/gWMS-CMSRunAnalysis.sh
@@ -31,6 +31,8 @@ function finish {
   chirp_exit_code
   END_TIME=$(date +%s)
   DIFF_TIME=$((END_TIME-START_TIME))
+  echo "Job started:  " $START_TIME ", " $(TZ=GMT date -d @$START_TIME)
+  echo "Job finished: " $END_TIME ", " $(TZ=GMT date -d @$END_TIME)
   echo "Job Running time in seconds: " $DIFF_TIME
   if [ "X$CRAB3_RUNTIME_DEBUG" = "X" ];
   then

--- a/scripts/submit_env.sh
+++ b/scripts/submit_env.sh
@@ -72,10 +72,11 @@ setup_python_comp() {
     echo "======== python bootstrap for stageout at $(TZ=GMT date) STARTING ========"
     # Python library required for Python2/Python3 compatibility through "future"
     PY3_FUTURE_VERSION=0.18.2
-    # Saving START_TIME and when job finishes END_TIME.
-    START_TIME=$(date +%s)
     WMA_DEFAULT_OS=rhel7
-    export JOBSTARTDIR=$PWD
+
+    # # the two following variables should be set elsewhere
+    # START_TIME=$(date +%s)
+    # export JOBSTARTDIR=$PWD
 
     # First, decide which COMP ScramArch to use based on the required OS and Architecture
     THIS_ARCH=`uname -m`  # if it's PowerPC, it returns `ppc64le`


### PR DESCRIPTION
Fixes #7602 
Fixes #7586 

### status

ready to merge, tested on test11:

- [x] https://cmsweb-test11.cern.ch/crabserver/ui/task/230419_094216%3Admapelli_crab_elapsed_20230419_114211

### description

Thank you both @belforte and @mmascher for having a look. I leaked a variable from WMCore indeed, there is no need for setting the start time in `submit_env.sh`.

For some obscure reason I have not been able to replicate the problem on my test environment, but since you found the culprit I will not give insist on it.

