### PR TITLE
refactor requestTapeRecall and accept dataset name. Fix #7603

### DIFF
--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -67,7 +67,7 @@ MAX_MEMORY = 2*1024
 # see https://github.com/dmwm/CRABServer/issues/5995
 MAX_MEMORY_PER_CORE = 2500
 MAX_MEMORY_SINGLE_CORE = 5000
-MAX_DISK_SPACE = 20000000 # Disk usage is not used from .job.ad as CRAB3 is not seeting it. 20GB is max.
+MAX_DISK_SPACE = 20000000  # Disk usage is not used from .job.ad as CRAB3 is not seeting it. 20GB is max.
 
 MAX_IDLE_JOBS = 1000
 MAX_POST_JOBS = 20
@@ -81,9 +81,11 @@ TASKLIFETIME = 30*24*60*60  # 30 days in seconds
 NUM_DAYS_FOR_RESUBMITDRAIN = 7
 ## Maximum number of days a task can stay in TAPERECALL status
 MAX_DAYS_FOR_TAPERECALL = 15
+## Threshold (in TB) to split a dataset among multiple sites when recalling from tape
+MAX_TB_TO_RECALL_AT_A_SINGLE_SITE = 10000  # effectively no limit. See https://github.com/dmwm/CRABServer/issues/7610
 
 ## These are all possible statuses of a task in the TaskDB.
-TASKDBSTATUSES_TMP = ['NEW', 'HOLDING', 'QUEUED']
+TASKDBSTATUSES_TMP = ['NEW', 'HOLDING', 'QUEUED', 'TAPERECALL', 'KILLRECALL']
 TASKDBSTATUSES_FAILURES = ['SUBMITFAILED', 'KILLFAILED', 'RESUBMITFAILED', 'FAILED']
 TASKDBSTATUSES_FINAL = ['UPLOADED', 'SUBMITTED', 'KILLED'] + TASKDBSTATUSES_FAILURES
 TASKDBSTATUSES = TASKDBSTATUSES_TMP + TASKDBSTATUSES_FINAL

--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -448,7 +448,7 @@ class DBSDataDiscovery(DataDiscovery):
             myScope = 'cms'
             dbsDatasetName = dataToRecall
             containerDid = {'scope': myScope, 'name': dbsDatasetName}
-        elif isinstance(dataToRecall, list) or isinstance(dataToRecall, dict_keys):
+        elif isinstance(dataToRecall, list):
             # need to prepare ad hoc container. Can not reuse a possibly existing one:
             # if a user wants one block from a large dataset, we must
             # not recall also all blocks possibly requested in the past
@@ -586,7 +586,7 @@ class DBSDataDiscovery(DataDiscovery):
                 activity='Analysis Input',
                 comment=comment,
                 ask_approval=ASK_APPROVAL, asynchronous=True)
-        except DuplicateRule as ex:
+        except DuplicateRule:
             # handle "A duplicate rule for this account, did, rse_expression, copies already exists"
             # which should only happen when testing, since container name is unique like task name, but
             # we cover also retry situations where TW was stopped/killed/crashed halfway in the process
@@ -597,7 +597,6 @@ class DBSDataDiscovery(DataDiscovery):
             ruleIds = [next(ruleIdGen)['id']]
             # extend rule lifetime
             rucio.update_replication_rule(ruleIds[0], {'lifetime': LIFETIME})
-
         except (InsufficientTargetRSEs, InsufficientAccountLimit, FullStorage) as ex:
             msg = "\nNot enough global quota to issue a tape recall request. Rucio exception:\n%s" % str(ex)
             raise TaskWorkerException(msg) from ex

--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -281,9 +281,9 @@ class DBSDataDiscovery(DataDiscovery):
 
         # make a copy of locationsMap dictionary, so that manipulating it in keeOnlyDiskRSE
         # does not touch blocksWithLocation
-        blocksWithLocation = list(locationsMap.copy().keys())
+        blocksWithLocation = locationsMap.copy().keys()
         if secondaryDataset:
-            secondaryBlocksWithLocation = list(secondaryLocationsMap.copy().keys())
+            secondaryBlocksWithLocation = secondaryLocationsMap.copy().keys()
 
         # take note of where tapes are
         tapeLocations = set()

--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -455,7 +455,7 @@ class DBSDataDiscovery(DataDiscovery):
             # not recall also all blocks possibly requested in the past
             #  by other users for other reasons.
             #  Therefore we stick with naming the container after the task name
-            myScope = 'user.crab_tape_recall'  # do not mess up with cms scope
+            myScope = 'user.crab_tape_recall'  # do not mess with cms scope
             containerName = '/TapeRecall/%s/USER' % self.taskName.replace(':', '.')
             containerDid = {'scope': myScope, 'name': containerName}
             self.makeContainerFromBlockList(


### PR DESCRIPTION
in the end the relevant change for #7603 is all in this line
https://github.com/dmwm/CRABServer/blob/a3e00c4bde7ba5bb27ed959d8b6802ba461acc7f/src/python/TaskWorker/Actions/DBSDataDiscovery.py#L314

everything else is a refactoring of requestTapeRecall to be more modular and readable and to accept a string (dataset name) as an alternative to a list of blocks.

#TODO
I tried and so far failed to move requestTapeRecall  to a separate file. Too many dependencies from things in the `self` of DBSDataDiscovery and so far no clear use case outside here. 
