### PR TITLE
Use acceleratorSitesCollector instead of glideinPool

### DIFF
--- a/src/python/TaskWorker/Actions/Recurring/GetAcceleratorSite.py
+++ b/src/python/TaskWorker/Actions/Recurring/GetAcceleratorSite.py
@@ -15,7 +15,7 @@ class GetAcceleratorSite(BaseRecurringAction):
 
     def _execute(self, config, task):  # pylint: disable=unused-argument
         # get glidein url from taskworker config
-        collector_url = config.TaskWorker.glideinPool
+        collector_url = config.TaskWorker.acceleratorSitesCollector
         collector = htcondor.Collector(collector_url)
         try:
             result = collector.query(htcondor.AdTypes.Any,


### PR DESCRIPTION
`TaskWorkerConfig.py` with new `acceleratorSitesCollector` name are committed [(51c05469)](https://gitlab.cern.ch/ai/it-puppet-hostgroup-vocmsglidein/-/compare/qa...crabdev_taskworker?from_project_id=4758&straight=false) in `crabdev_taskworker` branch in puppet repo.