### PR TITLE
RUCIO_Transfers.py: add MonitorLockStatus action

### DIFF
--- a/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
+++ b/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
@@ -1,0 +1,184 @@
+import logging
+import copy
+
+import ASO.Rucio.config as config
+from ASO.Rucio.utils import uploadToTransfersdb
+from ASO.Rucio.Actions.RegisterReplicas import RegisterReplicas
+
+class MonitorLockStatus:
+    """
+    This class checks the status of the replicas by giving Rucio's rule ID and
+    registering transfer completed replicas (status 'OK') to publish container,
+    then updating the transfer status back to REST to notify PostJob.
+    """
+    def __init__(self, transfer, rucioClient, crabRESTClient):
+        self.logger = logging.getLogger("RucioTransfer.Actions.MonitorLockStatus")
+        self.rucioClient = rucioClient
+        self.transfer = transfer
+        self.crabRESTClient = crabRESTClient
+
+    def execute(self):
+        """
+        Main execution step.
+        """
+        # Check replicas's lock status
+        okReplicas, notOKReplicas = self.checkLockStatus()
+        self.logger.debug(f'okReplicas: {okReplicas}')
+        self.logger.debug(f'notOKReplicas: {notOKReplicas}')
+
+        # Register transfer complete replicas to publish container.
+        publishedReplicas = self.registerToPublishContainer(okReplicas)
+        self.logger.debug(f'publishReplicas: {publishedReplicas}')
+        # update ok status
+        self.updateOKReplicasToREST(publishedReplicas)
+
+        # update block complete status
+        replicasToUpdateBlockComplete = self.checkBlockCompleteStatus(publishedReplicas)
+        self.logger.debug(f'Replicas to update block completion: {replicasToUpdateBlockComplete}')
+        self.updateBlockCompleteToREST(replicasToUpdateBlockComplete)
+
+        # Bookkeeping published replicas (only replicas with blockcomplete "ok")
+        self.transfer.updateTransferOKReplicas([x['name'] for x in replicasToUpdateBlockComplete])
+
+    def checkLockStatus(self):
+        """
+        Check all lock status of replicas in the rule from
+        `Transfer.containerRuleID`.
+
+        :return: list of `okReplicas` where transfers are completed, and
+            `notOkReplicas` where transfer transfers are still in REPLICATING
+             or STUCK state. Each item in list is dict of replica info.
+        :rtype: tuple of list of dict
+        """
+        okReplicas = []
+        notOKReplicas = []
+        try:
+            listReplicasLocks = self.rucioClient.list_replica_locks(self.transfer.containerRuleID)
+        except TypeError:
+            # Current rucio-clients==1.29.10 will raise exception when it get
+            # None response from server. It will happen when we run
+            # list_replica_locks immediately after register replicas with
+            # replicas lock info is not available yet.
+            self.logger.info('Error has raised. Assume there is still no lock info available yet.')
+            listReplicasLocks = []
+        replicasInContainer = self.transfer.replicasInContainer[self.transfer.transferContainer]
+        for replicaStatus in listReplicasLocks:
+            # Skip replicas that register in the same run.
+            if not replicaStatus['name'] in replicasInContainer:
+                continue
+            # skip if replicas transfer is in transferOKReplicas. No need to
+            # update status for transfer complete.
+            if replicaStatus['name'] in self.transfer.transferOKReplicas:
+                continue
+
+            replica = {
+                'id': self.transfer.replicaLFN2IDMap[replicaStatus['name']],
+                'name': replicaStatus['name'],
+                'dataset': None,
+                'blockcomplete': 'NO',
+                'ruleid': self.transfer.containerRuleID,
+            }
+            if replicaStatus['state'] == 'OK':
+                okReplicas.append(replica)
+            else:
+                notOKReplicas.append(replica)
+        return (okReplicas, notOKReplicas)
+
+    def registerToPublishContainer(self, replicas):
+        """
+        Register replicas to the published container. Update the replicas info
+        to the new dataset name.
+
+        :param replicas: replicas info return from `checkLockStatus` method.
+        :type replicas: list of dict
+
+        :return: replicas info with updated dataset name.
+        :rtype: list of dict
+        """
+        r = RegisterReplicas(self.transfer, self.rucioClient, None)
+        replicasPublishedInfo = r.addReplicasToContainer(replicas, self.transfer.publishContainer)
+        # Update dataset name for each replicas
+        tmpLFN2DatasetMap = {x['name']:x['dataset'] for x in replicasPublishedInfo}
+        tmpReplicas = copy.deepcopy(replicas)
+        for i in tmpReplicas:
+            i['dataset'] = tmpLFN2DatasetMap[i['name']]
+        return tmpReplicas
+
+    def checkBlockCompleteStatus(self, replicas):
+        """
+        check (DBS) block completion status from `is_open` dataset metadata.
+        Only return list of replica info where `is_open` of the dataset is
+        `False`.
+
+        :param replicas: replica info return from `registerToPublishContainer`
+            method.
+        :type replicas: list of dict
+
+        :return: list of replicas info with updated `blockcomplete` to `OK`.
+        :rtype: list of dict
+        """
+        tmpReplicas = []
+        datasetsMap = {}
+        for i in replicas:
+            dataset = i['dataset']
+            if not dataset in datasetsMap:
+                datasetsMap[dataset] = [i]
+            else:
+                datasetsMap[dataset].append(i)
+        for k, v in datasetsMap.items():
+            metadata = self.rucioClient.get_metadata(self.transfer.rucioScope, k)
+            # TODO: Also close dataset when (in or)
+            # - the task has completed.
+            # - no new replica/is_open for more than 6 hours
+            if not metadata['is_open']:
+                for r in v:
+                    item = copy.copy(r)
+                    item['blockcomplete'] = 'OK'
+                    tmpReplicas.append(item)
+
+        return tmpReplicas
+
+    def updateOKReplicasToREST(self, replicas):
+        """
+        Update OK status transfers info to REST server.
+
+        :param replicas: transferItems's ID and its information.
+        :type replicas: list of dict
+        """
+        # TODO: may need to refactor later along with rest and publisher part
+        num = len(replicas)
+        fileDoc = {
+            'asoworker': 'rucio',
+            'list_of_ids': [x['id'] for x in replicas],
+            'list_of_transfer_state': ['DONE']*num,
+            'list_of_dbs_blockname': [x['dataset'] for x in replicas],
+            'list_of_block_complete': [x['blockcomplete'] for x in replicas],
+            'list_of_fts_instance': ['https://fts3-cms.cern.ch:8446/']*num,
+            'list_of_failure_reason': None, # omit
+            'list_of_retry_value': None, # omit
+            'list_of_fts_id': ['NA']*num,
+        }
+        uploadToTransfersdb(self.crabRESTClient, 'filetransfers', 'updateTransfers', fileDoc, self.logger)
+
+    def updateBlockCompleteToREST(self, replicas):
+        """
+        Update block complete status of replicas to REST server.
+
+        :param replicas: transferItems's ID and its information.
+        :type replicas: list of dict
+        """
+        # TODO: may need to refactor later along with rest and publisher part
+        # This can be optimize to single REST API call together with updateTransfers's subresources
+        num = len(replicas)
+        fileDoc = {
+            'asoworker': 'rucio',
+            'list_of_ids': [x['id'] for x in replicas],
+            'list_of_transfer_state': ['DONE']*num,
+            'list_of_dbs_blockname': [x['dataset'] for x in replicas],
+            'list_of_block_complete': [x['blockcomplete'] for x in replicas],
+            'list_of_fts_instance': ['https://fts3-cms.cern.ch:8446/']*num,
+            'list_of_failure_reason': None, # omit
+            'list_of_retry_value': None, # omit
+            'list_of_fts_id': ['NA']*num,
+        }
+        uploadToTransfersdb(self.crabRESTClient, 'filetransfers', 'updateRucioInfo', fileDoc, self.logger)

--- a/src/python/ASO/Rucio/Actions/RegisterReplicas.py
+++ b/src/python/ASO/Rucio/Actions/RegisterReplicas.py
@@ -10,7 +10,6 @@ from ASO.Rucio.exception import RucioTransferException
 from ASO.Rucio.utils import chunks, uploadToTransfersdb, tfcLFN2PFN, LFNToPFNFromPFN
 
 
-
 class RegisterReplicas:
     """
     RegisterReplicas action is responsible for registering new files in the temp
@@ -185,7 +184,7 @@ class RegisterReplicas:
             # check the current number of files in the dataset
             num = len(list(self.rucioClient.list_content(self.transfer.rucioScope, currentDataset)))
             if num >= config.args.max_file_per_dataset:
-                # FIXME: close the last dataset when ALL Postjob has reach timeout.
+                self.logger.info(f'closing dataset: {currentDataset}')
                 self.rucioClient.close(self.transfer.rucioScope, currentDataset)
                 currentDataset = b.getOrCreateDataset(container)
         return containerReplicas
@@ -228,10 +227,10 @@ class RegisterReplicas:
             sourcePFNMap = self.rucioClient.lfns2pfns(sourceRSE, [did], operation="third_party_copy_read", scheme=srcScheme)
             pfn = sourcePFNMap[did]
             # hardcode fix for DESY temp,
-            if sourceRSE == 'T2_DE_DESY_Temp':
+            if sourceRSE == 'T2_DE_DESY':
                 pfn = pfn.replace('/pnfs/desy.de/cms/tier2/temp', '/pnfs/desy.de/cms/tier2/store/temp')
             # hardcode fix for T2_UK_SGrid_Bristol
-            if sourceRSE == 'T2_UK_SGrid_Bristol_Temp':
+            if sourceRSE == 'T2_UK_SGrid_Bristol':
                 proto = self.rucioClient.get_protocols('T2_UK_SGrid_Bristol_Temp')[0]
                 if proto['scheme'] != 'root':
                     raise RucioTransferException('Expected protocol scheme "root" from T2_UK_SGrid_Bristol_Temp (Temporary hardcoded).')
@@ -276,11 +275,12 @@ class RegisterReplicas:
             'asoworker': 'rucio',
             'list_of_ids': [x['id'] for x in replicas],
             'list_of_transfer_state': ['SUBMITTED']*num,
-            'list_of_dbs_blockname': [x['dataset'] for x in replicas],
+            'list_of_dbs_blockname': None, # omit, will update it in MonitorLockStatus action
             'list_of_block_complete': ['NO']*num,
             'list_of_fts_instance': ['https://fts3-cms.cern.ch:8446/']*num,
             'list_of_failure_reason': None, # omit
             'list_of_retry_value': None, # omit
+            'list_of_fts_id': [self.transfer.containerRuleID]*num,
             'list_of_fts_id': ['NA']*num,
         }
         uploadToTransfersdb(self.crabRESTClient, 'filetransfers', 'updateTransfers', fileDoc, self.logger)

--- a/src/python/ASO/Rucio/RunTransfer.py
+++ b/src/python/ASO/Rucio/RunTransfer.py
@@ -7,7 +7,7 @@ from ASO.Rucio.Transfer import Transfer
 from ASO.Rucio.exception import RucioTransferException
 from ASO.Rucio.Actions.BuildDBSDataset import BuildDBSDataset
 from ASO.Rucio.Actions.RegisterReplicas import RegisterReplicas
-#from ASO.Rucio.Actions.MonitorLocksStatus import MonitorLocksStatus
+from ASO.Rucio.Actions.MonitorLockStatus import MonitorLockStatus
 
 class RunTransfer:
     """
@@ -47,7 +47,7 @@ class RunTransfer:
         # do 1
         RegisterReplicas(self.transfer, self.rucioClient, self.crabRESTClient).execute()
         # do 2
-        #MonitorLocksStatus(self.transfer, self.rucioClient, self.crabRESTClient).execute()
+        MonitorLockStatus(self.transfer, self.rucioClient, self.crabRESTClient).execute()
 
     def _initRucioClient(self, username, proxypath=None):
         # maybe we can share with getNativeRucioClient

--- a/src/python/ASO/Rucio/Transfer.py
+++ b/src/python/ASO/Rucio/Transfer.py
@@ -36,6 +36,13 @@ class Transfer:
         # bookkeeping
         self.lastTransferLine = 0
         self.containerRuleID = ''
+        self.transferOKReplicas = None
+
+        # info from rucio
+        self.replicasInContainer = None
+
+        # map lfn to id
+        self.replicaLFN2IDMap = None
 
         # info from rucio
         self.replicasInContainer = None
@@ -59,6 +66,16 @@ class Transfer:
         self.readRESTInfo()
         self.readInfoFromTransferItems()
         self.readContainerRuleID()
+        self.readTransferOKReplicas()
+
+    def readInfoFromRucio(self, rucioClient):
+        """
+        Read the information from Rucio.
+
+        :param rucioClient: Rucio client
+        :type rucioClient: rucio.client.client.Client
+        """
+        self.initReplicasInContainer(rucioClient)
 
     def readInfoFromRucio(self, rucioClient):
         """
@@ -179,6 +196,39 @@ class Transfer:
         self.logger.info(f'Bookkeeping container rule ID [{ruleID}] to file: {path}')
         with writePath(path) as w:
             w.write(ruleID)
+
+    def readTransferOKReplicas(self):
+        """
+        Read transferOKReplicas from task_process/transfers/transfers_ok.txt
+        """
+        if config.args.ignore_transfer_ok:
+            self.transferOKReplicas = []
+            return
+        path = config.args.transfer_ok_path
+        try:
+            with open(path, 'r', encoding='utf-8') as r:
+                self.transferOKReplicas = r.read().splitlines()
+                self.logger.info(f'Got list of transfer status "OK" from bookkeeping: {self.transferOKReplicas}')
+        except FileNotFoundError:
+            self.transferOKReplicas = []
+            self.logger.info(f'Bookkeeping transfer status OK from path "{path}" does not exist. Assume this is first time it run.')
+
+    def updateTransferOKReplicas(self, newReplicas):
+        """
+        update transferOKReplicas to task_process/transfers/transfers_ok.txt
+
+        :param newReplicas: list of LFN
+        :type newReplicas: list of string
+        """
+        self.transferOKReplicas += newReplicas
+        if config.args.ignore_transfer_ok:
+            return
+        path = config.args.transfer_ok_path
+        self.logger.info(f'Bookkeeping transfer status OK: {self.transferOKReplicas}')
+        self.logger.info(f'to file: {path}')
+        with writePath(path) as w:
+            for l in self.transferOKReplicas:
+                w.write(f'{l}\n')
 
     def initReplicasInContainer(self, rucioClient):
         """

--- a/src/python/ASO/Rucio/utils.py
+++ b/src/python/ASO/Rucio/utils.py
@@ -48,7 +48,6 @@ def chunks(l, n=1):
                 break
 
 
-
 def uploadToTransfersdb(client, api, subresource, fileDoc, logger=None):
     """
     Upload fileDoc to REST

--- a/test/python/ASO/Rucio/Actions/test_MonitorLockStatus.py
+++ b/test/python/ASO/Rucio/Actions/test_MonitorLockStatus.py
@@ -1,0 +1,261 @@
+# monitor_locks_status get list of dataset from list_content() api from publishname
+# FOR EACH dataset, get rules name
+# ================================
+#
+# for source of truth (input), get it from bookkeeping file. not passing down
+# in memory from register replicas because register replicas already skip some
+# entry.
+# maybe do it at top
+# input is something like {ruleID1: datasetName1, ruleID2: datasetName2}
+# outputs are
+# 1. replicas state is ok: same as ReegisterReplicas.register(), but plus blockCompletes for rule state is ok
+# 2. replicas state is replication: need rule id and id (no need for dataset)
+import json
+import pytest
+import datetime
+from argparse import Namespace
+from unittest.mock import patch, Mock, call
+
+import ASO.Rucio.config as config
+from ASO.Rucio.Actions.MonitorLocksStatus import MonitorLocksStatus
+from ASO.Rucio.Actions.RegisterReplicas import RegisterReplicas
+
+@pytest.fixture
+def mock_Transfer():
+    username = 'cmscrab'
+    rucioScope = f'user.{username}'
+    publishname = '/TestPrimary/test-dataset/RAW'
+    currentDatasetUUID = 'c9b28b96-5d16-41cd-89af-2678971132c9'
+    currentDataset = f'{publishname}#{currentDatasetUUID}'
+    logsDataset = f'{publishname}#LOG'
+    return Mock(publishname=publishname, currentDataset=currentDataset, rucioScope=rucioScope, logsDataset=logsDataset, currentDatasetUUID=currentDatasetUUID, username=username)
+
+@pytest.fixture
+def mock_rucioClient():
+    with patch('rucio.client.client.Client', autospec=True) as m_rucioClient:
+        return m_rucioClient
+
+@pytest.fixture
+def loadDatasetMetadata():
+    with open('test/assets/dataset_metadata.json') as r:
+        return json.load(r)
+
+def test_checkLockStatus_all_ok(mock_Transfer, mock_rucioClient):
+    listRuleIDs = ['b43a554244c54dba954aa29cb2fdde0a']
+    outputAllOK = [
+        {
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+            "dataset": '/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER#c9b28b96-5d16-41cd-89af-2678971132c9',
+            "blockcomplete": 'OK',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
+        }
+    ]
+    listReplicaLocksReturnValue = [{
+        'name': '/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root',
+        'state': 'OK',
+    }]
+
+    mock_rucioClient.list_replica_locks.side_effect = ((x for x in listReplicaLocksReturnValue), ) # list_replica_locks return generator
+    mock_Transfer.replicaLFN2IDMap = {
+        '/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root' : '98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca'
+    }
+    mock_Transfer.replicasInContainer = {
+        '/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root' : '/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER#c9b28b96-5d16-41cd-89af-2678971132c9'
+    }
+    mock_Transfer.containerRuleID = 'b43a554244c54dba954aa29cb2fdde0a'
+    config.args = Namespace(max_file_per_dataset=1)
+    m = MonitorLocksStatus(mock_Transfer, mock_rucioClient, Mock())
+    assert m.checkLocksStatus() == (outputAllOK, [])
+
+def test_checkLockStatus_all_replicating(mock_Transfer, mock_rucioClient):
+    listRuleIDs = ['b43a554244c54dba954aa29cb2fdde0a']
+    outputNotOK = [
+        {
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+            "dataset": '/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER#c9b28b96-5d16-41cd-89af-2678971132c9',
+            "blockcomplete": 'NO',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
+        }
+    ]
+    getReplicationRuleReturnValue = {
+        'id': 'b43a554244c54dba954aa29cb2fdde0a',
+        'name': '/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER#c9b28b96-5d16-41cd-89af-2678971132c9',
+        'state': 'REPLICATING',
+    }
+    listReplicaLocksReturnValue = [{
+        'name': '/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root',
+        'state': 'REPLICATING',
+    }]
+    mock_rucioClient.get_replication_rule.return_value = getReplicationRuleReturnValue
+    mock_rucioClient.list_replica_locks.side_effect = ((x for x in listReplicaLocksReturnValue), ) # list_replica_locks return generator
+    mock_Transfer.getIDFromLFN.return_value = '98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca'
+    m = MonitorLocksStatus(mock_Transfer, mock_rucioClient, Mock())
+    assert m.checkLocksStatus(listRuleIDs) == ([], outputNotOK, [])
+
+@pytest.mark.skip(reason="Skip it for now due deadline.")
+def test_checkLockStatus_mix():
+    assert True == False
+
+# bookkeeping rule
+# - bookkeeping per dataset
+# - save rule id if rule ok to another file
+@patch.object(MonitorLocksStatus, 'checkLocksStatus')
+def test_execute_bookkeeping_none(mock_checkLockStatus, mock_Transfer):
+    allRules = ['b43a554244c54dba954aa29cb2fdde0a']
+    okRules = []
+    mock_Transfer.allRules = allRules
+    mock_Transfer.okRules = okRules
+    m = MonitorLocksStatus(mock_Transfer, mock_rucioClient, Mock())
+    mock_checkLockStatus.return_value = ([], [], okRules)
+    m.execute()
+    mock_checkLockStatus.assert_called_once_with(allRules)
+    mock_Transfer.updateOKRules.assert_called_once()
+
+@patch.object(MonitorLocksStatus, 'checkLocksStatus')
+def test_execute_bookkeeping_all(mock_checkLockStatus, mock_Transfer):
+    allRules = ['b43a554244c54dba954aa29cb2fdde0a']
+    okRules = ['b43a554244c54dba954aa29cb2fdde0a']
+    mock_Transfer.allRules = allRules
+    mock_Transfer.okRules = okRules
+    m = MonitorLocksStatus(mock_Transfer, mock_rucioClient, Mock())
+    mock_checkLockStatus.return_value = ([], [], [])
+    m.execute()
+    mock_checkLockStatus.assert_called_once_with([])
+    mock_Transfer.updateOKRules.assert_called_once()
+
+
+def generateExpectedOutput(doctype):
+    if doctype == 'complete':
+        return {
+            'asoworker': 'rucio',
+            'list_of_ids': ['98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca'], # hmm, how do we get this
+            'list_of_transfer_state': ['DONE'],
+            'list_of_dbs_blockname': ['/TestDataset/cmscrab-unittest-1/USER#c9b28b96-5d16-41cd-89af-2678971132ca'],
+            'list_of_block_complete': ['OK'],
+            'list_of_fts_instance': ['https://fts3-cms.cern.ch:8446/'],
+            'list_of_failure_reason': None, # omit
+            'list_of_retry_value': None, # omit
+            'list_of_fts_id': ['NA'],
+        }
+    elif doctype == 'notcomplete':
+        return {
+            'asoworker': 'rucio',
+            'list_of_ids': ['98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20cb'], # hmm, how do we get this
+            'list_of_transfer_state': ['SUBMITTED'],
+            'list_of_dbs_blockname': None,
+            'list_of_block_complete': None,
+            'list_of_fts_instance': ['https://fts3-cms.cern.ch:8446/'],
+            'list_of_failure_reason': None, # omit
+            'list_of_retry_value': None, # omit
+            'list_of_fts_id': ['b43a554244c54dba954aa29cb2fdde0b'],
+        }
+
+def test_prepareOKFileDoc(mock_Transfer):
+    okFileDoc = generateExpectedOutput('complete')
+    outputOK = [
+        {
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+            "dataset": '/TestDataset/cmscrab-unittest-1/USER#c9b28b96-5d16-41cd-89af-2678971132ca',
+            "blockcomplete": 'OK',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
+        }
+    ]
+    m = MonitorLocksStatus(mock_Transfer, Mock(), Mock())
+    assert okFileDoc == m.prepareOKFileDoc(outputOK)
+
+
+def test_prepareNotOKFileDoc(mock_Transfer):
+    notOKFileDoc = generateExpectedOutput('notcomplete')
+    outputNotOK = [
+        {
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20cb",
+            "dataset": '/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER#c9b28b96-5d16-41cd-89af-2678971132c9',
+            "blockcomplete": 'NO',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0b",
+        }
+    ]
+    m = MonitorLocksStatus(mock_Transfer, Mock(), Mock())
+    assert notOKFileDoc == m.prepareNotOKFileDoc(outputNotOK)
+
+def test_addReplicasToPublishContainer():
+    outputOK = [
+        {
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+            "dataset": '/TestDataset/cmscrab-unittest-1/USER#c9b28b96-5d16-41cd-89af-2678971132ca',
+            "blockcomplete": 'NO',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
+        }
+    ]
+    m = MonitorLocksStatus(mock_Transfer, mock_rucioClient, Mock())
+    m.addReplicasToPublishContainer(outputOK)
+
+
+@patch.object(RegisterReplicas, 'addReplicasToDataset')
+def test_updateBlockCompleteStatus(mock_addReplicasToDataset, mock_Transfer, mock_rucioClient, loadDatasetMetadata):
+    outputOK = [
+        {
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+            "dataset": None,
+            "blockcomplete": 'NO',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
+        },
+        {
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20cb",
+            "dataset": None,
+            "blockcomplete": 'NO',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
+        },
+        {
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20cc",
+            "dataset": None,
+            "blockcomplete": 'NO',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
+        },
+    ]
+    retAddReplicasToDataset = [
+        {
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+            "dataset": '/TestPrimary/test-dataset_TRANSFER-bc8b2558/USER#c3800048-d946-45f7-9e83-1f420b4fc32e',
+            "blockcomplete": 'NO',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
+        },
+        {
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20cb",
+            "dataset": '/TestPrimary/test-dataset_TRANSFER-bc8b2558/USER#c3800048-d946-45f7-9e83-1f420b4fc32e',
+            "blockcomplete": 'NO',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
+        },
+        {
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20cc",
+            "dataset": '/TestPrimary/test-dataset_TRANSFER-bc8b2558/USER#b74d9bde-9a36-4e40-af17-3d614f19d380',
+            "blockcomplete": 'NO',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
+        },
+    ]
+    expectedOutput = [
+        {
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+            "dataset": '/TestPrimary/test-dataset_TRANSFER-bc8b2558/USER#c3800048-d946-45f7-9e83-1f420b4fc32e',
+            "blockcomplete": 'OK',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
+        },
+        {
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20cb",
+            "dataset": '/TestPrimary/test-dataset_TRANSFER-bc8b2558/USER#c3800048-d946-45f7-9e83-1f420b4fc32e',
+            "blockcomplete": 'OK',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
+        },
+        {
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20cc",
+            "dataset": '/TestPrimary/test-dataset_TRANSFER-bc8b2558/USER#b74d9bde-9a36-4e40-af17-3d614f19d380',
+            "blockcomplete": 'NO',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
+        },
+    ]
+    mock_addReplicasToDataset.return_value = retAddReplicasToDataset
+    datasetMetadata = loadDatasetMetadata[:2]
+    datasetMetadata[0]['is_open'] = False
+    datasetMetadata[1]['is_open'] = True
+    mock_rucioClient.get_metadata.side_effect = datasetMetadata
+    m = MonitorLocksStatus(mock_Transfer, mock_rucioClient, Mock())
+    assert m.updateBlockCompleteStatus(outputOK) == expectedOutput


### PR DESCRIPTION
Third actions of RUICO_Transfers.py scripts. Basically:
- If replicas is OK, add it to publish container, update status in transferdb to transfer done.
- Check if block is complete, update block information in rest for all files in the block
- bookkeepping replicas where block is completed, in local file(s)

2 things that need to improve (but I have no idea how):
- `checkBlockCompleteStatus` function name can be mislead. 
  - Not just check and return block complete list. It actually filter out the replicas in incomplete block.
- Closing dataset when 6 hours pass. 
  - If we close it, next iteration will create new dataset, then close in next 6 hours. We will have empty dataset.