### PR TITLE
Refactor tape recall

### DIFF
--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -397,6 +397,7 @@ class DataWorkflow(object):
         if row.task_status == 'TAPERECALL':
             self.api.modify(self.Task.SetStatusWarningTask_sql, status=["KILLRECALL"], command=["KILL"],
                             taskname=[workflow], warnings=[str(warnings)])
+
         elif row.task_status == 'NEW' and row.task_command == 'SUBMIT':
             #if the task has just been submitted and not acquired by the TW
             self.api.modify(self.Task.SetStatusWarningTask_sql, status=["KILLED"], command=["KILL"],

--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -394,7 +394,7 @@ class DataWorkflow(object):
             self.api.modify(self.Task.SetStatusWarningTask_sql, status=["NEW"], command=["KILL"],
                             taskname=[workflow], warnings = [str(warnings)])
 
-        if row.task_status == 'TAPERECALL':
+        elif row.task_status == 'TAPERECALL':
             self.api.modify(self.Task.SetStatusWarningTask_sql, status=["KILLRECALL"], command=["KILL"],
                             taskname=[workflow], warnings=[str(warnings)])
 

--- a/src/python/CRABInterface/DataWorkflow.py
+++ b/src/python/CRABInterface/DataWorkflow.py
@@ -390,11 +390,17 @@ class DataWorkflow(object):
             warnings += [killwarning]
         warnings = str(warnings)
 
-        if row.task_status in ['SUBMITTED', 'KILLFAILED', 'RESUBMITFAILED', 'FAILED', 'KILLED', 'TAPERECALL']:
-            self.api.modify(self.Task.SetStatusWarningTask_sql, status = ["NEW"], command = ["KILL"], taskname = [workflow], warnings = [str(warnings)])
+        if row.task_status in ['SUBMITTED', 'KILLFAILED', 'RESUBMITFAILED', 'FAILED', 'KILLED']:
+            self.api.modify(self.Task.SetStatusWarningTask_sql, status=["NEW"], command=["KILL"],
+                            taskname=[workflow], warnings = [str(warnings)])
+
+        if row.task_status == 'TAPERECALL':
+            self.api.modify(self.Task.SetStatusWarningTask_sql, status=["KILLRECALL"], command=["KILL"],
+                            taskname=[workflow], warnings=[str(warnings)])
         elif row.task_status == 'NEW' and row.task_command == 'SUBMIT':
             #if the task has just been submitted and not acquired by the TW
-            self.api.modify(self.Task.SetStatusWarningTask_sql, status = ["KILLED"], command = ["KILL"], taskname = [workflow], warnings = [str(warnings)])
+            self.api.modify(self.Task.SetStatusWarningTask_sql, status=["KILLED"], command=["KILL"],
+                            taskname=[workflow], warnings=[str(warnings)])
         else:
             raise ExecutionError("You cannot kill a task if it is in the %s status" % row.task_status)
 

--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -76,7 +76,7 @@ MAX_POST_JOBS = 20
 ## It's also used during resubmissions since we don't allow a resubmission during the last week
 ## Before changing this value keep in mind that old running DAGs have the old value in the CRAB_TaskSubmitTime
 ## classad expression but DagmanResubmitter uses this value to calculate if a resubmission is possible
-TASKLIFETIME = 30*24*60*60
+TASKLIFETIME = 30*24*60*60  # 30 days in seconds
 ## Number of days where the resubmission is not possible if the task is expiring
 NUM_DAYS_FOR_RESUBMITDRAIN = 7
 ## Maximum number of days a task can stay in TAPERECALL status

--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -14,7 +14,7 @@ from WMCore.Services.DBS.DBSErrors import DBSReaderError
 
 from TaskWorker.WorkerExceptions import TaskWorkerException, TapeDatasetException
 from TaskWorker.Actions.DataDiscovery import DataDiscovery
-from ServerUtilities import FEEDBACKMAIL, parseDBSInstance, isDatasetUserDataset
+from ServerUtilities import FEEDBACKMAIL, MAX_DAYS_FOR_TAPERECALL, parseDBSInstance, isDatasetUserDataset
 from RucioUtils import getNativeRucioClient
 
 from rucio.common.exception import (DuplicateRule, DataIdentifierAlreadyExists, DuplicateContent,
@@ -190,7 +190,8 @@ class DBSDataDiscovery(DataDiscovery):
             #RSE_EXPRESSION = 'T3_IT_Trieste' # for testing
             WEIGHT = 'ddm_quota'
             #WEIGHT = None # for testing
-            LIFETIME = 30 * 24 * 3600  # 30 days
+            # make rul last 7 extra days to allow debugging in case TW or Recall action fail
+            LIFETIME = (MAX_DAYS_FOR_TAPERECALL + 7 ) * 24 * 60 * 60  # in seconds
             ASK_APPROVAL = False
             #ASK_APPROVAL = True # for testing
             ACCOUNT = 'crab_tape_recall'

--- a/src/python/TaskWorker/Actions/Recurring/RenewRemoteProxies.py
+++ b/src/python/TaskWorker/Actions/Recurring/RenewRemoteProxies.py
@@ -12,6 +12,7 @@ import HTCondorUtils
 from WMCore.Credential.Proxy import Proxy
 from RESTInteractions import CRABRest
 from ServerUtilities import SERVICE_INSTANCES, tempSetLogLevel
+from TaskWorker.MasterWorker import getRESTParams
 from TaskWorker.WorkerExceptions import ConfigException
 
 from TaskWorker.Actions.Recurring.BaseRecurringAction import BaseRecurringAction
@@ -62,28 +63,7 @@ class CRAB3ProxyRenewer(object):
 
     def get_backendurls(self):
         # need to deal with the fact that TaskWorkerConfig may only specify a name instance
-        # following code snipped is copy/pasted from MasterWorker.py
-        try:
-            instance = self.config.TaskWorker.instance
-        except:
-            msg = "No instance provided: need to specify config.TaskWorker.instance in the configuration"
-            raise ConfigException(msg)
-        if instance in SERVICE_INSTANCES:
-            self.logger.info('Will connect to CRAB service: %s', instance)
-            self.restHost = SERVICE_INSTANCES[instance]['restHost']
-            self.dbInstance = SERVICE_INSTANCES[instance]['dbInstance']
-        else:
-            msg = "Invalid instance value '%s'" % instance
-            raise ConfigException(msg)
-        if instance == 'other':
-            self.logger.info('Will use restHost and dbInstance from config file')
-            try:
-                self.restHost = self.config.TaskWorker.restHost
-                self.dbInstance = self.config.TaskWorker.dbInstance
-            except:
-                msg = "Need to specify config.TaskWorker.restHost and dbInstance in the configuration"
-                raise ConfigException(msg)
-
+        self.restHost, self.dbInstance = getRESTParams(self.config, self.logger)
         self.logger.info("Querying server %s for HTCondor schedds and pool names.", self.restHost)
         crabserver = CRABRest(self.restHost, self.config.TaskWorker.cmscert, self.config.TaskWorker.cmskey,
                               retry=2, userAgent='CRABTaskWorker')

--- a/src/python/TaskWorker/Actions/Recurring/TapeRecallManager.py
+++ b/src/python/TaskWorker/Actions/Recurring/TapeRecallManager.py
@@ -77,8 +77,8 @@ class TapeRecallManager(BaseRecurringAction):
             self.logger.info("Working on task %s", taskName)
             # 1.) check for "waited too long"
             if (time.time() - getTimeFromTaskname(str(taskName))) > MAX_DAYS_FOR_TAPERECALL*24*60*60:
-                msg = "Disk replica request (ID: %s) for input data did not complete in %d days." %\
-                      (reqId, MAX_DAYS_FOR_TAPERECALL)
+                msg = "Tape recall request for input data did not complete in %d days." %\
+                      MAX_DAYS_FOR_TAPERECALL
                 self.logger.info(msg)
                 failTask(taskName, self.crabserver, msg, self.logger, 'FAILED')
                 continue

--- a/src/python/TaskWorker/Actions/Recurring/TapeRecallManager.py
+++ b/src/python/TaskWorker/Actions/Recurring/TapeRecallManager.py
@@ -1,0 +1,237 @@
+"""
+Manages recurring actions for tape recall functionalities
+1. for tasks in TAPERECALL check status of rule and set to NEW when rule is OK
+2. for tasks in KILLRECALL delete rule and set to KILLED
+"""
+import logging
+import sys
+import os
+import time
+import datetime
+import copy
+
+from http.client import HTTPException
+from urllib.parse import urlencode
+
+from rucio.common.exception import RuleNotFound
+
+from ServerUtilities import MAX_DAYS_FOR_TAPERECALL, getTimeFromTaskname
+from RESTInteractions import CRABRest
+from RucioUtils import getNativeRucioClient
+from TaskWorker.MasterWorker import getRESTParams
+from TaskWorker.Worker import failTask
+from TaskWorker.Actions.Recurring.BaseRecurringAction import BaseRecurringAction
+
+class TapeRecallManager(BaseRecurringAction):
+    """ interface needed by the way TW deals with recurring actions
+    must have a class which inherit from BaseRecurringAction
+    which implements the _execute method (with the unused argument "task"...pff)
+    name of this class, this file and the recurring action in TW config list
+    must be the same """
+    pollingTime = 60*4  # unit=minutes. Runs every 4 hours
+    rucioClient = None
+    privilegedRucioClient = None
+    crabserver = None
+
+    def _execute(self, config, task):  # pylint: disable=unused-argument
+        """ this is what we do at every polling cycle """
+        self.config = config
+        # setup logger, crabserver client, rucio client
+        self.init()
+        # do the work
+        self.handleRecall()
+        self.handleKill()
+
+
+    def handleKill(self):
+        """ looks for tasks in KILLRECALL and deals with them """
+        status = 'KILLRECALL'
+        tasksToWorkOn = self.getTasks(status)
+
+        for aTask in tasksToWorkOn:
+            taskName = aTask['tm_taskname']
+            self.logger.info("Working on task %s", taskName)
+
+            reqId = aTask['tm_DDM_reqid']
+            if not reqId:
+                self.logger.debug("tm_DDM_reqid' is not defined for task %s, skipping it", taskName)
+                continue
+            msg = "Task points to Rucio RuleId:  %s " % reqId
+            self.logger.info(msg)
+
+            # delete rule and set task status to killed
+            self.logger.info('Will delete rule %s', reqId)
+            self.privilegedRucioClient.delete_replication_rule(reqId)
+            self.updateTaskStatus(taskName, 'KILLED')
+            # Clean up previous "dataset on tape" warnings
+            self.deleteWarnings(taskName)
+            self.logger.info("Done on this task")
+
+
+    def handleRecall(self):
+        """ looks for tasks in TAPERECALL and deals with them """
+        status = 'TAPERECALL'
+        tasksToWorkOn = self.getTasks(status)
+        for aTask in tasksToWorkOn:
+            taskName = aTask['tm_taskname']
+            self.logger.info("Working on task %s", taskName)
+            # 1.) check for "waited too long"
+            if (time.time() - getTimeFromTaskname(str(taskName))) > MAX_DAYS_FOR_TAPERECALL*24*60*60:
+                msg = "Disk replica request (ID: %s) for input data did not complete in %d days." %\
+                      (reqId, MAX_DAYS_FOR_TAPERECALL)
+                self.logger.info(msg)
+                failTask(taskName, self.crabserver, msg, self.logger, 'FAILED')
+                continue
+            # 2.) integrity checks
+            reqId = aTask['tm_DDM_reqid']
+            if not reqId:
+                self.logger.debug("tm_DDM_reqid' is not defined for task %s, skipping it", taskName)
+                continue
+            self.logger.info("Task points to Rucio RuleId:  %s ", reqId)
+            try:
+                rule = self.rucioClient.get_replication_rule(reqId)
+            except RuleNotFound:
+                msg = "Rucio rule id %s not found. Please report to experts" % reqId
+                self.logger.error(msg)
+                self.uploadWarning(msg, taskName)
+                continue
+            self.logger.info("Rule %s is %s", reqId, rule['state'])
+            # 3.) check if rule completed
+            if rule['state'] == 'OK':
+                # all good kick off a new processing
+                self.logger.info("Request %s is completed, proceed with submission", reqId)
+                self.updateTaskStatus(taskName, 'NEW')
+                # Clean up previous "dataset on tape" warnings
+                self.deleteWarnings(taskName)
+                # Make sure data will stay on disk
+                self.logger.info("Extending rule lifetime to 30 days from now")
+                newLifetime = 30 * 24 * 60 * 60  # 30 days in seconds
+                self.privilegedRucioClient.update_replication_rule(reqId, {'lifetime': newLifetime})
+            else:
+                expiration = rule['expires_at']  # this is a datetime.datetime object
+                # this condition could be met only if rule expiration is shorter then MAX_DAYS_FOR_TAPERECALL
+                # which is more a mistake than a possibility, anyhow, let's cover all grounds
+                if expiration < datetime.datetime.now():  # did we wait too much ?
+                    msg = ("Replication request %s for task %s expired." % (reqId, taskName))
+                    msg += " Setting its status to FAILED"
+                    self.logger.info(msg)
+                    failTask(taskName, self.crabserver, msg, self.logger, 'FAILED')
+                else:
+                    pass  # keep waiting
+            self.logger.info("Done on this task")
+
+
+    def init(self):
+        """ setup logger, crabserver client and rucio client"""
+        if not self.logger:
+            # running interactively, setup logging to stdout
+            self.logger = logging.getLogger(__name__)
+            handler = logging.StreamHandler(sys.stdout)  # pylint: disable=redefined-outer-name
+            formatter = logging.Formatter("%(asctime)s:%(levelname)s:%(module)s %(message)s")  # pylint: disable=redefined-outer-name
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
+            self.logger.setLevel(logging.DEBUG)
+        else:
+        # do not use BaseRecurringAction logger but create a new logger
+        # which writes to config.TaskWorker.logsDir/taks/recurring/TapeRecallManager_YYMMDD-HHMM.log
+            self.logger = logging.getLogger('TapeRecallManager')
+            logDir = self.config.TaskWorker.logsDir + '/tasks/recurring/'
+            if not os.path.exists(logDir):
+                os.makedirs(logDir)
+            timeStamp = time.strftime('%y%m%d-%H%M', time.localtime())
+            logFile = 'TapeRecallManager_' + timeStamp + '.log'
+            handler = logging.FileHandler(logDir + logFile)
+            formatter = logging.Formatter('%(asctime)s:%(levelname)s:%(module)s:%(message)s')
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
+
+        # setup a crabserver REST client
+        self.restHost, self.dbInstance = getRESTParams(self.config, self.logger)
+        if not self.crabserver:
+            self.crabserver = CRABRest(hostname=self.restHost, localcert=self.config.TaskWorker.cmscert,
+                                       localkey=self.config.TaskWorker.cmskey,
+                                       retry=2, userAgent='CRABTaskWorker')
+            self.crabserver.setDbInstance(self.dbInstance)
+
+        # setup a Rucio client
+        if not self.rucioClient:
+            self.rucioClient = getNativeRucioClient(config=self.config, logger=self.logger)
+
+        # setup a Rucio client with the account which can edit our rules
+        if not self.privilegedRucioClient:
+            tapeRecallConfig = copy.copy(self.config)
+            tapeRecallConfig.Services.Rucio_account = 'crab_tape_recall'
+            self.privilegedRucioClient = getNativeRucioClient(tapeRecallConfig, self.logger)
+
+
+    def getTasks(self, status):
+        """retrieve from DB a list of tasks with given status"""
+        #TODO this is also a candidate for TaskWorker/TaskUtils.py
+        self.logger.info("Retrieving %s tasks", status)
+        tasks = []
+        configreq = {'limit': 1000, 'workername': self.config.TaskWorker.name, 'getstatus': status}
+        try:
+            tasks = self.crabserver.get(api='workflowdb', data=configreq)[0]['result']
+        except Exception:
+            pass
+        if not tasks:
+            self.logger.info("No %s task retrieved.", status)
+        else:
+            self.logger.info("Retrieved a total of %d %s tasks", len(tasks), status)
+        return tasks
+
+    def uploadWarning(self, taskname, msg):
+        """ Uploads a warning message to the Task DB so that crab status can show it """
+        #TODO this is duplicated in TaskWorker/Actions/TaskAction.py but it is not possible
+        # to import from there. Should probably create a TaskWorker/TaskUtils.py for such functions
+        configreq = {'subresource': 'addwarning', 'workflow': taskname, 'warning': msg}
+        try:
+            self.crabserver.post(api='task', data=configreq)
+        except HTTPException as hte:
+            self.logger.error("Error uploading warning: %s", str(hte))
+            self.logger.warning("Cannot add a warning to REST interface. Warning message: %s", msg)
+
+    def deleteWarnings(self, taskname):
+        """ Removes all warnings uploaded so fare for this task """
+        #TODO this is also a candidate for TaskWorker/TaskUtils.py
+        configreq = {'subresource': 'deletewarnings', 'workflow': taskname}
+        try:
+            self.crabserver.post(api='task', data=configreq)
+        except HTTPException as hte:
+            self.logger.error("Error deleting warnings: %s", str(hte))
+            self.logger.warning("Can not delete warnings from REST interface.")
+
+    def updateTaskStatus(self, taskName, status):
+        """ change task status in the DB """
+        #TODO this is also a candidate for TaskWorker/TaskUtils.py
+        self.logger.info('Will set to %s task %s', status, taskName)
+        if status == 'NEW':
+            command = 'SUBMIT'
+        elif status == 'KILL':
+            command = 'KILL'
+        else:
+            self.logger.error('updateTaskStatus does not know how to handle status %s. Do nothing', status)
+            return
+        configreq = {'subresource': 'state', 'workflow': taskName, 'status': status, 'command': command}
+        data = urlencode(configreq)
+        self.crabserver.post(api='workflowdb', data=data)
+
+
+if __name__ == '__main__':
+    # Simple main to execute the action standalone for testing
+    # You just need to set the task worker environment and desired twconfig.
+
+    twconfig = '/data/srv/TaskManager/current/TaskWorkerConfig.py'
+
+    logger = logging.getLogger()
+    handler = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter("%(asctime)s:%(levelname)s:%(module)s %(message)s", datefmt="%a, %d %b %Y %H:%M:%S %Z(%z)")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+
+    from WMCore.Configuration import loadConfigurationFile
+    cfg = loadConfigurationFile(twconfig)
+
+    trs = TapeRecallManager(cfg.TaskWorker.logsDir)
+    trs._execute(cfg, None)  # pylint: disable=protected-access

--- a/src/python/TaskWorker/Actions/Recurring/TapeRecallManager.py
+++ b/src/python/TaskWorker/Actions/Recurring/TapeRecallManager.py
@@ -15,7 +15,7 @@ from urllib.parse import urlencode
 
 from rucio.common.exception import RuleNotFound
 
-from ServerUtilities import MAX_DAYS_FOR_TAPERECALL, getTimeFromTaskname
+from ServerUtilities import MAX_DAYS_FOR_TAPERECALL, TASKLIFETIME, getTimeFromTaskname
 from RESTInteractions import CRABRest
 from RucioUtils import getNativeRucioClient
 from TaskWorker.MasterWorker import getRESTParams
@@ -104,9 +104,8 @@ class TapeRecallManager(BaseRecurringAction):
                 # Clean up previous "dataset on tape" warnings
                 self.deleteWarnings(taskName)
                 # Make sure data will stay on disk
-                self.logger.info("Extending rule lifetime to 30 days from now")
-                newLifetime = 30 * 24 * 60 * 60  # 30 days in seconds
-                self.privilegedRucioClient.update_replication_rule(reqId, {'lifetime': newLifetime})
+                self.logger.info("Extending rule lifetime to last as long as the task")
+                self.privilegedRucioClient.update_replication_rule(reqId, {'lifetime': TASKLIFETIME})
             else:
                 pass  # keep waiting
             self.logger.info("Done on this task")

--- a/src/python/TaskWorker/Actions/Recurring/TapeRecallManager.py
+++ b/src/python/TaskWorker/Actions/Recurring/TapeRecallManager.py
@@ -171,7 +171,8 @@ class TapeRecallManager(BaseRecurringAction):
         tasks = []
         configreq = {'limit': 1000, 'workername': self.config.TaskWorker.name, 'getstatus': status}
         try:
-            tasks = self.crabserver.get(api='workflowdb', data=configreq)[0]['result']
+            data = urlencode(configreq)
+            tasks = self.crabserver.get(api='workflowdb', data=data)[0]['result']
         except Exception:
             pass
         if not tasks:

--- a/src/python/TaskWorker/Actions/Recurring/TapeRecallManager.py
+++ b/src/python/TaskWorker/Actions/Recurring/TapeRecallManager.py
@@ -195,8 +195,9 @@ class TapeRecallManager(BaseRecurringAction):
         """ Removes all warnings uploaded so fare for this task """
         #TODO this is also a candidate for TaskWorker/TaskUtils.py
         configreq = {'subresource': 'deletewarnings', 'workflow': taskname}
+        data = urlencode(configreq)
         try:
-            self.crabserver.post(api='task', data=configreq)
+            self.crabserver.post(api='task', data=data)
         except HTTPException as hte:
             self.logger.error("Error deleting warnings: %s", str(hte))
             self.logger.warning("Can not delete warnings from REST interface.")
@@ -207,7 +208,7 @@ class TapeRecallManager(BaseRecurringAction):
         self.logger.info('Will set to %s task %s', status, taskName)
         if status == 'NEW':
             command = 'SUBMIT'
-        elif status == 'KILL':
+        elif status == 'KILLED':
             command = 'KILL'
         else:
             self.logger.error('updateTaskStatus does not know how to handle status %s. Do nothing', status)

--- a/src/python/TaskWorker/Actions/Recurring/TapeRecallManager.py
+++ b/src/python/TaskWorker/Actions/Recurring/TapeRecallManager.py
@@ -108,16 +108,7 @@ class TapeRecallManager(BaseRecurringAction):
                 newLifetime = 30 * 24 * 60 * 60  # 30 days in seconds
                 self.privilegedRucioClient.update_replication_rule(reqId, {'lifetime': newLifetime})
             else:
-                expiration = rule['expires_at']  # this is a datetime.datetime object
-                # this condition could be met only if rule expiration is shorter then MAX_DAYS_FOR_TAPERECALL
-                # which is more a mistake than a possibility, anyhow, let's cover all grounds
-                if expiration < datetime.datetime.now():  # did we wait too much ?
-                    msg = ("Replication request %s for task %s expired." % (reqId, taskName))
-                    msg += " Setting its status to FAILED"
-                    self.logger.info(msg)
-                    failTask(taskName, self.crabserver, msg, self.logger, 'FAILED')
-                else:
-                    pass  # keep waiting
+                pass  # keep waiting
             self.logger.info("Done on this task")
 
 

--- a/src/python/TaskWorker/MasterWorker.py
+++ b/src/python/TaskWorker/MasterWorker.py
@@ -62,6 +62,8 @@ def validateConfig(config):
 def getRESTParams(config, logger):
     """ get REST host name and db instance from a config object
     returns a tuple of strings (host, dbinstance). If can't, raises exception"""
+    # TODO this is also a candidate for TaskWorker/TaskUtils.py
+
     try:
         instance = config.TaskWorker.instance
     except:

--- a/src/python/TaskWorker/MasterWorker.py
+++ b/src/python/TaskWorker/MasterWorker.py
@@ -59,6 +59,32 @@ def validateConfig(config):
         config.TaskWorker.scheddPickerFunction = HTCondorLocator.memoryBasedChoices
     return True, 'Ok'
 
+def getRESTParams(config, logger):
+    """ get REST host name and db instance from a config object
+    returns a tuple of strings (host, dbinstance). If can't, raises exception"""
+    try:
+        instance = config.TaskWorker.instance
+    except:
+        msg = "No instance provided: need to specify config.TaskWorker.instance in the configuration"
+        raise ConfigException(msg)
+
+    if instance in SERVICE_INSTANCES:
+        logger.info('Will connect to CRAB service: %s', instance)
+        restHost = SERVICE_INSTANCES[instance]['restHost']
+        dbInstance = SERVICE_INSTANCES[instance]['dbInstance']
+    else:
+        msg = "Invalid instance value '%s'" % instance
+        raise ConfigException(msg)
+    if instance == 'other':
+        logger.info('Will use restHost and dbInstance from config file')
+        try:
+            restHost = config.TaskWorker.restHost
+            dbInstance = config.TaskWorker.dbInstance
+        except:
+            msg = "Need to specify config.TaskWorker.restHost and dbInstance in the configuration"
+            raise ConfigException(msg)
+    return restHost, dbInstance
+
 
 class MasterWorker(object):
     """I am the master of the TaskWorker"""
@@ -191,29 +217,9 @@ class MasterWorker(object):
 
         logVersionAndConfig(self.config, self.logger)
 
-        try:
-            instance = self.config.TaskWorker.instance
-        except:
-            msg = "No instance provided: need to specify config.TaskWorker.instance in the configuration"
-            raise ConfigException(msg)
-
-        if instance in SERVICE_INSTANCES:
-            self.logger.info('Will connect to CRAB service: %s', instance)
-            self.restHost = SERVICE_INSTANCES[instance]['restHost']
-            dbInstance = SERVICE_INSTANCES[instance]['dbInstance']
-        else:
-            msg = "Invalid instance value '%s'" % instance
-            raise ConfigException(msg)
-        if instance == 'other':
-            self.logger.info('Will use restHost and dbInstance from config file')
-            try:
-                self.restHost = self.config.TaskWorker.restHost
-                dbInstance = self.config.TaskWorker.dbInstance
-            except:
-                msg = "Need to specify config.TaskWorker.restHost and dbInstance in the configuration"
-                raise ConfigException(msg)
+        restHost, dbInstance = getRESTParams(self.config, self.logger)
+        self.restHost = restHost
         self.dbInstance = dbInstance
-
         self.logger.info('Will connect via URL: https://%s/%s', self.restHost, self.dbInstance)
 
         #Let's increase the server's retries for recoverable errors in the MasterWorker


### PR DESCRIPTION
this PR does 2 main things:
1. when a task in status TAPERECALL is killed, it goes in KILLRECALL
2. introduces a new recurring action TapeRecallManager which will replace current TapeRecallStatus and handle both TAPERECALL and KILLRECALL states

improvements:
- when it kills tasks in TAPERECALL it also removes the Rucio recall rule
- when a rule completes and task is released for submission, it extends rule lifetime for another 30 days
- less code, get rid of useless instantiation of a new MasterWorker in TapeRecallStatus
- paves the way to further code cleanup and unification with other TW places

This is not fully tested yet, but ready for a first review.

**IMPORTANT NOTE**
when we will want to test and deploy, we must change also REST or tasks will never go into KILLRECALL
