### PR TITLE
move ALLOW_OPENSSL_1.0.2 to env.sh

### DIFF
--- a/src/script/Deployment/Publisher/env.sh
+++ b/src/script/Deployment/Publisher/env.sh
@@ -15,6 +15,9 @@ then
   export GHrepoDir='/data/repos'
 fi
 
+# until we get a new openssl version, python3 requires this
+export CRYPTOGRAPHY_ALLOW_OPENSSL_102=true
+
 # cleanup the environment (needed in some cases when running interactively)
 unset X509_USER_PROXY
 unset X509_USER_CERT

--- a/src/script/Deployment/Publisher/start.sh
+++ b/src/script/Deployment/Publisher/start.sh
@@ -62,8 +62,6 @@ ln -s /data/hostdisk/${SERVICE}/nohup.out nohup.out
 
 #==== START THE SERVICE
 
-export CRYPTOGRAPHY_ALLOW_OPENSSL_102=true
-
 case $MODE in
   current)
   # current mode: run current instance

--- a/src/script/Deployment/TaskWorker/env.sh
+++ b/src/script/Deployment/TaskWorker/env.sh
@@ -15,6 +15,9 @@ then
   export GHrepoDir='/data/repos'
 fi
 
+# until we get a new openssl version, python3 requires this
+export CRYPTOGRAPHY_ALLOW_OPENSSL_102=true
+
 # cleanup the environment (needed in some cases when running interactively)
 unset X509_USER_PROXY
 unset X509_USER_CERT

--- a/src/script/Deployment/TaskWorker/start.sh
+++ b/src/script/Deployment/TaskWorker/start.sh
@@ -62,8 +62,6 @@ ln -s /data/hostdisk/${SERVICE}/nohup.out nohup.out
 
 #==== START THE SERVICE
 
-export CRYPTOGRAPHY_ALLOW_OPENSSL_102=true
-
 case $MODE in
     current)
     # current mode: run current instance


### PR DESCRIPTION
two reasons
1. env.sh is where env. vars belong !
2. when I test I use `source env.sh` and I need this 