### PR TITLE
avoid belforte's private clone and cernbox

### DIFF
--- a/scripts/Utils/list-tape-recalls.sh
+++ b/scripts/Utils/list-tape-recalls.sh
@@ -8,23 +8,30 @@ if ! [ $rc == "0" ] ; then
     cat /afs/cern.ch/user/b/belforte/.globus/.stefano | /usr/bin/voms-proxy-init -quiet -pwstdin -rfc -voms cms -valid 192:00 -out ${proxy}
 fi
 export X509_USER_PROXY=$proxy
-#source /cvmfs/cms.cern.ch/rucio/setup-py3.sh > /dev/null
+
 export PYTHONPATH=$PYTHONPATH:/cvmfs/cms.cern.ch/rucio/x86_64/slc7/py3/current/lib/python3.6/site-packages/
-export PYTHONPATH=/afs/cern.ch/user/b/belforte/WORK/CRAB3/CRABServer/src/python:$PYTHONPATH
-export PYTHONPATH=/afs/cern.ch/user/b/belforte/WORK/CRAB3/WMCore/src/python:$PYTHONPATH
 export RUCIO_HOME=/cvmfs/cms.cern.ch/rucio/current/
 export RUCIO_ACCOUNT=`whoami`
 
 mkdir -p /tmp/belforte
 cd /tmp/belforte
-rm -f CheckTapeRecall.py
-wget -q https://github.com/dmwm/CRABServer/raw/master/scripts/Utils/CheckTapeRecall.py 
-python3 CheckTapeRecall.py > check.log 2>&1
+rm -rf CRABServer
+rm -rf WMCore
+git clone https://github.com/dmwm/CRABServer/
+git clone https://github.com/dmwm/WMCore
+wmcver=`cat CRABServer/requirements.txt|grep wmcver|cut -d= -f3`
+cd WMCore; git checkout $wmcver; cd -
+
+export PYTHONPATH=`pwd`/CRABServer/src/python:$PYTHONPATH
+export PYTHONPATH=`pwd`/WMCore/src/python:$PYTHONPATH
+
+python3 `pwd`/CRABServer/scripts/Utils/CheckTapeRecall.py > check.log 2>&1
 rc=$?
+
 if ! [ $rc == "0" ] ; then
     echo "TapeRecalls check failed: here's log"
     cat check.log
 else
-    cp RecallRules.html /eos/home-b/belforte/www/RecallRules.html
+    cp RecallRules.html /eos/project/c/cmsweb/www/CRAB/RecallRules.html
 fi
 

--- a/scripts/Utils/list-tape-recalls.sh
+++ b/scripts/Utils/list-tape-recalls.sh
@@ -17,10 +17,12 @@ mkdir -p /tmp/belforte
 cd /tmp/belforte
 rm -rf CRABServer
 rm -rf WMCore
-git clone https://github.com/dmwm/CRABServer/
-git clone https://github.com/dmwm/WMCore
+
+git clone -q https://github.com/dmwm/CRABServer/ > /dev/null
+git clone -q https://github.com/dmwm/WMCore > /dev/null
+
 wmcver=`cat CRABServer/requirements.txt|grep wmcver|cut -d= -f3`
-cd WMCore; git checkout $wmcver; cd -
+cd WMCore; git checkout -q $wmcver; cd - > /dev/null
 
 export PYTHONPATH=`pwd`/CRABServer/src/python:$PYTHONPATH
 export PYTHONPATH=`pwd`/WMCore/src/python:$PYTHONPATH


### PR DESCRIPTION
FYI @mapellidario 
I am now running this in my acrontab. I call it progress.

It fails on `crab-*-tw*` because `/usr/lib64/python3.6/site-packages` there does not have pycurl. 

I fixed the this on `crab-dev-tw01` with  (as root)
```
yum install  python3-deve
yum install libcurl-devel
yum install gcc
pip3 install pycurl
```

but then got in trouble with
```
File "/tmp/belforte/WMCore/src/python/WMCore/Services/pycurl_manager.py", line 338, in request
    curl.perform()
pycurl.error: (35, 'Peer does not recognize and trust the CA that issued your certificate.')
```
which I have seen many times, but have never found a solid recipe to fix, and none of my tricks worked so far. [*]

Current TW container misses `pandas` and a simple `pip install` failed. pff...


[*] in the end it works with my CERN certificate, fails with my INFN/Terena one. The latter works on lxplus, and aslo works with `curl https://cmsweb` from `crab-dev-tw01`.This points to something stale in `/etc/grid-security/certificates` .. oh well. I guess we do not want to solve all world's problems.

Up to you now if you want to setup a crontab with this on crab-...-tw... or rather make it work in the container first.

Grid authentication is always a pain.
Anyhow I also ran ` sudo update-ca-trust` on `crab-dev-tw01`  but can't easily test because currently we have no rules pending.





