### PR TITLE
run TapeRecallManager every 2h

### DIFF
--- a/src/python/TaskWorker/Actions/Recurring/TapeRecallManager.py
+++ b/src/python/TaskWorker/Actions/Recurring/TapeRecallManager.py
@@ -27,7 +27,7 @@ class TapeRecallManager(BaseRecurringAction):
     which implements the _execute method (with the unused argument "task"...pff)
     name of this class, this file and the recurring action in TW config list
     must be the same """
-    pollingTime = 60*4  # unit=minutes. Runs every 4 hours
+    pollingTime = 60*2  # unit=minutes. Runs every 2 hours
     rucioClient = None
     privilegedRucioClient = None
     crabserver = None


### PR DESCRIPTION
 this runs pretty quickly and most of the times recalls also happen quickly, so I'd like to see the plot/list of tasks in TAPERECALL status updated timely
