### PR TITLE
jobwrapper - many small improvements

### DIFF
--- a/scripts/gWMS-CMSRunAnalysis.sh
+++ b/scripts/gWMS-CMSRunAnalysis.sh
@@ -108,7 +108,7 @@ term_signal_handler() {
     check_file_exist cmsRun-stdout.log.tmp DUMMY printfile
 
     # proceed with exit pipeline: this will call finish()
-    exit
+    finish
 }
 
 # Set a trap for SIGINT and SIGTERM signals

--- a/scripts/gWMS-CMSRunAnalysis.sh
+++ b/scripts/gWMS-CMSRunAnalysis.sh
@@ -100,25 +100,6 @@ check_file_exist() {
     fi
 }
 
-term_signal_handler() {
-    echo "The job received a termination signal: " $1
-
-    # the job received a sigterm and it is likely that CMSRunAnalysis.py:logCMSSW()
-    # did not run. We then print here the stdout+stderr of cmsRun.
-    check_file_exist cmsRun-stdout.log.tmp DUMMY printfile
-
-    # proceed with exit pipeline: this will call finish()
-    finish
-}
-
-# Set a trap for SIGINT and SIGTERM signals
-# it is possible that condor only sends sigterm, but i'd rather
-# play it safe and trap also other termination signals
-trap "term_signal_handler TERM" SIGTERM
-trap "term_signal_handler INT"  SIGINT
-trap "term_signal_handler HUP"  SIGHUP
-trap "term_signal_handler QUIT" SIGQUIT
-
 function finish {
   parse_cmsrun
   chirp_exit_code
@@ -192,7 +173,7 @@ function parse_cmsrun {
     echo "======== Parsing output of cmsRun at $(TZ=GMT date)========"
     # We check which files that contain information about cmsRun execution exist.
 
-    check_file_exist cmsRun-stdout.log.tmp DUMMY
+    check_file_exist cmsRun-stdout.log.tmp DUMMY printfile
     check_file_exist cmsRun-stdout.log DUMMY
     check_file_exist FrameworkJobReport.xml DUMMY
     check_file_exist jobReport.json.$CRAB_Id JRJSON_NONEMPTY

--- a/scripts/gWMS-CMSRunAnalysis.sh
+++ b/scripts/gWMS-CMSRunAnalysis.sh
@@ -53,56 +53,9 @@ echo "======== Auxiliary Functions - STARTING ========"
 # auxiliary functions, needed when the job terminates
 # we can consider making some of these fuctions less CRAB-oriented and moving them to ./submit_env.sh
 
-print_file() {
-    # similar in spirit to CMSRunAnalysis.py:logCMSSW()
-
-    keepAtStart=1000
-    keepAtEnd=3000
-    maxLineLen=3000
-
-    FILEPATH=$1
-    cutLines=$(expr $(echo "[$FILEPATH]" | wc -L ) + $maxLineLen)
-    maxLines=$(expr $keepAtStart + $keepAtEnd)
-    numLines=$(wc -l $FILEPATH | cut -d ' ' -f 1)
-
-    print_line() {
-        # expects input to come from a pipe, such as
-        # > echo $mylongline | print_line
-        while read line; do echo "[$FILEPATH] $line" | awk -v cutLines=$cutLines '{print substr($0, 0, cutLines)}'; done
-    }
-
-    if [[ $numLines -gt $maxLines ]]; then
-        head -n $keepAtStart $FILEPATH | print_line
-        echo "[...]"
-        tail -n $keepAtEnd $FILEPATH | print_line
-    else
-        cat $FILEPATH | print_line
-    fi
-    echo
-}
-
-check_file_exist() {
-    FILEPATH=$1
-    REGISTERENVVAR=$2
-    if [[ -e $FILEPATH ]]; then
-        echo "the file $FILEPATH exists"
-        if [[ -s $FILEPATH ]]; then
-            echo "the file $FILEPATH is non-empty. wc (newlines, words, bytes): " $(wc $FILEPATH)
-            export $REGISTERENVVAR=true
-            if [[ $3 == "printfile" ]]; then
-                # used when the job terminates unexpectedly and we want to make sure that the
-                # content of a file is written to stdout.
-                print_file $FILEPATH
-            fi
-        fi
-    else 
-        echo "the file $FILEPATH does **NOT** exist"
-    fi
-}
-
 function finish {
-  parse_cmsrun
   chirp_exit_code
+  check_application_execution
   END_TIME=$(date +%s)
   DIFF_TIME=$((END_TIME-START_TIME))
   echo "Job started:  " $START_TIME ", " $(TZ=GMT date -d @$START_TIME)
@@ -122,37 +75,29 @@ function finish {
 trap finish EXIT
 
 function chirp_exit_code {
-    #Get the long exit code and set a classad using condor_chirp
-    #The long exit code is taken from jobReport.json file if it exist
-    #and is successfully loaded. It is taken from the EXIT_STATUS variable
-    #instead (which contains the short exit coce)
+    # Get the long exit code and set a classad using condor_chirp
+    # The long exit code is taken from jobReport.exitCode.txt file if it exist and is not empty
+    # Otherwise, it is taken from the EXIT_STATUS variable (which contains the short exit coce)
 
     echo "======== Figuring out long exit code of the job for condor_chirp at $(TZ=GMT date)========"
 
-    #check if the command condor_chirp exists
+    # check if the command condor_chirp exists
     command -v condor_chirp > /dev/null 2>&1
     if [ $? -ne 0 ]; then
         echo "Cannot find condor_chirp to set up the job exit code (ignoring, that's for monitoring purposes)"
         return
     fi
 
-    #check if exitCode is in there and report it
-    #otherwise check if EXIT_STATUS is set and report it
-    if [[ $EXITTXT_NONEMPTY ]]; then
-        #any error or exception will be printed to stderr and cause $? <> 0
+    if [[ -e jobReport.exitCode.txt ]] && [[ -s jobReport.exitCode.txt ]] ; then
+        # if jobReport.exitCode.txt exists and is not empty, 
+        # it should contain exitCode, so we report it
         LONG_EXIT_CODE=$(cat jobReport.exitCode.txt)
-        if [ $? -eq 0 ]; then
-            echo "==== Long exit code of the job is $LONG_EXIT_CODE ===="
-            condor_chirp set_job_attr_delayed Chirp_CRAB3_Job_ExitCode $LONG_EXIT_CODE
-            CHIRP_EC=$?
-        else
-            unset EXITTXT_NONEMPTY
-        fi
-    fi
-    if [[ ! $EXITTXT_NONEMPTY ]]; then
-        # we want to execute this code block if:
-        # - jobReport.exitCode.txt does not exist
-        # - jobReport.exitCode.txt exists, but fails to be parsed
+        echo "==== Long exit code of the job is $LONG_EXIT_CODE ===="
+        condor_chirp set_job_attr_delayed Chirp_CRAB3_Job_ExitCode $LONG_EXIT_CODE
+        CHIRP_EC=$?
+    else
+        # otherwise check if EXIT_STATUS is set and report it
+        # we want to execute this code block if jobReport.exitCode.txt does not exist
         echo "==== Failed to load the long exit code from jobReport.exitCode.txt. Falling back to short exit code ===="
         if [ -z "$EXIT_STATUS" ]; then
             echo "======== Short exit code also missing. Settint exit code to 80001 ========"
@@ -168,19 +113,66 @@ function chirp_exit_code {
 
 }
 
-function parse_cmsrun {
+function check_application_execution {
+    # We check the files that contain information about the execution of
+    # a generic user application. Then we focus on the execution of cmsRun
 
-    echo "======== Parsing output of cmsRun at $(TZ=GMT date)========"
-    # We check which files that contain information about cmsRun execution exist.
+    echo "======== Checking execution of user application (cmsRun and scriptExe) $(TZ=GMT date)========"
 
-    check_file_exist cmsRun-stdout.log.tmp DUMMY printfile
-    check_file_exist cmsRun-stdout.log DUMMY
-    check_file_exist FrameworkJobReport.xml DUMMY
-    check_file_exist jobReport.json.$CRAB_Id JRJSON_NONEMPTY
-    check_file_exist jobReport.exitCode.txt EXITTXT_NONEMPTY
+    check_file_exist cmsRun-stdout.log.tmp printfile
+    check_file_exist cmsRun-stdout.log
 
-    echo "======== Finished - Parsing output of cmsRun at $(TZ=GMT date)========"
+    echo "======== Checking execution of cmsRun $(TZ=GMT date)========"
 
+    check_file_exist FrameworkJobReport.xml
+    check_file_exist jobReport.json.$CRAB_Id
+    check_file_exist jobReport.exitCode.txt
+
+    echo "======== Finished - Checking execution of user application $(TZ=GMT date)========"
+}
+
+check_file_exist() {
+    # Helper function used to check the files that carry information about cmsRun execution
+    # it checks if a file exists and is not empty. In this case, it
+    # 1. prints some stats about it with wc
+    # 2. if the argument "printfile" is passed, then it prints the file content
+
+    FILEPATH=$1
+
+    if [[ -e $FILEPATH ]]; then
+        echo "the file $FILEPATH exists"
+        if [[ -s $FILEPATH ]]; then
+            echo "the file $FILEPATH is non-empty. wc (newlines, words, bytes): " $(wc $FILEPATH)
+            if [[ $2 == "printfile" ]]; then
+                # used when the job terminates unexpectedly and we want to make sure that the
+                # content of a file is written to stdout.
+                print_file $FILEPATH
+            fi
+        fi
+    else 
+        echo "the file $FILEPATH does **NOT** exist"
+    fi
+}
+
+print_file() {
+    # similar in spirit to CMSRunAnalysis.py:logCMSSW()
+
+    keepAtStart=1000
+    keepAtEnd=3000
+    maxLineLen=3000
+
+    FILEPATH=$1
+    maxLines=$(expr $keepAtStart + $keepAtEnd)
+    numLines=$(cat $FILEPATH | wc -l)
+
+    if [[ $numLines -gt $maxLines ]]; then
+        head -n $keepAtStart $FILEPATH
+        echo "[...]"
+        tail -n $keepAtEnd $FILEPATH
+    else
+        cat $FILEPATH
+    fi
+    echo
 }
 
 echo "======== Auxiliary Functions - FINISHING ========"


### PR DESCRIPTION
#### status

tested on test11

- [x] hammercloud https://cmsweb-test11.cern.ch/crabserver/ui/task/230428_162937%3Admapelli_crab_jobwr5_20230428_182936
- [x] montecarlo  https://cmsweb-test11.cern.ch/crabserver/ui/task/230428_164602%3Admapelli_crab_jobwr5_20230428_184559
- [x] retrieve logs of killed job: https://cmsweb-test11.cern.ch/crabserver/ui/task/230504_191507%3Admapelli_crab_jobwr5_20230504_211505

I propose to merge this PR, create a new tag and continue testing in testbed.

#### details

This PR gathers many small improvements to the jobwrapper. 

First of all, I propose change how we manage stdout+stderr of cmsRun / user script. Instead of keeping it in the Popen stdout (which is a pipe [1], and hence in memory), we redirect both stdout and stderr to the file `cmsRun-stdout.log.tmp`. This has two main advantages for CRAB. 

- We do not run out of memory if the job processes many events, as it can happen with automatic splitting on nanoaod. 
- We can to retrieve the stdout+err from cmsRun if it gets killed by the periodic removal 

We decided to buffer the stdout+stderr for up to one line. I am reluctant to buffer more than one line, I worry that it can cause stdout and stderr to go out of order with each other. I do not think it is necessary to turn off buffering. 

It is possible that writing often to the local disk can increase I/O and slow down execution. We will keep an eye out for this.

Secondly, I added some auxiliary functions to `gWMS-CMSRunAnalysis.py` that allow to check the content of the files where we keep information about the cmsRun execution (`cmsRun-stdout.log`, `FrameworkJobReport.xml`, ... ).

Thirdly, I added a trap on sigterm. Combined with the previous two addition, this allows to print the partial cmsRun stdout+stderr in case the job is gracefully killed by condor, for example due to a periodic removal policy. Before this PR, we would have lost stdout+stderr entirely, since at the moment it makes sense to run run `CMSRunAnalysis.py:logCMSSW()` only after the cmsRun execution finishes. We already have a way of intercepting the sigterm from condor [2],  but `CMSRunAnalysis.py:logCMSSW()` requires `cmsRun-stdout.log` to be present on disk (and before this PR we only write such file after the cmsRun completes), so even if condor sends a sigterm to all the child processes and we catch the sigterm in cmsrunanalysis.py, there is no file on disk to dump when the job is killed. This is still untested, as i did not managed yet to have my jobs killed by a periodic removal.

Lastly, I decided to stop using `jobReport.json.$CRAB_Id` for extracting the chirp exit code. I do not want condor_chirp to use python to parse a json. I do not want to rely on `gwms-python` to discover python for me. Moreover, on the remote nodes we do not have `jq` and I did not find a valid alternative to parse a json with pure bash. I'd rather create a new file `jobReport.exitCode.txt` that only contains the exit code, that chirp can read with a simple `cat`.

[1] https://github.com/dmwm/WMCore/blob/31d65166dc62c7251edd52890bc4ac2f0b79d7fe/src/python/WMCore/WMRuntime/Tools/Scram.py#L367
[2] https://github.com/dmwm/CRABServer/blob/3d7cb32e23e1b3c0da6fd2f93c7f646f093509a5/scripts/CMSRunAnalysis.py#L54
[] bash stdout and stderr: https://stackoverflow.com/a/16283739
[] https://www.gnu.org/software/coreutils/manual/html_node/stdbuf-invocation.html

---

Addendum

After reading [a.1], it is clear that dealing with termination signals does only depend on the receiving hand, it also depends on to which process the sigterm is sent to, whether only to the parent process or to the whole parent group.

In our case, we could catch the sigterm in cmsrunanalysis.py [a.2] only if condor sends a sigterm to all the processes in the `gWMS-CMSRunAnalysis.sh` group, for example. But this is not the default "send a sigterm" behavior. By default, only the parent process is killed, the child processes are killed independently only afterwards. As Stefano found, the condor docs are pretty vague [a.3].

In this PR, we could avoid writing `cmsRun-stdout.log.tmp` and only write to `cmsRun-stdout.log`, then hope that condor sends a sigterm to all the processes in the parent group id and let logCMSSW() print the cmsRun content. 

However, using traps in `gWMS-CMSRunAnalysis.sh` feels a bit more robust to changes on how condor kills our processes. I would keep this PR as it is now.

[a.1] https://www.baeldung.com/linux/signal-propagation 
[a.2] https://github.com/dmwm/CRABServer/blob/3d7cb32e23e1b3c0da6fd2f93c7f646f093509a5/scripts/CMSRunAnalysis.py#L54
[a.3] https://htcondor.readthedocs.io/en/latest/users-manual/priorities-and-preemption.html#details-about-how-htcondor-jobs-vacate-machines