### PR TITLE
RUCIO_Transfers.py: Improving readability

### DIFF
--- a/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
+++ b/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
@@ -22,111 +22,104 @@ class MonitorLockStatus:
         Main execution step.
         """
         # Check replicas's lock status
-        okReplicas, notOKReplicas = self.checkLockStatus()
-        self.logger.debug(f'okReplicas: {okReplicas}')
-        self.logger.debug(f'notOKReplicas: {notOKReplicas}')
+        okFileDocs, notOKFileDocs = self.checkLockStatus()
+        self.logger.debug(f'okFileDocs: {okFileDocs}')
+        self.logger.debug(f'notOKFileDocs: {notOKFileDocs}')
 
         # Register transfer complete replicas to publish container.
-        publishedReplicas = self.registerToPublishContainer(okReplicas)
-        self.logger.debug(f'publishReplicas: {publishedReplicas}')
-        # update ok status
-        self.updateOKReplicasToREST(publishedReplicas)
+        publishedFileDocs = self.registerToPublishContainer(okFileDocs)
+        self.logger.debug(f'publishedFileDocs: {publishedFileDocs}')
+        # update fileDoc for ok filedocs
+        self.updateRESTFileDocsStateToDone(publishedFileDocs)
 
         # update block complete status
-        replicasToUpdateBlockComplete = self.checkBlockCompleteStatus(publishedReplicas)
-        self.logger.debug(f'Replicas to update block completion: {replicasToUpdateBlockComplete}')
-        self.updateBlockCompleteToREST(replicasToUpdateBlockComplete)
+        blockCompletefileDocs = self.checkBlockCompleteStatus(publishedFileDocs)
+        self.logger.debug(f'fileDocs to update block completion: {blockCompletefileDocs}')
+        self.updateRESTFileDocsBlockCompletionInfo(blockCompletefileDocs)
 
         # Bookkeeping published replicas (only replicas with blockcomplete "ok")
-        self.transfer.updateTransferOKReplicas([x['name'] for x in replicasToUpdateBlockComplete])
+        self.transfer.updateOKLocks([x['name'] for x in blockCompletefileDocs])
 
     def checkLockStatus(self):
         """
         Check all lock status of replicas in the rule from
         `Transfer.containerRuleID`.
 
-        :return: list of `okReplicas` where transfers are completed, and
-            `notOkReplicas` where transfer transfers are still in REPLICATING
-             or STUCK state. Each item in list is dict of replica info.
+        :return: list of `okFileDocs` where locks is `OK` and `notOKFileDocs`
+            where locks is `REPLICATING` or `STUCK`. Return as fileDoc format
         :rtype: tuple of list of dict
         """
-        okReplicas = []
-        notOKReplicas = []
+        okFileDocs = []
+        notOKFileDocs = []
         try:
             listReplicasLocks = self.rucioClient.list_replica_locks(self.transfer.containerRuleID)
         except TypeError:
             # Current rucio-clients==1.29.10 will raise exception when it get
-            # None response from server. It will happen when we run
-            # list_replica_locks immediately after register replicas with
+            # None from server. It happen when we run list_replica_locks
+            # immediately after register replicas in transfer container which
             # replicas lock info is not available yet.
-            self.logger.info('Error has raised. Assume there is still no lock info available yet.')
+            self.logger.info('Error was raised. Assume there is still no lock info available yet.')
             listReplicasLocks = []
-        replicasInContainer = self.transfer.replicasInContainer[self.transfer.transferContainer]
-        for replicaStatus in listReplicasLocks:
-            # Skip replicas that register in the same run.
-            if not replicaStatus['name'] in replicasInContainer:
-                continue
+        for lock in listReplicasLocks:
             # skip if replicas transfer is in transferOKReplicas. No need to
             # update status for transfer complete.
-            if replicaStatus['name'] in self.transfer.transferOKReplicas:
+            if lock['name'] in self.transfer.transferOKReplicas:
                 continue
-
-            replica = {
-                'id': self.transfer.replicaLFN2IDMap[replicaStatus['name']],
-                'name': replicaStatus['name'],
+            fileDoc = {
+                'id': self.transfer.replicaLFN2IDMap[lock['name']],
+                'name': lock['name'],
                 'dataset': None,
                 'blockcomplete': 'NO',
                 'ruleid': self.transfer.containerRuleID,
             }
-            if replicaStatus['state'] == 'OK':
-                okReplicas.append(replica)
+            if lock['state'] == 'OK':
+                okFileDocs.append(fileDoc)
             else:
-                notOKReplicas.append(replica)
-        return (okReplicas, notOKReplicas)
+                notOKFileDocs.append(fileDoc)
+        return (okFileDocs, notOKFileDocs)
 
-    def registerToPublishContainer(self, replicas):
+    def registerToPublishContainer(self, fileDocs):
         """
-        Register replicas to the published container. Update the replicas info
+        Register replicas to the publish container. Update the replicas info
         to the new dataset name.
 
-        :param replicas: replicas info return from `checkLockStatus` method.
-        :type replicas: list of dict
+        :param fileDocs: replicas info return from `checkLockStatus` method.
+        :type fileDocs: list of dict (fileDoc)
 
         :return: replicas info with updated dataset name.
         :rtype: list of dict
         """
         r = RegisterReplicas(self.transfer, self.rucioClient, None)
-        replicasPublishedInfo = r.addReplicasToContainer(replicas, self.transfer.publishContainer)
+        publishContainerFileDocs = r.addReplicasToContainer(fileDocs, self.transfer.publishContainer)
         # Update dataset name for each replicas
-        tmpLFN2DatasetMap = {x['name']:x['dataset'] for x in replicasPublishedInfo}
-        tmpReplicas = copy.deepcopy(replicas)
-        for i in tmpReplicas:
-            i['dataset'] = tmpLFN2DatasetMap[i['name']]
-        return tmpReplicas
+        tmpLFN2DatasetMap = {x['name']:x['dataset'] for x in publishContainerFileDocs}
+        tmpFileDocs = copy.deepcopy(fileDocs)
+        for f in tmpFileDocs:
+            f['dataset'] = tmpLFN2DatasetMap[f['name']]
+        return tmpFileDocs
 
-    def checkBlockCompleteStatus(self, replicas):
+    def checkBlockCompleteStatus(self, fileDocs):
         """
-        check (DBS) block completion status from `is_open` dataset metadata.
-        Only return list of replica info where `is_open` of the dataset is
-        `False`.
+        Checking (DBS) block completion status from `is_open` dataset metadata.
+        Only return list of fileDocs where `is_open` of the dataset is `False`.
 
-        :param replicas: replica info return from `registerToPublishContainer`
+        :param fileDocs: replicas's fileDocs
             method.
-        :type replicas: list of dict
+        :type fileDocs: list of dict
 
         :return: list of replicas info with updated `blockcomplete` to `OK`.
         :rtype: list of dict
         """
-        tmpReplicas = []
+        tmpFileDocs = []
         datasetsMap = {}
-        for i in replicas:
-            dataset = i['dataset']
-            if not dataset in datasetsMap:
-                datasetsMap[dataset] = [i]
+        for i in fileDocs:
+            datasetName = i['dataset']
+            if not datasetName in datasetsMap:
+                datasetsMap[datasetName] = [i]
             else:
-                datasetsMap[dataset].append(i)
-        for k, v in datasetsMap.items():
-            metadata = self.rucioClient.get_metadata(self.transfer.rucioScope, k)
+                datasetsMap[datasetName].append(i)
+        for dataset, v in datasetsMap.items():
+            metadata = self.rucioClient.get_metadata(self.transfer.rucioScope, dataset)
             # TODO: Also close dataset when (in or)
             # - the task has completed.
             # - no new replica/is_open for more than 6 hours
@@ -134,51 +127,52 @@ class MonitorLockStatus:
                 for r in v:
                     item = copy.copy(r)
                     item['blockcomplete'] = 'OK'
-                    tmpReplicas.append(item)
+                    tmpFileDocs.append(item)
 
-        return tmpReplicas
+        return tmpFileDocs
 
-    def updateOKReplicasToREST(self, replicas):
+    def updateRESTFileDocsStateToDone(self, fileDocs):
         """
-        Update OK status transfers info to REST server.
+        Update files transfer state in filetransfersdb to DONE, along with
+        metadata info required by REST.
 
-        :param replicas: transferItems's ID and its information.
-        :type replicas: list of dict
+        :param fileDocs: transferItems's ID and its information.
+        :type fileDocs: list of dict
         """
         # TODO: may need to refactor later along with rest and publisher part
-        num = len(replicas)
-        fileDoc = {
+        num = len(fileDocs)
+        restFileDoc = {
             'asoworker': 'rucio',
-            'list_of_ids': [x['id'] for x in replicas],
+            'list_of_ids': [x['id'] for x in fileDocs],
             'list_of_transfer_state': ['DONE']*num,
-            'list_of_dbs_blockname': [x['dataset'] for x in replicas],
-            'list_of_block_complete': [x['blockcomplete'] for x in replicas],
+            'list_of_dbs_blockname': [x['dataset'] for x in fileDocs],
+            'list_of_block_complete': None, # omit
             'list_of_fts_instance': ['https://fts3-cms.cern.ch:8446/']*num,
             'list_of_failure_reason': None, # omit
             'list_of_retry_value': None, # omit
-            'list_of_fts_id': ['NA']*num,
+            'list_of_fts_id': [x['ruleid'] for x in fileDocs]*num,
         }
-        uploadToTransfersdb(self.crabRESTClient, 'filetransfers', 'updateTransfers', fileDoc, self.logger)
+        uploadToTransfersdb(self.crabRESTClient, 'filetransfers', 'updateTransfers', restFileDoc, self.logger)
 
-    def updateBlockCompleteToREST(self, replicas):
+    def updateRESTFileDocsBlockCompletionInfo(self, fileDocs):
         """
-        Update block complete status of replicas to REST server.
+        Update block complete status of fileDocs to REST server.
 
-        :param replicas: transferItems's ID and its information.
-        :type replicas: list of dict
+        :param fileDocs: transferItems's ID and its information.
+        :type fileDocs: list of dict
         """
         # TODO: may need to refactor later along with rest and publisher part
         # This can be optimize to single REST API call together with updateTransfers's subresources
-        num = len(replicas)
-        fileDoc = {
+        num = len(fileDocs)
+        restFileDoc = {
             'asoworker': 'rucio',
-            'list_of_ids': [x['id'] for x in replicas],
+            'list_of_ids': [x['id'] for x in fileDocs],
             'list_of_transfer_state': ['DONE']*num,
-            'list_of_dbs_blockname': [x['dataset'] for x in replicas],
-            'list_of_block_complete': [x['blockcomplete'] for x in replicas],
+            'list_of_dbs_blockname': [x['dataset'] for x in fileDocs],
+            'list_of_block_complete': [x['blockcomplete'] for x in fileDocs],
             'list_of_fts_instance': ['https://fts3-cms.cern.ch:8446/']*num,
             'list_of_failure_reason': None, # omit
             'list_of_retry_value': None, # omit
-            'list_of_fts_id': ['NA']*num,
+            'list_of_fts_id': None,
         }
-        uploadToTransfersdb(self.crabRESTClient, 'filetransfers', 'updateRucioInfo', fileDoc, self.logger)
+        uploadToTransfersdb(self.crabRESTClient, 'filetransfers', 'updateRucioInfo', restFileDoc, self.logger)

--- a/src/python/ASO/Rucio/Transfer.py
+++ b/src/python/ASO/Rucio/Transfer.py
@@ -36,16 +36,7 @@ class Transfer:
         # bookkeeping
         self.lastTransferLine = 0
         self.containerRuleID = ''
-        self.transferOKReplicas = None
-
-        # info from rucio
-        self.replicasInContainer = None
-
-        # map lfn to id
-        self.replicaLFN2IDMap = None
-
-        # info from rucio
-        self.replicasInContainer = None
+        self.bookkeepingOKLocks = None
 
         # map lfn to id
         self.replicaLFN2IDMap = None
@@ -66,7 +57,7 @@ class Transfer:
         self.readRESTInfo()
         self.readInfoFromTransferItems()
         self.readContainerRuleID()
-        self.readTransferOKReplicas()
+        self.readOKLocks()
 
     def readInfoFromRucio(self, rucioClient):
         """
@@ -75,16 +66,7 @@ class Transfer:
         :param rucioClient: Rucio client
         :type rucioClient: rucio.client.client.Client
         """
-        self.initReplicasInContainer(rucioClient)
-
-    def readInfoFromRucio(self, rucioClient):
-        """
-        Read the information from Rucio.
-
-        :param rucioClient: Rucio client
-        :type rucioClient: rucio.client.client.Client
-        """
-        self.initReplicasInContainer(rucioClient)
+        pass
 
     def readLastTransferLine(self):
         """
@@ -197,52 +179,38 @@ class Transfer:
         with writePath(path) as w:
             w.write(ruleID)
 
-    def readTransferOKReplicas(self):
+    def readOKLocks(self):
         """
-        Read transferOKReplicas from task_process/transfers/transfers_ok.txt
+        Read bookkeepingOKLocks from task_process/transfers/transfers_ok.txt.
+        Initialize empty list in case of path not found or
+        `--ignore-transfer-ok` is `True`.
         """
         if config.args.ignore_transfer_ok:
-            self.transferOKReplicas = []
+            self.bookkeepingOKLocks = []
             return
         path = config.args.transfer_ok_path
         try:
             with open(path, 'r', encoding='utf-8') as r:
-                self.transferOKReplicas = r.read().splitlines()
-                self.logger.info(f'Got list of transfer status "OK" from bookkeeping: {self.transferOKReplicas}')
+                self.bookkeepingOKLocks = r.read().splitlines()
+                self.logger.info(f'Got list of "OK" locks from bookkeeping: {self.bookkeepingOKLocks}')
         except FileNotFoundError:
-            self.transferOKReplicas = []
-            self.logger.info(f'Bookkeeping transfer status OK from path "{path}" does not exist. Assume this is first time it run.')
+            self.bookkeepingOKLocks = []
+            self.logger.info(f'Bookkeeping path "{path}" does not exist. Assume this is first time it run.')
 
-    def updateTransferOKReplicas(self, newReplicas):
+    def updateOKLocks(self, newLocks):
         """
-        update transferOKReplicas to task_process/transfers/transfers_ok.txt
+        update bookkeepingOKLocks to task_process/transfers/transfers_ok.txt
 
-        :param newReplicas: list of LFN
-        :type newReplicas: list of string
+        :param newLocks: list of LFN
+        :type newLocks: list of string
         """
-        self.transferOKReplicas += newReplicas
-        if config.args.ignore_transfer_ok:
-            return
+        self.bookkeepingOKLocks += newLocks
         path = config.args.transfer_ok_path
-        self.logger.info(f'Bookkeeping transfer status OK: {self.transferOKReplicas}')
+        self.logger.info(f'Bookkeeping transfer status OK: {self.bookkeepingOKLocks}')
         self.logger.info(f'to file: {path}')
         with writePath(path) as w:
-            for l in self.transferOKReplicas:
+            for l in self.bookkeepingOKLocks:
                 w.write(f'{l}\n')
-
-    def initReplicasInContainer(self, rucioClient):
-        """
-        Get replicas from transfer and publish container and assign it to
-        self.replicasInContainer as key-value pare of containerName and map of
-        LFN2Dataset.
-
-        :param rucioClient: Rucio Client
-        :type rucioClient: rucio.client.client.Client
-        """
-        replicasInContainer = {}
-        replicasInContainer[self.transferContainer] = self.populateLFN2DatasetMap(self.transferContainer, rucioClient)
-        replicasInContainer[self.publishContainer] = self.populateLFN2DatasetMap(self.publishContainer, rucioClient)
-        self.replicasInContainer = replicasInContainer
 
     def populateLFN2DatasetMap(self, container, rucioClient):
         """

--- a/src/python/ASO/Rucio/utils.py
+++ b/src/python/ASO/Rucio/utils.py
@@ -24,7 +24,6 @@ def writePath(path):
         yield w
     shutil.move(tmpPath, path)
 
-
 def chunks(l, n=1):
     """
     Yield successive n-sized chunks from l.
@@ -33,10 +32,14 @@ def chunks(l, n=1):
     :type l: list
     :param n: chunk size
     :type n: int
-    :return: yield the next list chunk
+    :return: yield the next chunk list
     :rtype: generator
     """
     if isinstance(l, list):
+        for i in range(0, len(l), n):
+            yield l[i:i + n]
+    elif isinstance(l, dict):
+        l = list(l.items())
         for i in range(0, len(l), n):
             yield l[i:i + n]
     else:
@@ -46,7 +49,6 @@ def chunks(l, n=1):
                 yield newList
             else:
                 break
-
 
 def uploadToTransfersdb(client, api, subresource, fileDoc, logger=None):
     """


### PR DESCRIPTION
This PR replaces [#7693](https://github.com/dmwm/CRABServer/pull/7693) to focus on readability.

- The separation between rucio replica and the metadata we use for crab rest. The metadata is called fileDoc.
- Change the return variable structure from prepare().
- Rename update to rest method to reflect state change.
- Remove `initReplicasInContainer()` and use `populateLFN2DatasetMap()` directly where it needed.
- remove "skip monitoring lock for the files in the same run.", the useless statement.