### PR TITLE
RUCIO_Transfers.py: Add RegisterReplicas action

### DIFF
--- a/src/python/ASO/Rucio/Actions/RegisterReplicas.py
+++ b/src/python/ASO/Rucio/Actions/RegisterReplicas.py
@@ -1,0 +1,324 @@
+import logging
+import itertools
+import copy
+from ASO.Rucio.Actions.BuildDBSDataset import BuildDBSDataset
+from rucio.rse.rsemanager import find_matching_scheme
+from rucio.common.exception import FileAlreadyExists
+
+import ASO.Rucio.config as config
+from ASO.Rucio.exception import RucioTransferException
+from ASO.Rucio.utils import chunks, updateDB, tfcLFN2PFN, LFNToPFNFromPFN
+
+
+
+class RegisterReplicas:
+    """
+    RegisterReplicas action is responsible for registering new files in the temp
+    area to Rucio. The transferring is done by Rucio's side (by the rule we
+    created in BuildDBSDataset).
+    """
+    def __init__(self, transfer, rucioClient, crabRESTClient):
+        self.logger = logging.getLogger("RucioTransfer.Actions.RegisterReplicas")
+        self.rucioClient = rucioClient
+        self.transfer = transfer
+        self.crabRESTClient = crabRESTClient
+
+    def execute(self):
+        """
+        Main execution steps to register replicas to datasets.
+        """
+        # Generate generator for range of transferItems we want to register.
+        # This make it easier for do testing.
+        start = self.transfer.lastTransferLine
+        if config.args.force_total_files:
+            end = start + config.args.force_total_files
+        else:
+            end = len(self.transfer.transferItems)
+        transferGenerator = itertools.islice(self.transfer.transferItems, start, end)
+        # Prepare
+        preparedReplicasByRSE = self.prepare(transferGenerator)
+        # Remove registered replicas
+        replicasToRegisterByRSE, registeredReplicas = self.removeRegisteredReplicas(preparedReplicasByRSE)
+        self.logger.debug(f'replicasToRegisterByRSE: {replicasToRegisterByRSE}')
+        self.logger.debug(f'registeredReplicas: {registeredReplicas}')
+        # Register only new transferItems
+        successReplicasFromRegister, failReplicas = self.register(replicasToRegisterByRSE)
+        self.logger.debug(f'successReplicasFromRegister: {successReplicasFromRegister}')
+        self.logger.debug(f'failReplicas: {failReplicas}')
+        # Merge already registered replicas and newly registered replicas
+        successReplicas = successReplicasFromRegister + registeredReplicas
+        self.logger.debug(f'successReplicas: {successReplicas}')
+        # Create new entry in REST in FILETRANSFERDB table
+        if successReplicas:
+            successFileDoc = self.prepareSuccessFileDoc(successReplicas)
+            updateDB(self.crabRESTClient, 'filetransfers', 'updateRucioInfo', successFileDoc, self.logger)
+        if failReplicas:
+            failFileDoc = self.prepareFailFileDoc(failReplicas)
+            updateDB(self.crabRESTClient, 'filetransfers', 'updateTransfers', failFileDoc, self.logger)
+        # After everything is done, bookkeeping LastTransferLine.
+        self.transfer.updateLastTransferLine(end)
+
+    def prepare(self, transfers):
+        """
+        Convert a list of transfer items to a ready-to-use variable for
+        `register()` method. It receives Generator of `Transfer.transferItems`
+        and constructs dicts of replicas cotain information needed for
+        `rucioClient.add_replicas` function, grouped by source sites.
+
+        We still need to resolve PFN manually because Temp RSE is
+        non-deterministic. We rely on `rucioClient.lfn2pfns()` to determine the
+        PFN of Temp RSE from normal RSE (The RSE without `Temp` suffix).
+
+        :param transfers: the iterable object which produce item of transfer.
+        :type transfers: iterator
+
+        :returns: map of `<site>_Temp` and list of dicts that replicas information.
+        :rtype: dict
+        """
+        # create bucket RSE
+        bucket = {}
+        replicasByRSE = {}
+        for xdict in transfers:
+            # /store/temp are register as `<site>_Temp` in rucio
+            rse = f'{xdict["source"]}_Temp'
+            if not rse in bucket:
+                bucket[rse] = []
+            bucket[rse].append(xdict)
+        for rse in bucket:
+            xdict = bucket[rse][0]
+            # We determine PFN of Temp RSE from normal RSE.
+            # Simply remove temp suffix before passing to getSourcePFN function.
+            pfn = self.getSourcePFN(xdict["source_lfn"], rse.split('_Temp')[0], xdict["destination"])
+            replicasByRSE[rse] = []
+            for xdict in bucket[rse]:
+                replica = {
+                    'scope': self.transfer.rucioScope,
+                    'pfn': LFNToPFNFromPFN(xdict["source_lfn"], pfn),
+                    'name': xdict['destination_lfn'],
+                    'bytes': xdict['filesize'],
+                    'adler32': xdict['checksums']['adler32'].rjust(8, '0'),
+                    # TODO: move id out of replicas info
+                    'id': xdict['id'],
+                }
+                replicasByRSE[rse].append(replica)
+        return replicasByRSE
+
+    def register(self, prepareReplicas):
+        """
+        Register replicas to datasets via `rucioClient.add_replicas()` in chunks
+        (chunk size is defined in `config.args.replicas_chunk_size`) and attach
+        it to the current dataset. It also creates a new dataset when the
+        dataset exceeds `config.arg.max_file_per_datset`.
+
+        :param prepareReplicas: dict return from `prepare()` method.
+        :type prepareReplicas: dict
+
+        :returns: a success list and fail list, the list contain dict
+            of infomation to create new entries in FILETRANSFERDB table in REST.
+        :rtype: tuple of list
+        """
+        successReplicas = []
+        failReplicas = []
+        self.logger.debug(f'Prepare replicas: {prepareReplicas}')
+        b = BuildDBSDataset(self.transfer, self.rucioClient)
+        for rse, replicas in prepareReplicas.items():
+            self.logger.debug(f'Registering replicas from {rse}')
+            self.logger.debug(f'Replicas: {replicas}')
+            for chunk in chunks(replicas, config.args.replicas_chunk_size):
+                try:
+                    # TODO: remove id from dict we construct in prepare() method.
+                    # remove 'id' from dict
+                    r = []
+                    for c in chunk:
+                        d = c.copy()
+                        d.pop('id')
+                        r.append(d)
+                    # add_replicas with same dids will always return True, even
+                    # with changing metadata (e.g pfn), rucio will not update to
+                    # the new value.
+                    # See https://github.com/dmwm/CMSRucio/issues/343#issuecomment-1543663323
+                    retAddReplicas = self.rucioClient.add_replicas(rse, r)
+                    if not retAddReplicas:
+                        failItems = [{
+                            'id': x['id'],
+                            'dataset': '',
+                        } for x in chunk]
+                        failReplicas += failItems
+                        continue
+                except Exception as ex:
+                    # Note that 2 exceptions we encounter so far here is due to
+                    # LFN to PFN converstion and RSE protocols.
+                    # https://github.com/dmwm/CRABServer/issues/7632
+                    raise RucioTransferException('Something wrong with adding new replicas') from ex
+
+                dids = [{
+                    'scope': self.transfer.rucioScope,
+                    'type': "FILE",
+                    'name': x["name"]
+                } for x in chunk]
+                # no need to try catch for duplicate content. Not sure if
+                # restart process is enough for the case of connection error
+                self.rucioClient.add_files_to_datasets([{
+                        'scope': self.transfer.rucioScope,
+                        'name': self.transfer.currentDataset,
+                        'dids': dids
+                    }],
+                    ignore_duplicate=True)
+                successItems = [{
+                    'id': x['id'],
+                    'dataset': self.transfer.currentDataset
+                } for x in chunk]
+                successReplicas += successItems
+                # Current algo will add files whole chunk, so total number of
+                # files in dataset is at most is max_file_per_datset+replicas_chunk_size.
+                #
+                # check the current number of files in the dataset
+                num = len(list(self.rucioClient.list_content(self.transfer.rucioScope, self.transfer.currentDataset)))
+                if num >= config.args.max_file_per_dataset:
+                    # FIXME: close the last dataset when ALL Postjob has reach timeout.
+                    #        But, do we really need to close dataset?
+                    self.rucioClient.close(self.transfer.rucioScope, self.transfer.currentDataset)
+                    newDataset = b.generateDatasetName()
+                    b.createDataset(newDataset)
+                    self.transfer.currentDataset = newDataset
+        return successReplicas, failReplicas
+
+    def getSourcePFN(self, sourceLFN, sourceRSE, destinationRSE):
+        """
+        Get source PFN from `rucioClient.lfns2pfns()`.
+
+        :param sourceLFN: source LFN
+        :type sourceLFN: string
+        :param sourceRSE: source RSE where LFN is reside, but it must be normal
+            RSE name (e.g. `T2_CH_CERN` without suffix `_Temp`). Otherwise, it
+            will raise exception in `rucioClient.lfns2pfns()`.
+        :type sourceRSE: string
+        :param destinationRSE: need for select proper protocol for transfer
+            with `find_machine_scheme()`.
+        :type destinationRSE: string
+
+        :returns: PFN return from `lfns2pfns()`
+        :rtype: string
+        """
+        self.logger.debug(f'Getting pfn for {sourceLFN} at {sourceRSE}')
+        try:
+            _, srcScheme, _, _ = find_matching_scheme(
+                {"protocols": self.rucioClient.get_protocols(destinationRSE)},
+                {"protocols": self.rucioClient.get_protocols(sourceRSE)},
+                "third_party_copy_read",
+                "third_party_copy_write",
+            )
+            did = f'{self.transfer.rucioScope}:{sourceLFN}'
+            sourcePFNMap = self.rucioClient.lfns2pfns(sourceRSE, [did], operation="third_party_copy_read", scheme=srcScheme)
+            pfn = sourcePFNMap[did]
+            self.logger.debug(f'PFN: {pfn}')
+            return pfn
+        except Exception as ex:
+            raise RucioTransferException("Failed to get source PFN") from ex
+
+    def getSourcePFN2(self, sourceLFN, sourceRSE):
+        """
+        Just for crosschecking with FTS algo we use in `getSourcePFN()`
+        Will remove it later.
+        """
+        self.logger.debug(f'Getting pfn for {sourceLFN} at {sourceRSE}')
+        rgx = self.rucioClient.get_protocols(
+            sourceRSE, protocol_domain='ALL', operation="read")[0]
+        didStr = f'{self.transfer.rucioScope}:{sourceLFN}'
+        if not rgx['extended_attributes'] or 'tfc' not in rgx['extended_attributes']:
+            pfn = self.rucioClient.lfns2pfns(
+                sourceRSE, [didStr], operation="read")[didStr]
+        else:
+            tfc = rgx['extended_attributes']['tfc']
+            tfc_proto = rgx['extended_attributes']['tfc_proto']
+            pfn = tfcLFN2PFN(sourceLFN, tfc, tfc_proto)
+
+        if sourceRSE == 'T2_DE_DESY':
+            pfn = pfn.replace('/pnfs/desy.de/cms/tier2/temp', '/pnfs/desy.de/cms/tier2/store/temp')
+        self.logger.debug(f'PFN2: {pfn}')
+        return pfn
+
+    def removeRegisteredReplicas(self, replicasByRSE):
+        """
+        Separate registered from unregistered replicas to prevent duplication of
+        replicas in the same container. The list of registered replicas is
+        stored in `self.transfer.replicasInContainer`.
+
+        :param replicasByRSE: dict return from `prepare()` method.
+        :type replicasByRSE: dict
+
+        :returns: list of unregistered replicas and list of registered
+            replicas. The unregistered replicas will have the same structure as
+            `replicasByRSE` param, and the registered will have the same
+            information and structure returned by `register()` method.
+        :rtype: tuple of list
+        """
+        notRegister = copy.deepcopy(replicasByRSE)
+        registered = []
+        for k, v in notRegister.items():
+            newV = []
+            for i in range(len(v)):
+                if v[i]['name'] in self.transfer.replicasInContainer:
+                    registeredReplica = {
+                        'id': v[i]['id'],
+                        'dataset': self.transfer.replicasInContainer[v[i]['name']],
+                    }
+                    registered.append(registeredReplica)
+                else:
+                    newV.append(v[i])
+            notRegister[k] = newV
+        return notRegister, registered
+
+    def prepareSuccessFileDoc(self, replicas):
+        """
+        Convert replicas info to fileDoc to upload file transfer information to
+        REST.
+        This method is for successfully registered replicas.
+
+        :param replicas: list of dict contains transferItems's ID and its
+            information.
+        :type replicas: list
+
+        :return: dict which use in `filetransfers` REST API.
+        :rtype: dict
+        """
+        num = len(replicas)
+        fileDoc = {
+            'asoworker': 'rucio',
+            'list_of_ids': [x['id'] for x in replicas],
+            'list_of_transfer_state': ['SUBMITTED']*num,
+            'list_of_dbs_blockname': [x['dataset'] for x in replicas],
+            'list_of_block_complete': ['NO']*num,
+            'list_of_fts_instance': ['https://fts3-cms.cern.ch:8446/']*num,
+            'list_of_failure_reason': None, # omit
+            'list_of_retry_value': None, # omit
+            'list_of_fts_id': ['NA']*num,
+        }
+        return fileDoc
+
+    def prepareFailFileDoc(self, replicas):
+        """
+        Convert replicas info to fileDoc to upload file transfer information to
+        REST.
+        This method is for fail registered replicas.
+
+        :param replicas: list of dict contains transferItems's ID and its
+            information.
+        :type replicas: list
+
+        :return: dict which use in `filetransfers` REST API.
+        :rtype: dict
+        """
+        num = len(replicas)
+        fileDoc = {
+            'asoworker': 'rucio',
+            'list_of_ids': [x['id'] for x in replicas],
+            'list_of_transfer_state': ['FAILED']*num,
+            'list_of_dbs_blockname': None,  # omit
+            'list_of_block_complete': None, # omit
+            'list_of_fts_instance': ['https://fts3-cms.cern.ch:8446/']*num,
+            'list_of_failure_reason': ['Failed to register files within RUCIO']*num,
+            'list_of_retry_value': [0]*num, # No need for retry -> delegate to RUCIO
+            'list_of_fts_id': ['NA']*num,
+        }
+        return fileDoc

--- a/src/python/ASO/Rucio/RunTransfer.py
+++ b/src/python/ASO/Rucio/RunTransfer.py
@@ -2,11 +2,12 @@ import logging
 import os
 from rucio.client.client import Client as RucioClient
 
+from RESTInteractions import CRABRest
 from ASO.Rucio.Transfer import Transfer
 from ASO.Rucio.exception import RucioTransferException
 from ASO.Rucio.Actions.BuildDBSDataset import BuildDBSDataset
-#from ASO.Rucio.Actions.RegisterReplicas import RegisterReplicas
 #from ASO.Rucio.Actions.MonitorLocksStatus import MonitorLocksStatus
+from ASO.Rucio.Actions.RegisterReplicas import RegisterReplicas
 
 class RunTransfer:
     """
@@ -33,14 +34,23 @@ class RunTransfer:
         self.transfer = Transfer()
         self.transfer.readInfo()
         self.rucioClient = self._initRucioClient(self.transfer.username, self.transfer.restProxyFile)
-        #self.crabRESTClient = self._initCrabRESTClient
-        # do dbs dataset
-        #BuildDBSDataset(self.transfer, self.rucioClient).execute()
+        self.transfer.readInfoFromRucio(self.rucioClient)
+        self.crabRESTClient = self._initCrabRESTClient(
+            self.transfer.restHost,
+            self.transfer.restDBInstance,
+            self.transfer.restProxyFile,
+        )
+        # build dataset
+        BuildDBSDataset(self.transfer, self.rucioClient).execute()
         # do 1
-        #RegisterReplicas(self.transfer, self.rucioClient, self.crabRESTClient).execute()
+        RegisterReplicas(self.transfer, self.rucioClient, self.crabRESTClient).execute()
+        # do 2
+        #MonitorLocksStatus(self.transfer, self.rucioClient, self.crabRESTClient).execute()
+
     def _initRucioClient(self, username, proxypath=None):
         # maybe we can share with getNativeRucioClient
         rucioLogger = logging.getLogger('RucioTransfer.RucioClient')
+        rucioLogger.setLevel(logging.INFO)
         if os.environ.get('X509_USER_PROXY', None):
             creds = None
         else:
@@ -56,3 +66,22 @@ class RunTransfer:
         )
         self.logger.debug(f'RucioClient.whoami(): {rc.whoami()}')
         return rc
+
+    def _initCrabRESTClient(self, host, dbInstance, proxypath='/tmp/x509_u999999'):
+        """
+        Initialize client for CRAB REST
+        """
+        proxyPathEnv = os.environ.get('X509_USER_PROXY', None)
+        if proxyPathEnv:
+            proxypath = proxyPathEnv
+        if not os.path.isfile(proxypath):
+            raise RucioTransferException(f'proxy file not found: {proxypath}')
+
+        crabRESTClient = CRABRest(
+            host,
+            localcert=proxypath,
+            localkey=proxypath,
+            userAgent='CRABSchedd'
+        )
+        crabRESTClient.setDbInstance(dbInstance)
+        return crabRESTClient

--- a/src/python/ASO/Rucio/utils.py
+++ b/src/python/ASO/Rucio/utils.py
@@ -1,7 +1,9 @@
 import shutil
+import re
 from contextlib import contextmanager
 
 from ServerUtilities import encodeRequest
+from ASO.Rucio.exception import RucioTransferException
 
 @contextmanager
 def writePath(path):
@@ -14,9 +16,88 @@ def writePath(path):
     replace original path with temp file.
 
     :param path: path to write.
-    :yield: `_io.TextIOWrapper` object for write operation.
+    :type path:
+    :yield: return object from `open()` function for write operation.
+    :ytype: _io.TextIOWrapper
     """
     tmpPath = f'{path}_tmp'
     with open(tmpPath, 'w', encoding='utf-8') as w:
         yield w
     shutil.move(tmpPath, path)
+
+
+def chunks(l, n=1):
+    """
+    Yield successive n-sized chunks from l.
+
+    :param l: list to split
+    :type l: list
+    :param n: chunk size
+    :type n: int
+    :return: yield the next list chunk
+    :rtype: generator
+    """
+    for i in range(0, len(l), n):
+        yield l[i:i + n]
+
+
+def updateDB(client, api, subresource, fileDoc):
+    """
+    Upload fileDoc to REST
+
+    :param client: CRAB REST client.
+    :type client: RESTInteractions.CRABRest
+    :param api: API name
+    :type api: string
+    :param subresource: API subresource
+    :type subresource: string
+    :param fileDoc: fileDoc to upload to REST
+    :type fileDoc: dict
+    """
+    fileDoc['subresource'] = subresource
+    client.post(
+        api=api,
+        data=encodeRequest(fileDoc)
+    )
+
+def tfcLFN2PFN(lfn, tfc, proto, depth=0):
+    """
+    Just for crosschecking with FTS algo we use in `getSourcePFN()`
+    Will remove it later.
+    """
+    # Hardcode
+    MAX_CHAIN_DEPTH = 5
+    if depth > MAX_CHAIN_DEPTH:
+        raise RucioTransferException(f"Max depth reached matching lfn {lfn} and protocol {proto} with tfc {tfc}")
+    for rule in tfc:
+        if rule['proto'] == proto:
+            if 'chain' in rule:
+                import pdb; pdb.set_trace()
+                lfn = tfcLFN2PFN(lfn, tfc, rule['chain'], depth + 1)
+            regex = re.compile(rule['path'])
+            if regex.match(lfn):
+                return regex.sub(rule['out'].replace('$', '\\'), lfn)
+    if depth > 0:
+        return lfn
+    raise ValueError(f"lfn {lfn} with proto {proto} cannot be matched by tfc {tfc}")
+
+
+def LFNToPFNFromPFN(lfn, pfn):
+    """
+    Simple function to convert from LFP to PFN by extract prefix from example
+    PFN.
+
+    :param lfn: LFN
+    :type lfn: string
+    :param pfn: PFN example to extract it prefix
+    :type pfn: string
+
+    :return: PFN of LFN param
+    :rtype: string
+    """
+    pfnPrefix = '/'.join(pfn.split("/")[:-2])
+    if lfn.split("/")[-2] == 'log' :
+        fileid = '/'.join(lfn.split("/")[-3:])
+    else:
+        fileid = '/'.join(lfn.split("/")[-2:])
+    return f'{pfnPrefix}/{fileid}'

--- a/test/python/ASO/Rucio/Actions/test_BuildDBSDataset.py
+++ b/test/python/ASO/Rucio/Actions/test_BuildDBSDataset.py
@@ -6,7 +6,10 @@ from unittest.mock import patch, Mock
 from ASO.Rucio.exception import RucioTransferException
 from rucio.common.exception import DataIdentifierAlreadyExists, InvalidObject, DuplicateRule, DuplicateContent
 
-from ASO.Rucio.Actions.BuildTaskDataset import BuildTaskDataset
+from ASO.Rucio.Actions.BuildDBSDataset import BuildTaskDataset
+
+# FIXME: class name is changed from BuildTaskDataset to BuildDBSDataset.
+# Need to fix on all test in this files
 
 @pytest.fixture
 def mock_Transfer():
@@ -44,6 +47,7 @@ def test_checkOrCreateContainer_container_exist(mock_rucioClient, mock_Transfer)
 #    should we do it in integration test or in unittest?
 
 def test_createDataset(mock_Transfer, mock_rucioClient):
+    mock_Transfer.addNewRules = Mock()
     b = BuildTaskDataset(mock_Transfer, mock_rucioClient)
     b.createDataset(mock_Transfer.datasetName)
     mock_rucioClient.add_dataset.assert_called_once()
@@ -56,6 +60,7 @@ def test_createDataset(mock_Transfer, mock_rucioClient):
     ('attach_dids', DuplicateContent),
 ])
 def test_createDataset_raise_exception(mock_Transfer, mock_rucioClient, methodName, exception):
+    mock_Transfer.addNewRules = Mock()
     getattr(mock_rucioClient, methodName).side_effect = exception
     b = BuildTaskDataset(mock_Transfer, mock_rucioClient)
     b.createDataset(mock_Transfer.datasetName)
@@ -63,7 +68,6 @@ def test_createDataset_raise_exception(mock_Transfer, mock_rucioClient, methodNa
     mock_rucioClient.add_dataset.assert_called_once()
     mock_rucioClient.add_replication_rule.assert_called_once()
     mock_rucioClient.attach_dids.assert_called_once()
-
 
 # test getOrCreateDataset()
 # algo

--- a/test/python/ASO/Rucio/Actions/test_RegisterReplicas.py
+++ b/test/python/ASO/Rucio/Actions/test_RegisterReplicas.py
@@ -1,0 +1,256 @@
+import pytest
+import json
+from unittest.mock import patch, Mock
+from argparse import Namespace
+
+from ASO.Rucio.Actions.RegisterReplicas import RegisterReplicas
+import ASO.Rucio.config as config
+
+# somehow register return [[item1,item2]] while it should return [item1, item2], but unittest fail to detect this
+
+# prepare_replicas
+# input is just transfers.txt start from last lines
+# {"id": "7e6d075f7434f1307a764d491d86ab1192554b76106d139846810834", "username": "tseethon", "taskname": "230227_174038:tseethon_crab_rucio_transfer_test12_20230227_184034", "start_time": 1677520683, "destination": "T2_CH_CERN", "destination_lfn": "/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1677519634/230227_174038/0000/output_2.root", "source": "T3_US_FNALLPC", "source_lfn": "/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-workflow/GenericTTbar/autotest-1677519634/230227_174038/0000/output_2.root", "filesize": 630710, "publish": 0, "transfer_state": "NEW", "publication_state": "NOT_REQUIRED", "job_id": "2", "job_retry_count": 1, "type": "output", "publishname": "autotest-1677519634-00000000000000000000000000000000", "checksums": {"adler32": "5cbf440e", "cksum": "3473488862"}, "outputdataset": "/GenericTTbar/tseethon-autotest-1677519634-94ba0e06145abd65ccb1d21786dc7e1d/USER"}
+# expect output is MAP OF RSE key replicas in RSE
+# {rse1: [replica1,replicas2], rse2: [replica3, replica4]}
+# where
+# replica = {'scope': glob.rucio_scope, 'pfn': pfn_map[rse][source_lfn],
+#            'name': destination_lfn, 'bytes': size, 'adler32': checksum}
+# and
+# pfn_map is map of ALL lfn of input in format of
+# pfn_map = {rse1: {source_lfn1: pfn}}
+# well let change to make it more simpler
+
+@pytest.fixture
+def mock_rucioClient():
+    with patch('rucio.client.client.Client', autospec=True) as m_rucioClient:
+        return m_rucioClient
+
+@pytest.fixture
+def mock_Transfer():
+    username = 'cmscrab'
+    rucioScope = f'user.{username}'
+    publishname = '/TestPrimary/test-dataset/RAW'
+    currentDatasetUUID = 'c9b28b96-5d16-41cd-89af-2678971132c9'
+    currentDataset = f'{publishname}#{currentDatasetUUID}'
+    logsDataset = f'{publishname}#LOG'
+    return Mock(publishname=publishname, currentDataset=currentDataset, rucioScope=rucioScope, logsDataset=logsDataset, currentDatasetUUID=currentDatasetUUID, username=username)
+
+@pytest.fixture
+def loadTransferList():
+    with open('test/assets/transfers.txt', encoding='utf-8') as r:
+        return [json.loads(line) for line in r]
+
+@pytest.fixture
+def loadPrepareExpectedOutput():
+    with open('test/assets/prepare_expectedoutput.json', encoding='utf-8') as r:
+        return json.load(r)
+
+def generateExpectedOutput(doctype):
+    if doctype == 'success':
+        return {
+            'asoworker': 'rucio',
+            'list_of_ids': ['98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca'], # hmm, how do we get this
+            'list_of_transfer_state': ['SUBMITTED'],
+            'list_of_dbs_blockname': ['/TestPrimary/test-dataset/RAW#c9b28b96-5d16-41cd-89af-2678971132c9'],
+            'list_of_block_complete': ['NO'],
+            'list_of_fts_instance': ['https://fts3-cms.cern.ch:8446/'],
+            'list_of_failure_reason': None, # omit
+            'list_of_retry_value': None, # omit
+            'list_of_fts_id': ['NA'], # maybe we should put ruleid of container here
+        }
+    elif doctype == 'fail':
+        return {
+            'asoworker': 'rucio',
+            'list_of_ids': ['98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca'], # hmm, how do we get this
+            'list_of_transfer_state': ['FAILED'],
+            'list_of_dbs_blockname': None,  # omit
+            'list_of_block_complete': None, # omit
+            'list_of_fts_instance': ['https://fts3-cms.cern.ch:8446/'],
+            'list_of_failure_reason': ['Failed to register files within RUCIO'],
+            # No need for retry -> delegate to RUCIO
+            'list_of_retry_value': [0],
+            'list_of_fts_id': ['NA'],
+        }
+
+
+def test_getSourcePFN(mock_Transfer, mock_rucioClient):
+    srcRSE = 'T3_US_FNALLPC'
+    dstRSE = 'T2_CH_CERN'
+    srcLFN = '/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_17.root'
+    srcPFN = 'root://eoscms.cern.ch//eos/cms/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_17.root'
+    srcDid = f'{mock_Transfer.rucioScope}:{srcLFN}'
+    returnLfns2pfns = {srcDid: srcPFN}
+    mock_rucioClient.lfns2pfns.return_value = returnLfns2pfns
+    with patch('ASO.Rucio.Actions.RegisterReplicas.find_matching_scheme', autospec=True) as mock_find_matching_scheme:
+        mock_find_matching_scheme.return_value = ('', 'davs', '', '')
+        # TODO: ensure RSE pass as argument should not have suffix with '_Temp'
+        r = RegisterReplicas(mock_Transfer, mock_rucioClient, Mock())
+        assert r.getSourcePFN(srcLFN, srcRSE, dstRSE) == srcPFN
+        mock_find_matching_scheme.assert_called_once()
+    mock_rucioClient.get_protocols.assert_called()
+    mock_rucioClient.lfns2pfns.assert_called_once()
+
+def test_prepare_single_xdict(mock_Transfer, mock_rucioClient):
+    # input
+    prepareInput = [{
+        "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+        "username": "cmscrab",
+        "taskname": "230324_151740:tseethon_crab_rucio_transfer_whitelist_cern_test12_20230324_161736",
+        "start_time": 1679671544,
+        "destination": "T2_CH_CERN",
+        "destination_lfn": "/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root",
+        "source": "T2_CH_CERN",
+        "source_lfn": "/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root",
+        "filesize": 628054,
+        "publish": 0,
+        "transfer_state": "NEW",
+        "publication_state": "NOT_REQUIRED",
+        "job_id": "9",
+        "job_retry_count": 0,
+        "type": "output",
+        "publishname": "autotest-1679671056-00000000000000000000000000000000",
+        "checksums": {
+            "adler32": "812b8235",
+            "cksum": "1236675270"
+        },
+        "outputdataset": "/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER"
+    }]
+
+    # expectedOuput should be
+    getSourcePFNReturnValue = 'davs://eoscms.cern.ch:443/eos/cms/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root'
+    expectedOutput = {
+        "T2_CH_CERN_Temp": [
+            {
+                "scope": "user.cmscrab",
+                "pfn": getSourcePFNReturnValue,
+                "name": "/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root",
+                "bytes": 628054,
+                "adler32": "812b8235",
+                "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca"
+            }
+        ]
+    }
+    with patch('ASO.Rucio.Actions.RegisterReplicas.RegisterReplicas.getSourcePFN', autospec=True) as mock_getSourcePFN:
+        config.args = Namespace(force_replica_name_suffix=None)
+        mock_getSourcePFN.return_value = getSourcePFNReturnValue
+        mock_Transfer.replicasInContainer = []
+        r = RegisterReplicas(mock_Transfer, mock_rucioClient, Mock())
+        assert r.prepare(prepareInput) == expectedOutput
+
+@pytest.mark.skip(reason="skip it for now due to deadline.")
+def test_prepare_last_line_is_not_zero(mock_Transfer, mock_rucioClient):
+    assert 0 == 1
+
+
+@pytest.mark.skip(reason="Need to implement (or not?) but skip it for now.")
+def test_prepare_skip_direct_stageout(mock_Transfer, mock_rucioClient, loadTransferList):
+    assert 0 == 1
+
+#def test_prepare_duplicate_replicas(mock_Transfer, mock_rucioClient, loadTransferList, loadPrepareExpectedOutput):
+#    prepareInput = loadTransferList[:3]
+#    mock_Transfer.rucioScope = f"user.{loadTransferList[0]['username']}"
+#    mock_Transfer.replicasInContainer = [prepareInput[0]['destination_lfn']] # skip first
+#    expectedOutput = loadPrepareExpectedOutput
+#    expectedOutput['T2_CH_CERN_Temp'] = loadPrepareExpectedOutput['T2_CH_CERN_Temp'][1:] # expect 2 items
+#    getSourcePFNReturnValue = [x['pfn'] for x in expectedOutput['T2_CH_CERN_Temp']]
+#    config.args = Namespace(force_replica_name_suffix=None)
+#    with patch('ASO.Rucio.Actions.RegisterReplicas.RegisterReplicas.getSourcePFN', autospec=True) as mock_getSourcePFN:
+#        mock_getSourcePFN.side_effect = getSourcePFNReturnValue
+#        r = RegisterReplicas(mock_Transfer, mock_rucioClient, Mock())
+#        assert r.prepare(prepareInput) == expectedOutput
+
+def test_removeRegisteredReplicas(mock_Transfer, mock_rucioClient, loadPrepareExpectedOutput):
+    fInput = {
+        'T2_CH_CERN_Temp': loadPrepareExpectedOutput['T2_CH_CERN_Temp'][:3]
+    }
+    mock_Transfer.replicasInContainer = {
+        '/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root': '/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER#ec579451-65f1-484f-a345-8c29916c3715'
+    }
+    expectedReplicasToRegister = {
+        'T2_CH_CERN_Temp': loadPrepareExpectedOutput['T2_CH_CERN_Temp'][1:3]
+    }
+    expectedRegisteredReplicas = [{
+        "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+        "dataset": '/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER#ec579451-65f1-484f-a345-8c29916c3715',
+        "blockcomplete": 'NO',
+    }]
+    expectedOutput = (expectedReplicasToRegister, expectedRegisteredReplicas)
+    config.args = Namespace(force_replica_name_suffix=None)
+    r = RegisterReplicas(mock_Transfer, Mock(), Mock())
+    assert r.removeRegisteredReplicas(fInput) == expectedOutput
+
+def test_register_success(mock_Transfer, mock_rucioClient):
+    prepareReplicasByRSE = {
+        "T2_CH_CERN_Temp": [
+            {
+                "scope": "user.cmscrab",
+                "pfn": 'davs://eoscms.cern.ch:443/eos/cms/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root',
+                "name": "/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root",
+                "bytes": 628054,
+                "adler32": "812b8235",
+                "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+            }
+        ]
+    }
+    expectedSuccess = [
+        {
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+            "dataset": mock_Transfer.currentDataset,
+        }
+    ]
+    expectedFail = []
+    config.config = Namespace(replicas_chunk_size=2, dataset_file_limit=9)
+    r = RegisterReplicas(mock_Transfer, mock_rucioClient, Mock())
+    s, f = r.register(prepareReplicasByRSE)
+    # FIXME: should we add replica one at a time instead of bulk?
+    # to prevent one file cause fail whole bulk and prevent postjob to retry
+    # TODO: ensure add_replicas only have all key exception id (id is crab id we store in rest)
+    mock_rucioClient.add_replicas.assert_called()
+    mock_rucioClient.add_files_to_datasets.assert_called()
+
+@pytest.mark.skip(reason="Skip it for now due deadline.")
+def test_register_fail(mock_Transfer, mock_rucioClient):
+    assert 0 == 1
+
+@pytest.mark.skip(reason="Skip it for now due deadline.")
+def test_register_mix_fail_and_success(mock_Transfer, mock_rucioClient):
+    assert 0 == 1
+
+@pytest.mark.skip(reason="Skip it for now due deadline.")
+def test_register_rerun_from_last_crash(mock_Transfer, mock_rucioClient):
+    assert 0 == 1
+
+@pytest.mark.skip(reason="Skip it for now due deadline.")
+def test_register_create_new_dataset(mock_Transfer, mock_rucioClient):
+    assert 0 == 1
+
+
+@pytest.mark.skip(reason="Skip it for now due deadline.")
+def test_register_ensure_bookkeeping_to_last_transfers(mock_Transfer, mock_rucioClient):
+    assert 0 == 1
+
+
+def test_prepareSuccessFileDoc(mock_Transfer):
+    successFileDoc = generateExpectedOutput('success')
+    outputSuccess = [
+        {
+            "id": successFileDoc['list_of_ids'][0],
+            "dataset": successFileDoc['list_of_dbs_blockname'][0],
+            "blockcomplete": 'NO',
+        }
+    ]
+    r = RegisterReplicas(mock_Transfer, Mock(), Mock())
+    assert successFileDoc == r.prepareSuccessFileDoc(outputSuccess)
+
+def test_prepareFailFileDoc(mock_Transfer):
+    failFileDoc = generateExpectedOutput('fail')
+    outputFail = [
+        {
+            "id": failFileDoc['list_of_ids'][0],
+            "dataset": '',
+            "blockcomplete": 'NO',
+        }
+    ]
+    r = RegisterReplicas(mock_Transfer, Mock(), Mock())
+    assert failFileDoc == r.prepareFailFileDoc(outputFail)

--- a/test/python/ASO/Rucio/Actions/test_UpdateStatusToREST.py
+++ b/test/python/ASO/Rucio/Actions/test_UpdateStatusToREST.py
@@ -1,0 +1,121 @@
+# old code
+# caller
+# ====================================
+# to_update_success_docs = make_filedoc_for_db(
+#     ids=[glob.id2lfn_map[x['lfn']] for x in success_from_registration],
+#     states=["SUBMITTED" for x in success_from_registration],
+#     dbsBlocknames=[x['dbsBlock'] for x in success_from_registration],
+#     blockCompletes=[x['complete'] for x in success_from_registration],
+#     reasons=None
+# )
+# ===================
+# new code value return from RegisterReplicas
+# =====================
+#    expectedSuccess = [
+#        {
+#            "name": "/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root",
+#            "dataset": mock_Transfer.currentDataset,
+#        }
+#    ]
+# ===================
+#  and this is value make_filedoc_for_db needs
+# ==================
+#    fileDoc['asoworker'] = 'rucio'
+#    fileDoc['subresource'] = 'updateTransfers'
+#    fileDoc['list_of_ids'] = ids
+#    fileDoc['list_of_transfer_state'] = states
+#    fileDoc['list_of_dbs_blockname'] = dbsBlocknames
+#    fileDoc['list_of_block_complete'] = blockCompletes
+#    fileDoc['list_of_fts_instance'] = [
+#        'https://fts3-cms.cern.ch:8446/' for _ in ids]
+#    if reasons:
+#        if len(reasons) != len(ids):
+#            raise
+#        fileDoc['list_of_failure_reason'] = reasons
+#        # No need for retry -> delegate to RUCIO
+#        fileDoc['list_of_retry_value'] = [0 for _ in ids]
+#    if rule_ids:
+#        fileDoc['list_of_fts_id'] = [x for x in rule_ids]
+#    else:
+#        fileDoc['list_of_fts_id'] = ['NA' for _ in ids]
+
+import pytest
+import json
+from unittest.mock import patch, Mock, call
+
+from ASO.Rucio.Actions.UpdateStatusToREST import UpdateStatusToREST
+
+@pytest.fixture
+def mock_Transfer():
+    username = 'cmscrab'
+    rucioScope = f'user.{username}'
+    publishname = '/TestPrimary/test-dataset/RAW'
+    currentDatasetUUID = 'c9b28b96-5d16-41cd-89af-2678971132c9'
+    currentDataset = f'{publishname}#{currentDatasetUUID}'
+    logsDataset = f'{publishname}#LOG'
+    return Mock(publishname=publishname, currentDataset=currentDataset, rucioScope=rucioScope, logsDataset=logsDataset, currentDatasetUUID=currentDatasetUUID, username=username)
+
+@pytest.fixture
+def mock_crabserver():
+    with patch('RESTInteractions.CRABRest', autospec=True) as client:
+        return client
+
+def generateExpectedOutput(doctype):
+    if doctype == 'success':
+        return {
+            'asoworker': 'rucio',
+            'list_of_ids': ['98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca'], # hmm, how do we get this
+            'list_of_transfer_state': ['SUBMITTED'],
+            'list_of_dbs_blockname': ['/TestPrimary/test-dataset/RAW#c9b28b96-5d16-41cd-89af-2678971132c9'],
+            'list_of_block_complete': ['NO'],
+            'list_of_fts_instance': ['https://fts3-cms.cern.ch:8446/'],
+            'list_of_failure_reason': None, # omit
+            'list_of_retry_value': None, # omit
+            'list_of_fts_id': ['NA'],
+        }
+    elif doctype == 'fail':
+        return {
+            'asoworker': 'rucio',
+            'list_of_ids': ['98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca'], # hmm, how do we get this
+            'list_of_transfer_state': ['FAILED'],
+            'list_of_dbs_blockname': None,  # omit
+            'list_of_block_complete': None, # omit
+            'list_of_fts_instance': ['https://fts3-cms.cern.ch:8446/'],
+            'list_of_failure_reason': ['Failed to register files within RUCIO'],
+            # No need for retry -> delegate to RUCIO
+            'list_of_retry_value': [0],
+            'list_of_fts_id': ['NA'],
+        }
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_updateRegisteredTransfers_success_replica(mock_crabserver):
+    registerReplicasOutput = [
+        {
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+            "dataset": '/TestPrimary/test-dataset/RAW#c9b28b96-5d16-41cd-89af-2678971132c9',
+        }
+    ]
+    expectedSuccessCalled = generateExpectedOutput('success')
+    expectedFailCalled = generateExpectedOutput('fail')
+    with patch('ASO.Rucio.Actions.UpdateStatusToREST.UpdateStatusToREST.updateDB') as mock_updateDB:
+        u = UpdateStatusToREST(mock_crabserver)
+        u.updateRegisteredTransfers(registerReplicasOutput, [])
+        calls = [
+            call('updateTransfers', expectedSuccessCalled),
+        ]
+        mock_updateDB.assert_has_calls(calls)
+
+@pytest.mark.skip(reason="skip it for now due to deadline")
+def test_makefileDoc_fail_register_replica(mock_crabserver, mock_Transfer):
+    pass
+
+# maybe do integration test instead?
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_updateDB_of_register_replica(mock_crabserver, mock_Transfer):
+    with patch('ASO.Rucio.Actions.UpdateStatusToREST.encodeRequest', autospec=True) as mock_encodeRequest:
+        u = UpdateStatusToREST(mock_crabserver)
+        expectedOutput = generateExpectedOutput('success')
+        subresource = 'updateTransfers'
+        u.updateDB(subresource, expectedOutput)
+        mock_crabserver.post.assert_called_once()
+        mock_encodeRequest.assert_called_once()

--- a/test/python/ASO/Rucio/test_Transfer.py
+++ b/test/python/ASO/Rucio/test_Transfer.py
@@ -9,55 +9,252 @@ from argparse import Namespace
 from ASO.Rucio.Transfer import Transfer
 from ASO.Rucio.exception import RucioTransferException
 import ASO.Rucio.config as config
+from .fixtures import mock_rucioClient
 
 
-def test_Transfer_readInfo():
+@pytest.fixture
+def transfersTxtContent():
+    path = 'test/assets/transfers.txt'
+    with open(path, 'r', encoding='utf-8') as r:
+        return r.read()
 
-    restInfoForFileTransfersJson = {
-        "host": "cmsweb-test12.cern.ch:8443",
-        "dbInstance": "devthree",
-        "proxyfile": "9041f6500ff40aaca33737316a2dbfb57116e8e0"
+@pytest.fixture
+def restInfoForFileTransfersJsonContent():
+    path = 'test/assets/RestInfoForFileTransfers.json'
+    with open(path, 'r', encoding='utf-8') as r:
+        return r.read()
+
+@pytest.fixture
+def bookkeepingRulesJSONContent():
+    path = 'test/assets/bookkeeping_rules.json'
+    with open(path, 'r', encoding='utf-8') as r:
+        return json.load(r)
+
+
+@pytest.fixture
+def listContentDatasets():
+    path = 'test/assets/rucio_list_content_datasets.json'
+    with open(path, 'r', encoding='utf-8') as r:
+        return json.load(r)
+
+@pytest.fixture
+def listContentFiles():
+    path = 'test/assets/rucio_list_content_datasets.json'
+    with open(path, 'r', encoding='utf-8') as r:
+        return json.load(r)
+
+#old relic
+#def test_Transfer_readInfo():
+#    restInfoForFileTransfersJson = {
+#        "host": "cmsweb-test12.cern.ch:8443",
+#        "dbInstance": "devthree",
+#        "proxyfile": "9041f6500ff40aaca33737316a2dbfb57116e8e0"
+#    }
+#    transfersTxt = {
+#        "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+#        "username": "tseethon",
+#        "taskname": "230324_151740:tseethon_crab_rucio_transfer_whitelist_cern_test12_20230324_161736",
+#        "start_time": 1679671544,
+#        "destination": "T2_CH_CERN",
+#        "destination_lfn": "/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root",
+#        "source": "T2_CH_CERN",
+#        "source_lfn": "/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root",
+#        "filesize": 628054,
+#        "publish": 0,
+#        "transfer_state": "NEW",
+#        "publication_state": "NOT_REQUIRED",
+#        "job_id": "9",
+#        "job_retry_count": 0,
+#        "type": "output",
+#        "publishname": "autotest-1679671056-00000000000000000000000000000000",
+#        "checksums": {"adler32": "812b8235", "cksum": "1236675270"},
+#        "outputdataset": "/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER"
+#    }
+#    config.config = Namespace(force_publishname=None, rest_info_path='/a/b/c', transfer_info_path='/d/e/f')
+#    with patch('builtins.open', new_callable=mock_open, read_data=f'{json.dumps(restInfoForFileTransfersJson)}\n') as mo:
+#        # setup config
+#        mo.side_effect = (mo.return_value, mock_open(read_data=f'{json.dumps(transfersTxt)}\n').return_value,)
+#        # run config
+#        t = Transfer()
+#        t.readInfo()
+#        assert t.proxypath == '9041f6500ff40aaca33737316a2dbfb57116e8e0'
+#        assert t.username == 'tseethon'
+#        assert t.rucioScope == 'user.tseethon'
+#        assert t.destination == 'T2_CH_CERN'
+#        assert t.publishname == '/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER'
+#        assert t.logsDataset == '/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER#LOGS'
+#        assert t.currentDataset == ''
+
+#def test_Transfer_readInfo_filenotfound():
+#    # setup config
+#
+#    # run transfer
+#    config.config = Namespace(rest_info_path='/a/b/c', transfer_info_path='/d/e/f')
+#    t = Transfer()
+#    with pytest.raises(RucioTransferException):
+#        t.readInfo()
+
+def test_readInfoFromTransferItems():
+    transferDict = {
+        'source_lfn': '/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_7.root',
+        'destination_lfn': '/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_7.root',
+        'id': '5b5c6d9f2e99ae32191e2c702ca9bba32951d69027289a7cde884468',
+        'source': 'T2_CH_CERN_Temp',
+        'destination': 'T2_CH_CERN',
+        'checksum': 'cde8011f',
+        'filesize': 628826,
+        'publishname': '/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER',
+        'username': 'tseethon',
     }
-    transfersTxt = {
-        "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
-        "username": "tseethon",
-        "taskname": "230324_151740:tseethon_crab_rucio_transfer_whitelist_cern_test12_20230324_161736",
-        "start_time": 1679671544,
-        "destination": "T2_CH_CERN",
-        "destination_lfn": "/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root",
-        "source": "T2_CH_CERN",
-        "source_lfn": "/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root",
-        "filesize": 628054,
-        "publish": 0,
-        "transfer_state": "NEW",
-        "publication_state": "NOT_REQUIRED",
-        "job_id": "9",
-        "job_retry_count": 0,
-        "type": "output",
-        "publishname": "autotest-1679671056-00000000000000000000000000000000",
-        "checksums": {"adler32": "812b8235", "cksum": "1236675270"},
-        "outputdataset": "/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER"
-    }
-    config.config = Namespace(force_publishname=None, rest_info_path='/a/b/c', transfer_info_path='/d/e/f')
-    with patch('builtins.open', new_callable=mock_open, read_data=f'{json.dumps(restInfoForFileTransfersJson)}\n') as mo:
-        # setup config
-        mo.side_effect = (mo.return_value, mock_open(read_data=f'{json.dumps(transfersTxt)}\n').return_value,)
-        # run config
-        t = Transfer()
-        t.readInfo()
-        assert t.proxypath == '9041f6500ff40aaca33737316a2dbfb57116e8e0'
-        assert t.username == 'tseethon'
-        assert t.rucioScope == 'user.tseethon'
-        assert t.destination == 'T2_CH_CERN'
-        assert t.publishname == '/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER'
-        assert t.logsDataset == '/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER#LOGS'
-        assert t.currentDataset == ''
-
-def test_Transfer_readInfo_filenotfound():
-    # setup config
-
-    # run transfer
-    config.config = Namespace(rest_info_path='/a/b/c', transfer_info_path='/d/e/f')
     t = Transfer()
+    t.transferItems = [transferDict]
+    t.readInfoFromTransferItems()
+    assert t.username == 'tseethon'
+    assert t.rucioScope == 'user.tseethon'
+    assert t.destination == 'T2_CH_CERN'
+    assert t.publishname == '/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER'
+    assert t.logsDataset == '/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER#LOGS'
+    assert t.currentDataset == ''
+
+
+def test_readRESTInfo(restInfoForFileTransfersJsonContent):
+    t = Transfer()
+    t.lastTransferLine = 0
+    config.args = Namespace(rest_info_path='/path/to/RestInfoForFileTransfers.json')
+    with patch('ASO.Rucio.Transfer.open', new_callable=mock_open, read_data=restInfoForFileTransfersJsonContent) as mo:
+        t.readRESTInfo()
+        assert mo.call_args.args[0] == '/path/to/RestInfoForFileTransfers.json'
+        assert t.restHost == "cmsweb-test12.cern.ch:8443"
+        assert t.restDBinstance == 'devthree'
+        assert t.restProxyFile == '9041f6500ff40aaca33737316a2dbfb57116e8e0'
+
+def test_readRESTInfo_FileNotFoundError():
+    t = Transfer()
+    t.lastTransferLine = 0
+    config.args = Namespace(rest_info_path='/path/should/not/found')
     with pytest.raises(RucioTransferException):
-        t.readInfo()
+        t.readRESTInfo()
+
+
+def test_readTransferItems(transfersTxtContent):
+    t = Transfer()
+    t.lastTransferLine = 0
+    path = '/path/to/transfers.txt'
+    config.args = Namespace(transfers_txt_path=path)
+    with patch('ASO.Rucio.Transfer.open', new_callable=mock_open, read_data=transfersTxtContent) as mo:
+        t.readTransferItems()
+        assert mo.call_args.args[0] == path
+        assert t.transferItems[5]['id'] == '5b5c6d9f2e99ae32191e2c702ca9bba32951d69027289a7cde884468'
+        assert t.transferItems[5]['source'] == 'T2_CH_CERN'
+        assert t.transferItems[5]['checksums']['adler32'] == 'cde8011f'
+
+def test_readTransferItems_FileNotFoundError():
+    t = Transfer()
+    t.lastTransferLine = 0
+    path = '/path/to/transfers.txt'
+    config.args = Namespace(transfers_txt_path=path)
+    with pytest.raises(RucioTransferException):
+        t.readTransferItems()
+
+def test_readTransferItems_no_new_item(transfersTxtContent):
+    # maybe another exception class to seperate between filenotfound and no new entry
+    t = Transfer()
+    t.lastTransferLine = 20
+    path = '/path/to/transfers.txt'
+    config.args = Namespace(transfers_txt_path=path)
+    with patch('ASO.Rucio.Transfer.open', new_callable=mock_open, read_data=transfersTxtContent) as mo:
+        with pytest.raises(RucioTransferException):
+            t.readTransferItems()
+
+def test_readLastTransferLine():
+    config.args = Namespace(last_line_path='/path/to/last_transfer.txt')
+    with patch('ASO.Rucio.Transfer.open', new_callable=mock_open, read_data='5\n') as mo:
+        t = Transfer()
+        t.readLastTransferLine()
+        assert t.lastTransferLine == 5
+        assert mo.call_args.args[0] == '/path/to/last_transfer.txt'
+
+def test_readLastTransferLine_file_not_found():
+    config.args = Namespace(last_line_path='/path/should/not/found')
+    t = Transfer()
+    t.readLastTransferLine()
+    assert t.lastTransferLine == 0
+
+# do we need to test this thing?
+# ======================
+# if not os.path.exists('task_process/transfers'):
+#     os.makedirs('task_process/transfers')
+
+
+
+def test_readBookkeepingRules(bookkeepingRulesJSONContent):
+    config.args = Namespace(bookkeeping_rules_path='/path/to/bookkeeping_rules.json')
+    with patch('ASO.Rucio.Transfer.open', new_callable=mock_open, read_data=json.dumps(bookkeepingRulesJSONContent)) as mo:
+        t = Transfer()
+        t.readBookkeepingRules()
+        assert t.allRules == bookkeepingRulesJSONContent['all']
+        assert t.okRules == bookkeepingRulesJSONContent['ok']
+
+
+def test_readBookkeepingRules_FileNotFoundError():
+    config.args = Namespace(bookkeeping_rules_path='/path/to/bookkeeping_rules.json')
+    with patch('ASO.Rucio.Transfer.open', new_callable=mock_open) as mo:
+        mo.side_effect = FileNotFoundError
+        t = Transfer()
+        t.readBookkeepingRules()
+        assert t.allRules == []
+        assert t.okRules == []
+
+
+def test_updateOKRules(bookkeepingRulesJSONContent):
+    config.args = Namespace(bookkeeping_rules_path='/path/to/bookkeeping_rules.json')
+    with patch('ASO.Rucio.Transfer.open', new_callable=mock_open) as mo:
+        with patch('ASO.Rucio.Transfer.somecontextlibfunc') as mock_somecontextlibfunc:
+            t = Transfer()
+            t.allRules = list(bookkeepingRulesJSONContent['all'])
+            t.okRules = list(bookkeepingRulesJSONContent['ok'])
+            writePath = '/path/to/tmp'
+            mock_somecontextlibfunc.return_value.__enter__.return_value = writePath
+            newOK = ['e609d75e4a7a4fa3a880ea0bb6681371']
+            t.updateOKRules(newOK)
+            mo.assert_called_once_with(writePath, 'w', encoding='utf-8')
+            assert t.okRules == bookkeepingRulesJSONContent['ok'] + newOK
+            # TODO: need to check content but I do not know how to do it
+
+@pytest.mark.skip(reason='Skip for now due to deadline')
+def test_updateOKRules_ok_rules_not_in_all(bookkeepingRulesJSONContent):
+    assert 0 == 1
+
+
+def test_addNewRule(bookkeepingRulesJSONContent):
+    config.args = Namespace(bookkeeping_rules_path='/path/to/bookkeeping_rules.json')
+    with patch('ASO.Rucio.Transfer.open', new_callable=mock_open) as mo:
+        with patch('ASO.Rucio.Transfer.somecontextlibfunc') as mock_somecontextlibfunc:
+            t = Transfer()
+            t.allRules = list(bookkeepingRulesJSONContent['all'])
+            t.okRules = list(bookkeepingRulesJSONContent['ok'])
+            writePath = '/path/to/tmp'
+            mock_somecontextlibfunc.return_value.__enter__.return_value = writePath
+            newAll = ['e609d75e4a7a4fa3a880ea0bb6681999']
+            t.addNewRule(newAll)
+            mo.assert_called_once_with(writePath, 'w', encoding='utf-8')
+            assert t.allRules == bookkeepingRulesJSONContent['all'] + newAll
+            assert t.okRules == bookkeepingRulesJSONContent['ok']
+            # TODO: need to check content but I do not know how to do it
+
+def test_getContainerInfo(mock_rucioClient, listContentDatasets, listContentFiles):
+    t = Transfer()
+    t.publishname = '/GenericTTbar/tseethon-integrationtest-1/USER'
+    t.rucioScope = 'user.tseethon'
+    mock_rucioClient.list_content.side_effect = (
+        (x for x in listContentDatasets),
+        (x for x in listContentFiles[:3]),
+        (x for x in listContentFiles[3:]),
+    )
+    t.getContainerInfo(mock_rucioClient)
+    expectedReplicas = [x['name'] for x in listContentFiles]
+    assert t.replicasInContainer == expectedReplicas
+
+@pytest.mark.skip(reason='I am really lazy')
+def test_buildReplica2IDMap():
+    assert 0 == 1


### PR DESCRIPTION
The second PR of new RUCIO_Transfers.py scripts for `RegisterReplicas` action.
Note that I merged https://github.com/dmwm/CRABServer/pull/7636 and this PR is opened on top of that.

@belforte do you prefer to review it by yourself or do it together ?