### PR TITLE
RUCIO_Transfers.py: Add checksums to json FJR for non-EDM outputs

### DIFF
--- a/scripts/cmscp.py
+++ b/scripts/cmscp.py
@@ -27,6 +27,7 @@ import WMCore.Storage.StageOutError as StageOutError
 from WMCore.Storage.Registry import retrieveStageOutImpl
 from WMCore.Algorithms.Alarm import Alarm, alarmHandler
 import WMCore.WMException as WMException
+from Utils.FileTools import calculateChecksums
 
 ## See the explanation of this sentry file in CMSRunAnalysis.py.
 with open('wmcore_initialized', 'w') as fd_wmcore:
@@ -314,6 +315,9 @@ def add_output_file_to_job_report(file_name, key = 'addoutput'):
         print(msg)
     else:
         output_file_info['size'] = file_size
+
+    (adler32, cksum) = calculateChecksums(file_name)
+    output_file_info['checksums'] = {'adler32': adler32, 'cksum': cksum}
     is_ok = add_to_job_report([(key, output_file_info)], \
                               ['steps', 'cmsRun', 'output'], 'update')
     if not is_ok:
@@ -449,7 +453,7 @@ def perform_local_stageout(local_stageout_mgr, \
         signal.alarm(0)
     if retval == 0:
         dest_temp_file_name = os.path.split(dest_temp_lfn)[-1]
-        
+
         # If fallback stageout happens, PNN can be different as source
         if 'PNN' in stageout_info:
             print("INFO: PNN is defined in site-local-config. %s changed to %s" % (source_site, stageout_info['PNN']))


### PR DESCRIPTION
Fix https://github.com/dmwm/CRABServer/issues/7718

As @mapellidario suggested, put it in `cmscp.py` where the `addoutput` key is created. The rest already handled by `PostJob.py`.
I discovered last Tuesday that JobWrapper ALWAYS use `Utils.FileTools.calculateChecksums` to calculate checksums of output file in [CMSRunAnalysis.py#L455-L470](https://github.com/novicecpp/CRABServer/blob/db9c3bdcf78c1361fa7a59c2ec6c20a69ec5588f/scripts/CMSRunAnalysis.py#L455-L470) ([recent job](https://cmsweb.cern.ch:8443/scheddmon/0107/afelizia/230706_082652:afelizia_crab_crab_afelizia_2023-07-06_UTC10-25-47/job_out.21.0.txt) in the production).


It is works so far for my test tasks [230704_055629:tseethon_crab_rucio_transfers_hc1kj_withnonedm_test12_20230704_075628](https://monit-grafana.cern.ch/d/cmsTMDetail/cms_task_monitoring?orgId=11&var-user=tseethon&var-task=230704_055629:tseethon_crab_rucio_transfers_hc1kj_withnonedm_test12_20230704_075628&from=1688450189000&to=now).


