### PR TITLE
move DataRecall and DataLock to separate file

### DIFF
--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -907,10 +907,15 @@ class MeasureTime:
     cherrypy.log("%s executemany time: %6f" % (trace, mt.perf_counter,))
 
     """
+
     def __init__(self, logger=None, modulename="", label=""):
         self.logger = logger
         self.modulename = modulename
         self.label = label
+        self.perf_counter = None
+        self.process_time = None
+        self.thread_time = None
+        self.readout = None
 
     def __enter__(self):
         self.perf_counter = time.perf_counter()
@@ -918,7 +923,7 @@ class MeasureTime:
         self.thread_time = time.thread_time()
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, t, v, tb):
         self.thread_time = time.thread_time() - self.thread_time
         self.process_time = time.process_time() - self.process_time
         self.perf_counter = time.perf_counter() - self.perf_counter

--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -59,6 +59,10 @@ SERVICE_INSTANCES = {'prod': {'restHost':'cmsweb.cern.ch', 'dbInstance':'prod'},
                      'other': {'restHost':None, 'dbInstance':None},
                      }
 
+# Limits for TaskWorker
+MAX_LUMIS_IN_BLOCK = 100000  # 100K lumis to avoid blowing up memory
+
+
 # Fatal error limits for job resource usage
 # Defaults are used if unable to load from .job.ad
 # Otherwise it uses these values.

--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -19,7 +19,7 @@ from ServerUtilities import FEEDBACKMAIL, MAX_DAYS_FOR_TAPERECALL, MAX_TB_TO_REC
 from ServerUtilities import TASKLIFETIME
 from RucioUtils import getNativeRucioClient
 
-from RucioActions import TapeRecaller, InputLocker
+from TaskWorker.Actions.RucioActions import RucioAction
 
 from rucio.common.exception import (DuplicateRule, DataIdentifierAlreadyExists, DuplicateContent,
                                     InsufficientTargetRSEs, InsufficientAccountLimit, FullStorage)
@@ -425,9 +425,10 @@ class DBSDataDiscovery(DataDiscovery):
             else:
                 dataToLock = inputBlocks
             try:
-                locker = InputLocker(config=config, crabserver=self.crabserver,
-                                    taskName=self.taskName, username=self.username,
-                                    logger=self.logger)
+                locker = RucioAction(config=config, crabserver=self.crabserver,
+                                     rucioAcccount='crab_input',
+                                     taskName=self.taskName, username=self.username,
+                                     logger=self.logger)
                 locker.lockData(dataToLock=dataToLock)
             except Exception as e:
                 self.logger.exception("Fatal exception in lockData:\n%s" % e)
@@ -455,9 +456,10 @@ class DBSDataDiscovery(DataDiscovery):
         if not isinstance(dataToRecall, str) and not isinstance(dataToRecall, list):
             return
         if system == 'Rucio':
-            recaller = TapeRecaller(config=config, crabserver=self.crabserver,
-                                    taskName=self.taskName, username=self.username,
-                                    logger=self.logger)
+            recaller = RucioAction(config=config, crabserver=self.crabserver,
+                                   rucioAcccount='crab_tape_recall',
+                                   taskName=self.taskName, username=self.username,
+                                   logger=self.logger)
             recaller.recallData(dataToRecall=dataToRecall, sizeToRecall=sizeToRecall,
                                          tapeLocations=tapeLocations, msgHead=msg)
 

--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -1,6 +1,8 @@
 """
 Performing the data discovery through CMS DBS service.
 """
+# avoid pylint complainging about non-elegfant code . It is old and works. Do not touch.
+# pylint: disable=too-many-locals, too-many-branches, too-many-nested-blocks, too-many-statements
 import os
 import logging
 import sys
@@ -8,6 +10,7 @@ import sys
 from WMCore.DataStructs.LumiList import LumiList
 from WMCore.Services.DBS.DBSReader import DBSReader
 from WMCore.Services.DBS.DBSErrors import DBSReaderError
+from WMCore.Configuration import ConfigurationEx
 
 from TaskWorker.WorkerExceptions import TaskWorkerException, TapeDatasetException
 from TaskWorker.Actions.DataDiscovery import DataDiscovery
@@ -29,11 +32,12 @@ class DBSDataDiscovery(DataDiscovery):
         self.rucioClient = rucioClient
 
     def checkDatasetStatus(self, dataset, kwargs):
+        """ as the name says """
         res = self.dbs.dbs.listDatasets(dataset=dataset, detail=1, dataset_access_type='*')
         if not res:
-            raise TaskWorkerException("Cannot find dataset %s in %s DBS instance" % (dataset, self.dbsInstance))
+            raise TaskWorkerException(f"Cannot find dataset {dataset} in {self.dbsInstance} DBS instance")
         if len(res) > 1:
-            raise TaskWorkerException("Found more than one dataset while checking in DBS the status of %s" % dataset)
+            raise TaskWorkerException(f"Found more than one dataset while checking in DBS the status of {dataset}")
         res = res[0]
         #import pprint
         #self.logger.info("Input dataset details: %s", pprint.pformat(res))
@@ -45,21 +49,23 @@ class DBSDataDiscovery(DataDiscovery):
                 msg = f"CRAB refuses to proceed in getting the details of the dataset {dataset} from DBS"
                 msg += f"because the dataset is not 'VALID' but '{accessType}'."
                 if accessType == 'DEPRECATED':
-                    msg += " (%s)" % (msgForDeprecDS)
+                    msg += f" ({msgForDeprecDS})"
                 msg += " To allow CRAB to consider a dataset that is not 'VALID', set Data.allowNonValidInputDataset = True in the CRAB configuration."
                 msg += " Notice that this will not force CRAB to run over all files in the dataset;"
                 msg += " CRAB will still check if there are any valid files in the dataset and run only over those files."
                 raise TaskWorkerException(msg)
-            msg = "The input dataset %s is not 'VALID' but '%s'." % (dataset, accessType)
+            msg = f"The input dataset {dataset} is not 'VALID' but '{accessType}'."
             msg += " CRAB will check if there are any valid files in the dataset and run only over those files."
             if accessType == 'DEPRECATED':
-                msg += " %s" % (msgForDeprecDS)
+                msg += f" ({msgForDeprecDS})"
             self.uploadWarning(msg, kwargs['task']['user_proxy'], kwargs['task']['tm_taskname'])
 
 
     def keepOnlyDiskRSEs(self, locationsMap):
-        # get all the RucioStorageElements (RSEs) which are of kind 'Disk'
-        # locationsMap is a dictionary {block1:[locations], block2:[locations],...}
+        """
+        get all the RucioStorageElements (RSEs) which are of kind 'Disk'
+        locationsMap is a dictionary {block1:[locations], block2:[locations],...}
+        """
         diskLocationsMap = {}
         for block, locations in locationsMap.items():
             # as of Sept 2020, tape RSEs ends with _Tape, go for the quick hack
@@ -80,7 +86,7 @@ class DBSDataDiscovery(DataDiscovery):
             blockInfo = self.dbs.getDBSSummaryInfo(block=block)
             if blockInfo.get('NumberOfLumis', 0) > MAX_LUMIS_IN_BLOCK:
                 msg = f"Block {block} contains more than {MAX_LUMIS_IN_BLOCK} lumis."
-                msg += f"\nThis blows up CRAB server memory"
+                msg += "\nThis blows up CRAB server memory"
                 msg += "\nCRAB can only split this by ignoring lumi information. You can do this"
                 msg += "\nusing FileBased split algorithm and avoiding any additional request"
                 msg += "\nwich may cause lumi information to be looked up. See CRAB FAQ for more info:"
@@ -95,13 +101,16 @@ class DBSDataDiscovery(DataDiscovery):
         # DBS3 requires X509_USER_CERT to be set - but we don't want to leak that to other modules
         # so use a context manager to set an ad hoc env and restore as soon as
         # executeInternal is over, even if it raises exception
+        # NOTE this is legacy from the time we were using X509 to submit to schedd, most likely
+        # we can use a single X509 env. throught all of TW. But for now.. be conservative
 
         with self.config.TaskWorker.envForCMSWEB:
             result = self.executeInternal(*args, **kwargs)
 
         return result
 
-    def executeInternal(self, *args, **kwargs):  # pylinf: disable=unused-argument
+    def executeInternal(self, *args, **kwargs):  # pylint: disable=unused-argument
+        """ this is where things happen """
 
         self.logger.info("Data discovery with DBS")  # to be changed into debug
         if kwargs['task']['tm_dbs_url']:
@@ -154,7 +163,7 @@ class DBSDataDiscovery(DataDiscovery):
             # dataset not found in DBS is a known use case
             if str(dbsexc).find('No matching data'):
                 raise TaskWorkerException(
-                    "CRAB could not find dataset %s in this DBS instance: %s" % inputDataset, dbsurl
+                    f"CRAB could not find dataset {inputDataset} in this DBS instance: {dbsurl}"
                 ) from dbsexc
             raise
         ## Create a map for block's locations: for each block get the list of locations.
@@ -181,9 +190,9 @@ class DBSDataDiscovery(DataDiscovery):
         if useRucioForLocations:
             scope = "cms"
             # If the dataset is a USER one, use the Rucio user scope to find it
-            # TODO: we need a way to enable users to indicate others user scopes as source
+            # NOTE we need a way to enable users to indicate others user scopes as source
             if isUserDataset:
-                scope = "user.%s" % self.username
+                scope = f"user.{self.username}"
             self.logger.info("Looking up data location with Rucio in %s scope.", scope)
             locationsMap = {}
             partialLocationsMap = {}
@@ -208,8 +217,8 @@ class DBSDataDiscovery(DataDiscovery):
                     if partialReplicas:
                         partialLocationsMap[blockName] = partialReplicas
 
-            except Exception as exc:
-                msg = "Rucio lookup failed with\n%s" % str(exc)
+            except Exception as exc:  # pylint: disable=broad-except
+                msg = f"Rucio lookup failed with\n{exc}"
                 self.logger.warning(msg)
                 locationsMap = None
 
@@ -232,7 +241,7 @@ class DBSDataDiscovery(DataDiscovery):
                     raise TaskWorkerException(
                         "CRAB server could not get file locations from DBS for a USER dataset.\n"+\
                         "This is could be a temporary DBS glitch, please try to submit a new task (resubmit will not work)"+\
-                        " and contact the experts if the error persists.\nError reason: %s" % str(ex)
+                        f" and contact the experts if the error persists.\nError reason: {ex}"
                     ) from ex
                 useCernbox = False
                 for v in locationsMap.values():
@@ -260,7 +269,7 @@ class DBSDataDiscovery(DataDiscovery):
                     raise TaskWorkerException(
                         "CRAB server could not get file locations from DBS for secondary dataset of USER tier.\n"+\
                         "This is could be a temporary DBS glitch, please try to submit a new task (resubmit will not work)"+\
-                        " and contact the experts if the error persists.\nError reason: %s" % str(ex)
+                        f" and contact the experts if the error persists.\nError reason: {ex}"
                     ) from ex
             else:
                 self.logger.info("Trying data location of secondary dataset blocks with Rucio")
@@ -275,12 +284,12 @@ class DBSDataDiscovery(DataDiscovery):
                                 replicas.add(item['rse'])
                         if replicas:  # only fill map for blocks which have at least one location
                             secondaryLocationsMap[blockName] = replicas
-                except Exception as exc:
-                    msg = "Rucio lookup failed with\n%s" % str(exc)
+                except Exception as exc:  # pylint: disable=broad-except
+                    msg = f"Rucio lookup failed with\n{exc}"
                     self.logger.warning(msg)
                     secondaryLocationsMap = None
             if not secondaryLocationsMap:
-                msg = "No locations found for secondaryDataset %s." % secondaryDataset
+                msg = f"No locations found for secondaryDataset {secondaryDataset}."
                 raise TaskWorkerException(msg)
 
 
@@ -380,18 +389,18 @@ class DBSDataDiscovery(DataDiscovery):
                             infos['Parents'].append(secfilename)
                 self.logger.info("Done matching files from secondary dataset")
                 kwargs['task']['tm_use_parent'] = 1
-        except Exception as ex: #TODO should we catch HttpException instead?
+        except Exception as ex:
             self.logger.exception(ex)
             raise TaskWorkerException(
                 "The CRAB3 server backend could not contact DBS to get the files details (Lumis, events, etc).\n"+\
                 "This is could be a temporary DBS glitch. Please try to submit a new task (resubmit will not work)"+\
-                " and contact the experts if the error persists.\nError reason: %s" % str(ex)
+                f" and contact the experts if the error persists.\nError reason: {ex}"
             ) from ex
         if not filedetails:
             raise TaskWorkerException(
                 ("Cannot find any file inside the dataset. Please, check your dataset in DAS\n%s\n" +
                  "Aborting submission. Resubmitting your task will not help.") %
-                ("https://cmsweb.cern.ch/das/request?instance=%s&input=dataset=%s" % (self.dbsInstance, inputDataset))
+                (f"https://cmsweb.cern.ch/das/request?instance={self.dbsInstance}&input=dataset={inputDataset}")
             )
 
         ## Format the output creating the data structures required by WMCore. Filters out invalid files,
@@ -403,8 +412,7 @@ class DBSDataDiscovery(DataDiscovery):
         if not result.result:
             raise TaskWorkerException(("Cannot find any valid file inside the dataset. Please, check your dataset in DAS, %s.\n" +
                                        "Aborting submission. Resubmitting your task will not help.") %
-                                      ("https://cmsweb.cern.ch/das/request?instance=%s&input=dataset=%s") %
-                                      (self.dbsInstance, inputDataset))
+                                      (f"https://cmsweb.cern.ch/das/request?instance={self.dbsInstance}&input=dataset={inputDataset}"))
 
         self.logger.debug("Got %s files", len(result.result.getFiles()))
 
@@ -424,7 +432,7 @@ class DBSDataDiscovery(DataDiscovery):
                                      taskName=self.taskName, username=self.username,
                                      logger=self.logger)
                 locker.lockData(dataToLock=dataToLock)
-            except Exception as e:
+            except Exception as e:  # pylint: disable=broad-except
                 self.logger.exception("Fatal exception in lockData:\n%s", e)
                 msg = 'Locking of input data failed. Details in TaskWorker log. Submit anyhow'
                 self.logger.info(msg)
@@ -446,10 +454,12 @@ class DBSDataDiscovery(DataDiscovery):
             The exception message contains details and an attempt is done to upload it to TaskDB
             so that crab status can report it
         """
+        # SB: DO WE REALLY NEED THIS ? It was a helper when transitioning from DDM to Rucio
         msg = msgHead
         if not isinstance(dataToRecall, str) and not isinstance(dataToRecall, list):
             return
-        if system == 'Rucio':
+        # The else is needed here after the raise !
+        if system == 'Rucio':  # pylint: disable=no-else-raise
             recaller = RucioAction(config=config, crabserver=self.crabserver,
                                    rucioAcccount='crab_tape_recall',
                                    taskName=self.taskName, username=self.username,
@@ -460,7 +470,7 @@ class DBSDataDiscovery(DataDiscovery):
             msg += "\nThis task will be automatically submitted as soon as the stage-out is completed."
             self.uploadWarning(msg, self.userproxy, self.taskName)
             raise TapeDatasetException(msg)
-        elif system == 'None':
+        else:
             msg += '\nIt is not possible to request a recall from tape.'
             msg += "\nPlease, check DAS (https://cmsweb.cern.ch/das) and make sure the dataset is accessible on DISK."
             raise TaskWorkerException(msg)
@@ -476,11 +486,10 @@ if __name__ == '__main__':
     ###
     dbsInstance = sys.argv[1]
     dbsDataset = sys.argv[2]
-    dbsSecondaryDataset = sys.argv[3] if len(sys.argv) == 4 else None
+    dbsSecondaryDataset = sys.argv[3] if len(sys.argv) == 4 else None  # pylint: disable=invalid-name
     DBSUrl = f"https://cmsweb.cern.ch/dbs/{dbsInstance}/DBSReader/"
 
     logging.basicConfig(level=logging.DEBUG)
-    from WMCore.Configuration import ConfigurationEx
 
     config = ConfigurationEx()
     config.section_("Services")

--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -1,12 +1,9 @@
-from __future__ import print_function
+"""
+Performing the data discovery through CMS DBS service.
+"""
 import os
-import random
 import logging
-import copy
-from http.client import HTTPException
-
 import sys
-from urllib.parse import urlencode  # pylint: disable=no-name-in-module  # for pylint2 compat.
 
 from WMCore.DataStructs.LumiList import LumiList
 from WMCore.Services.DBS.DBSReader import DBSReader
@@ -14,19 +11,15 @@ from WMCore.Services.DBS.DBSErrors import DBSReaderError
 
 from TaskWorker.WorkerExceptions import TaskWorkerException, TapeDatasetException
 from TaskWorker.Actions.DataDiscovery import DataDiscovery
-from ServerUtilities import FEEDBACKMAIL, MAX_DAYS_FOR_TAPERECALL, MAX_TB_TO_RECALL_AT_A_SINGLE_SITE,\
-    parseDBSInstance, isDatasetUserDataset
-from ServerUtilities import TASKLIFETIME
+from ServerUtilities import FEEDBACKMAIL, parseDBSInstance, isDatasetUserDataset
 from RucioUtils import getNativeRucioClient
 
 from TaskWorker.Actions.RucioActions import RucioAction
 
-from rucio.common.exception import (DuplicateRule, DataIdentifierAlreadyExists, DuplicateContent,
-                                    InsufficientTargetRSEs, InsufficientAccountLimit, FullStorage)
-
 
 class DBSDataDiscovery(DataDiscovery):
-    """Performing the data discovery through CMS DBS service.
+    """
+    the way TW works, we need a class which implements the execute method
     """
 
     # disable pylint warning in next line since they refer to conflict with the main()
@@ -431,7 +424,7 @@ class DBSDataDiscovery(DataDiscovery):
                                      logger=self.logger)
                 locker.lockData(dataToLock=dataToLock)
             except Exception as e:
-                self.logger.exception("Fatal exception in lockData:\n%s" % e)
+                self.logger.exception("Fatal exception in lockData:\n%s", e)
                 msg = 'Locking of input data failed. Details in TaskWorker log. Submit anyhow'
                 self.logger.info(msg)
                 self.uploadWarning(msg, self.userproxy, self.taskName)

--- a/src/python/TaskWorker/Actions/RucioActions.py
+++ b/src/python/TaskWorker/Actions/RucioActions.py
@@ -1,0 +1,307 @@
+import os
+import random
+import copy
+from urllib.parse import urlencode
+from http.client import HTTPException
+
+
+from TaskWorker.Actions.TaskAction import TaskAction
+from TaskWorker.WorkerExceptions import TaskWorkerException, TapeDatasetException
+
+from ServerUtilities import FEEDBACKMAIL, MAX_DAYS_FOR_TAPERECALL, MAX_TB_TO_RECALL_AT_A_SINGLE_SITE
+from ServerUtilities import TASKLIFETIME
+
+from RucioUtils import getNativeRucioClient
+
+from rucio.common.exception import (DuplicateRule, DataIdentifierAlreadyExists, DuplicateContent,
+                                    InsufficientTargetRSEs, InsufficientAccountLimit, FullStorage)
+
+class RucioActions():
+    """
+    performs action on tasks which require non trivial interaction with Rucio
+    contains a few common methods to the two classes tapeRecaller and inputLocker
+    acting as base class for those
+    """
+    def __init__(self, config=None, crabserver=None, taskName=None, username=None, logger=None):
+        self.config = config
+        self.crabserver = crabserver
+        self.taskName = taskName
+        self.logger = logger
+        self.username = username
+        # following two will be filled in inherited subclasses TapeRecaller and InputLocker
+        self.rucioAccount = None
+        self.rucioClient = None
+
+
+    def makeContainerFromBlockList(self, rucio=None, blockList=None, containerDid=None):
+        """ create container and fill with given blocks """
+        scope = containerDid['scope']
+        containerName = containerDid['name']
+        # turn input CMS blocks into Rucio dids in cms scope
+        dids = [{'scope': 'cms', 'name': block} for block in blockList]
+        # prepare container
+        self.logger.info("Create Rucio container %s", containerName)
+        try:
+            rucio.add_container(scope, containerName)
+        except DataIdentifierAlreadyExists:
+            self.logger.debug("Container name already exists in Rucio. Keep going")
+        except Exception as ex:
+            msg = "\nRucio exception creating container: %s" % (str(ex))
+            raise TaskWorkerException(msg) from ex
+        # add block dids to container
+        try:
+            rucio.attach_dids(scope, containerName, dids)
+        except DuplicateContent:
+            self.logger.debug("Some dids are already in this container. Keep going")
+        except Exception as ex:
+            msg = "\nRucio exception adding blocks to container: %s" % (str(ex))
+            raise TaskWorkerException(msg) from ex
+        self.logger.info("Rucio container %s:%s created with %d blocks", scope, containerName, len(blockList))
+
+
+    def createOrReuseRucioRule(self, did=None, grouping=None,
+                               RSE_EXPRESSION='', comment='', lifetime=0):
+        # Some RSE_EXPR for testing
+        # RSE_EXPRESSION = 'ddm_quota>0&(tier=1|tier=2)&rse_type=DISK'
+        # RSE_EXPRESSION = 'T3_IT_Trieste' # for testing
+        WEIGHT = 'ddm_quota'  # only makes sense for rules which trigger replicas
+        # WEIGHT = None # for testing
+        ASK_APPROVAL = False
+        # ASK_APPROVAL = True # for testing
+        copies = 1
+        try:
+            ruleIds = self.rucioClient.add_replication_rule(  # N.B. returns a list
+                dids=[did], copies=copies, rse_expression=RSE_EXPRESSION,
+                grouping=grouping, weight=WEIGHT, lifetime=lifetime,
+                account=self.rucioAccount, activity='Analysis Input',
+                comment=comment,
+                ask_approval=ASK_APPROVAL, asynchronous=True)
+            ruleId = ruleIds[0]
+        except DuplicateRule:
+            # handle "A duplicate rule for this account, did, rse_expression, copies already exists"
+            # which should only happen when testing, since container name is unique like task name, but
+            # we cover also retry situations where TW was stopped/killed/crashed halfway in the process
+            self.logger.debug("A duplicate rule for this account, did, rse_expression, copies already exists. Use that")
+            # find the existing rule id
+            ruleIdGen = self.rucioClient.list_did_rules(scope=did['scope'], name=did['name'])
+            for rule in ruleIdGen:
+                if rule['account'] == self.rucioAccount:
+                    ruleId = rule['id']
+                    break
+            # extend rule lifetime
+            self.rucioClient.update_replication_rule(ruleId, {'lifetime': lifetime})
+        except (InsufficientTargetRSEs, InsufficientAccountLimit, FullStorage) as ex:
+            msg = "\nNot enough global quota to issue a tape recall request. Rucio exception:\n%s" % str(ex)
+            raise TaskWorkerException(msg) from ex
+        except Exception as ex:
+            msg = "\nRucio exception creating rule: %s" % str(ex)
+            raise TaskWorkerException(msg) from ex
+
+        return ruleId
+
+
+
+class TapeRecaller(RucioActions):
+    """
+    request tape recall
+    """
+    def __init__(self, config=None, crabserver=None, taskName=None, username=None, logger=None):
+        RucioActions.__init__(self, config=config, crabserver=crabserver, taskName=taskName,
+                       username=username, logger=logger)
+        # need to use crab_tape_recall Rucio account to create containers and create rules
+        self.rucioAccount = 'crab_tape_recall'
+        tapeRecallConfig = copy.deepcopy(self.config)
+        tapeRecallConfig.Services.Rucio_account = self.rucioAccount
+        self.rucioClient = getNativeRucioClient(tapeRecallConfig, self.logger)  # pylint: disable=redefined-outer-name
+
+
+    def whereToRecall(self, tapeLocations=None, TBtoRecall=0):
+        # make RSEs lists
+        # asking for ddm_quota>0 gets rid also of Temp and Test RSE's
+        ALL_RSES = "ddm_quota>0&(tier=1|tier=2)&rse_type=DISK"
+        # tune list according to where tapes are, we expect a single location
+        # if there are more... let Rucio deal with them to find best route
+        if tapeLocations:
+            if 'T1_RU_JINR_Tape' in tapeLocations and len(tapeLocations) > 1:
+                tapeLocations.remove('T1_RU_JINR_Tape')  # JINR tape data are often duplicated
+            if len(tapeLocations) == 1:
+                if 'US' in list(tapeLocations)[0]:
+                    ALL_RSES += "&(country=US|country=BR)"
+                else:
+                    ALL_RSES += "\country=US\country=BR"  # Rucio wants the set complement operator \
+        rses = self.rucioClient.list_rses(ALL_RSES)
+        rseNames = [r['rse'] for r in rses]
+        largeRSEs = []  # a list of largish (i.e. solid) RSEs
+        for rse in rseNames:
+            if rse[2:6] == '_RU_':  # avoid fragile sites, see #7400
+                continue
+            usageDetails = list(self.rucioClient.get_rse_usage(rse, filters={'source': 'static'}))
+            if not usageDetails:  # some RSE's are put in the system with an empty list here, e.g. T2_FR_GRIF
+                continue
+            size = usageDetails[0]['used']  # bytes
+            if float(size) / 1.e15 > 1.0:  # more than 1 PB
+                largeRSEs.append(rse)
+        # sort lists so that duplicated rules can be spotted
+        largeRSEs.sort()
+        if TBtoRecall <= MAX_TB_TO_RECALL_AT_A_SINGLE_SITE:  #
+            grouping = 'ALL'
+            self.logger.info("Will place all blocks at a single site")
+            RSE_EXPRESSION = '|'.join(largeRSEs)  # any solid site will do, most datasets are a few TB anyhow
+        else:
+            grouping = 'DATASET'  # Rucio DATASET i.e. CMS block !
+            self.logger.info("Will scatter blocks on multiple sites")
+            # restrict the list to as few sites as possible
+            nRSEs = int(TBtoRecall / MAX_TB_TO_RECALL_AT_A_SINGLE_SITE) + 1
+            myRSEs = random.sample(largeRSEs, nRSEs)
+            RSE_EXPRESSION = '|'.join(myRSEs)
+        self.logger.debug('Will use RSE_EXPRESSION = %s', RSE_EXPRESSION)
+        return RSE_EXPRESSION, grouping
+
+
+    def setTaskToTapeRecall(self, ruleId='', msg=''):
+        tapeRecallStatus = 'TAPERECALL'
+        configreq = {'workflow': self.taskName,
+                     'taskstatus': tapeRecallStatus,
+                     'ddmreqid': ruleId,
+                     'subresource': 'addddmreqid',
+                     }
+        try:
+            tapeRecallStatusSet = self.crabserver.post(api='task', data=urlencode(configreq))
+        except HTTPException as hte:
+            self.logger.exception(hte)
+            msg = "HTTP Error while contacting the REST Interface %s:\n%s" % (
+                self.crabserver.server['host'], str(hte))
+            msg += "\nStoring of %s status and ruleId (%s) failed for task %s" % (
+                tapeRecallStatus, ruleId, self.taskName)
+            msg += "\nHTTP Headers are: %s" % hte.headers
+            raise TaskWorkerException(msg, retry=True) from hte
+        if tapeRecallStatusSet[2] == "OK":
+            self.logger.info("Status for task %s set to '%s'", self.taskName, tapeRecallStatus)
+        msg += "\nThis task will be automatically submitted as soon as the stage-out is completed."
+        self.uploadWarning(msg, self.userproxy, self.taskName)
+        raise TapeDatasetException(msg)
+
+
+    def recallData(self, dataToRecall=None, sizeToRecall=0, tapeLocations=None, msgHead=''):
+
+        """
+        implements tape recall with Rucio
+        params and returns are the same as requestTapeRecall defined above
+        """
+
+        # friendly units from bytes to TB
+        TBtoRecall = sizeToRecall // 1e12
+        # Sanity check
+        if TBtoRecall > 1e3:
+            msg = msgHead + f"\nDataset size {TBtoRecall} TB. Will not trigger automatic recall for >1PB. Contact DataOps"
+            raise TaskWorkerException(msg)
+
+        # a friendly-formatted string to print the size
+        recallSize = f"{TBtoRecall:.0f} TBytes" if TBtoRecall > 0 else f"{sizeToRecall / 1e9:.0f} GBytes"
+        self.logger.info("Total size of data to recall : %s", recallSize)
+
+
+        # prepare container to be recalled
+        if isinstance(dataToRecall, str):
+            # recalling a full DBS dataset, simple the container already exists
+            myScope = 'cms'
+            dbsDatasetName = dataToRecall
+            containerDid = {'scope': myScope, 'name': dbsDatasetName}
+        elif isinstance(dataToRecall, list):
+            # need to prepare ad hoc container. Can not reuse a possibly existing one:
+            # if a user wants one block from a large dataset, we must
+            # not recall also all blocks possibly requested in the past
+            #  by other users for other reasons.
+            #  Therefore we stick with naming the container after the task name
+            myScope = f"user.{self.rucioAccount}"  # do not mess with cms scope
+            containerName = '/TapeRecall/%s/USER' % self.taskName.replace(':', '.')
+            containerDid = {'scope': myScope, 'name': containerName}
+            self.makeContainerFromBlockList(blockList=dataToRecall, containerDid=containerDid)
+            # beware blockList being not subscriptable (e.g. dict_keys type)
+            dbsDatasetName = next(iter(dataToRecall)).split('#')[0]
+        else:
+            return
+
+        # prepare comment to be inserted in the Rucio rule
+        comment = f"Recall {recallSize} for user: {self.username} dataset: {dbsDatasetName}"
+
+        # define where to recall to, which depends also on where data are on tape
+        (RSE_EXPRESSION, grouping) = self.whereToRecall(tapeLocations=tapeLocations, TBtoRecall=TBtoRecall)
+
+        # create rule
+        # make rule last 7 extra days to allow debugging in case TW or Recall action fail
+        LIFETIME = (MAX_DAYS_FOR_TAPERECALL + 7) * 24 * 60 * 60  # in seconds
+        ruleId = self.createOrReuseRucioRule(did=containerDid, grouping=grouping,
+                                             RSE_EXPRESSION=RSE_EXPRESSION,
+                                             comment=comment, lifetime=LIFETIME)
+        msg = f"Created Rucio rule ID: {ruleId}"
+        self.logger.info(msg)
+
+        # this will be printed by "crab status"
+        msg = msgHead
+        msg += "\nA disk replica has been requested to Rucio.  Check progress via:"
+        msg += "\n  rucio rule-info %s" % ruleId
+        msg += "\nor simply check 'state' line in this page: https://cms-rucio-webui.cern.ch/rule?rule_id=%s" % ruleId
+
+        # update task status in CRAB DB and store the rule ID
+        self.setTaskToTapeRecall(ruleId=ruleId, msg=msg)
+
+        return
+
+
+class InputLocker(RucioActions):
+    """
+    lock input data for the lifetime of the task
+    """
+    def __init__(self, config=None, crabserver=None, taskName=None, username=None, logger=None):
+        RucioActions.__init__(self, config=config, crabserver=crabserver, taskName=taskName,
+                       username=username, logger=logger)
+        # need to use crab_input Rucio account to create containers and create rules
+        self.rucioAccount = 'crab_input'
+        tapeRecallConfig = copy.deepcopy(self.config)
+        tapeRecallConfig.Services.Rucio_account = self.rucioAccount
+        self.rucioClient = getNativeRucioClient(tapeRecallConfig, self.logger)  # pylint: disable=redefined-outer-name
+
+
+    def lockData(self, dataToLock=None):
+
+        """
+        lock input data on disk via a Rucio rule
+        """
+        if not isinstance(dataToLock, str) and not isinstance(dataToLock, list):
+            return
+
+        msg = f"Lock {dataToLock} on disk"
+        self.logger.info(msg)
+
+        # prepare container to be locked
+        if isinstance(dataToLock, str):
+            # recalling a full DBS dataset, simple the container already exists
+            myScope = 'cms'
+            dbsDatasetName = dataToLock
+            containerDid = {'scope': myScope, 'name': dbsDatasetName}
+        elif isinstance(dataToLock, list):
+            # need to prepare ad hoc container. Can not reuse a possibly existing one
+            # for this dataset which may have had a different content
+            # Therefore we stick with naming the container after the task name
+            myScope = f"user.{self.rucioAccount}"  # do not mess with cms scope
+            containerName = '/TapeRecall/%s/USER' % self.taskName.replace(':', '.')
+            containerDid = {'scope': myScope, 'name': containerName}
+            self.makeContainerFromBlockList(
+                rucio=self.rucioClient, blockList=dataToLock,
+                containerDid=containerDid)
+            # beware blockList being not subscriptable (e.g. dict_keys type)
+            dbsDatasetName = next(iter(dataToLock)).split('#')[0]
+        else:
+            return
+
+        # prepare comment to be inserted in the Rucio rule
+        partOf = "" if not isinstance(dataToLock, list) else "part of"
+        comment = f"Lock {partOf} dataset: {dbsDatasetName} for user: {self.username}"
+
+        # create rule
+        ruleId = self.createOrReuseRucioRule(did=containerDid, RSE_EXPRESSION='rse_type=DISK',
+                                             comment=comment, lifetime=TASKLIFETIME)
+        msg = f"Created Rucio rule ID: {ruleId}"
+        self.logger.info(msg)
+        return

--- a/src/python/TaskWorker/Actions/RucioActions.py
+++ b/src/python/TaskWorker/Actions/RucioActions.py
@@ -28,7 +28,6 @@ class RucioAction():
         self.taskName = taskName
         self.logger = logger
         self.username = username
-        # following two will be filled in inherited subclasses TapeRecaller and InputLocker
         self.rucioAccount = rucioAcccount
         myConfig = copy.deepcopy(self.config)
         myConfig.Services.Rucio_account = self.rucioAccount

--- a/src/python/TaskWorker/Actions/RucioActions.py
+++ b/src/python/TaskWorker/Actions/RucioActions.py
@@ -1,25 +1,25 @@
-import os
+"""
+a Class to perform Actions useful to TaskWorker via Rucio
+"""
 import random
 import copy
 from urllib.parse import urlencode
 from http.client import HTTPException
 
-
 from TaskWorker.WorkerExceptions import TaskWorkerException, TapeDatasetException
-
 from ServerUtilities import MAX_DAYS_FOR_TAPERECALL, MAX_TB_TO_RECALL_AT_A_SINGLE_SITE
 from ServerUtilities import TASKLIFETIME
-
 from RucioUtils import getNativeRucioClient
 
 from rucio.common.exception import (DuplicateRule, DataIdentifierAlreadyExists, DuplicateContent,
                                     InsufficientTargetRSEs, InsufficientAccountLimit, FullStorage)
 
+
 class RucioAction():
     """
-    performs action on tasks which require non trivial interaction with Rucio
-    contains a few common methods to the two classes tapeRecaller and inputLocker
-    acting as base class for those. Different actions may require different Rucio accounts
+    Instantiates an object to performs action on tasks in TW context
+    which require non trivial interaction with Rucio.
+    Allows for different actions to use different Rucio accounts
     """
     def __init__(self, config=None, crabserver=None, rucioAcccount=None,
                  taskName=None, username=None, logger=None):
@@ -46,37 +46,37 @@ class RucioAction():
             rucio.add_container(scope, containerName)
         except DataIdentifierAlreadyExists:
             self.logger.debug("Container name already exists in Rucio. Keep going")
-        except Exception as ex:
-            msg = "\nRucio exception creating container: %s" % (str(ex))
-            raise TaskWorkerException(msg) from ex
+        except Exception as e:
+            msg = f"\nRucio exception creating container: {e}"
+            raise TaskWorkerException(msg) from e
         # add block dids to container
         try:
             rucio.attach_dids(scope, containerName, dids)
         except DuplicateContent:
             self.logger.debug("Some dids are already in this container. Keep going")
-        except Exception as ex:
-            msg = "\nRucio exception adding blocks to container: %s" % (str(ex))
-            raise TaskWorkerException(msg) from ex
+        except Exception as e:
+            msg = f"\nRucio exception adding blocks to container: {e}"
+            raise TaskWorkerException(msg) from e
         self.logger.info("Rucio container %s:%s created with %d blocks", scope, containerName, len(blockList))
 
-
     def createOrReuseRucioRule(self, did=None, grouping=None,
-                               RSE_EXPRESSION='', comment='', lifetime=0):
+                               rseExpression='', comment='', lifetime=0):
+        """ if Rucio report duplicate rule exception, reuse exisitn one """
         # Some RSE_EXPR for testing
-        # RSE_EXPRESSION = 'ddm_quota>0&(tier=1|tier=2)&rse_type=DISK'
-        # RSE_EXPRESSION = 'T3_IT_Trieste' # for testing
-        WEIGHT = 'ddm_quota'  # only makes sense for rules which trigger replicas
-        # WEIGHT = None # for testing
-        ASK_APPROVAL = False
-        # ASK_APPROVAL = True # for testing
+        # rseExpression = 'ddm_quota>0&(tier=1|tier=2)&rse_type=DISK'
+        # rseExpression = 'T3_IT_Trieste' # for testing
+        weight = 'ddm_quota'  # only makes sense for rules which trigger replicas
+        # weight = None # for testing
+        askApproval = False
+        # askApproval = True # for testing
         copies = 1
         try:
             ruleIds = self.rucioClient.add_replication_rule(  # N.B. returns a list
-                dids=[did], copies=copies, rse_expression=RSE_EXPRESSION,
-                grouping=grouping, weight=WEIGHT, lifetime=lifetime,
+                dids=[did], copies=copies, rse_expression=rseExpression,
+                grouping=grouping, weight=weight, lifetime=lifetime,
                 account=self.rucioAccount, activity='Analysis Input',
                 comment=comment,
-                ask_approval=ASK_APPROVAL, asynchronous=True)
+                ask_approval=askApproval, asynchronous=True)
             ruleId = ruleIds[0]
         except DuplicateRule:
             # handle "A duplicate rule for this account, did, rse_expression, copies already exists"
@@ -91,20 +91,20 @@ class RucioAction():
                     break
             # extend rule lifetime
             self.rucioClient.update_replication_rule(ruleId, {'lifetime': lifetime})
-        except (InsufficientTargetRSEs, InsufficientAccountLimit, FullStorage) as ex:
-            msg = "\nNot enough global quota to issue a tape recall request. Rucio exception:\n%s" % str(ex)
-            raise TaskWorkerException(msg) from ex
-        except Exception as ex:
-            msg = "\nRucio exception creating rule: %s" % str(ex)
-            raise TaskWorkerException(msg) from ex
+        except (InsufficientTargetRSEs, InsufficientAccountLimit, FullStorage) as e:
+            msg = f"\nNot enough global quota to issue a tape recall request. Rucio exception:\n{e}"
+            raise TaskWorkerException(msg) from e
+        except Exception as e:
+            msg = f"\nRucio exception creating rule: {e}"
+            raise TaskWorkerException(msg) from e
 
         return ruleId
 
-
-    def whereToRecall(self, tapeLocations=None, TBtoRecall=0):
+    def whereToRecall(self, tapeLocations=None, teraBytesToRecall=0):
+        """ decide which RSE's to use """
         # make RSEs lists
         # asking for ddm_quota>0 gets rid also of Temp and Test RSE's
-        ALL_RSES = "ddm_quota>0&(tier=1|tier=2)&rse_type=DISK"
+        allRses = "ddm_quota>0&(tier=1|tier=2)&rse_type=DISK"
         # tune list according to where tapes are, we expect a single location
         # if there are more... let Rucio deal with them to find best route
         if tapeLocations:
@@ -112,11 +112,11 @@ class RucioAction():
                 tapeLocations.remove('T1_RU_JINR_Tape')  # JINR tape data are often duplicated
             if len(tapeLocations) == 1:
                 if 'US' in list(tapeLocations)[0]:
-                    ALL_RSES += "&(country=US|country=BR)"
+                    allRses += "&(country=US|country=BR)"
                 else:
                     # Rucio wants the set complement operator \
-                    ALL_RSES += "\country=US\country=BR"  # pylint: disable=anomalous-backslash-in-string
-        rses = self.rucioClient.list_rses(ALL_RSES)
+                    allRses += r"\country=US\country=BR"  # pylint: disable=anomalous-backslash-in-string
+        rses = self.rucioClient.list_rses(allRses)
         rseNames = [r['rse'] for r in rses]
         largeRSEs = []  # a list of largish (i.e. solid) RSEs
         for rse in rseNames:
@@ -130,22 +130,22 @@ class RucioAction():
                 largeRSEs.append(rse)
         # sort lists so that duplicated rules can be spotted
         largeRSEs.sort()
-        if TBtoRecall <= MAX_TB_TO_RECALL_AT_A_SINGLE_SITE:  #
+        if teraBytesToRecall <= MAX_TB_TO_RECALL_AT_A_SINGLE_SITE:  #
             grouping = 'ALL'
             self.logger.info("Will place all blocks at a single site")
-            RSE_EXPRESSION = '|'.join(largeRSEs)  # any solid site will do, most datasets are a few TB anyhow
+            rseExpression = '|'.join(largeRSEs)  # any solid site will do, most datasets are a few TB anyhow
         else:
             grouping = 'DATASET'  # Rucio DATASET i.e. CMS block !
             self.logger.info("Will scatter blocks on multiple sites")
             # restrict the list to as few sites as possible
-            nRSEs = int(TBtoRecall / MAX_TB_TO_RECALL_AT_A_SINGLE_SITE) + 1
+            nRSEs = int(teraBytesToRecall / MAX_TB_TO_RECALL_AT_A_SINGLE_SITE) + 1
             myRSEs = random.sample(largeRSEs, nRSEs)
-            RSE_EXPRESSION = '|'.join(myRSEs)
-        self.logger.debug('Will use RSE_EXPRESSION = %s', RSE_EXPRESSION)
-        return RSE_EXPRESSION, grouping
-
+            rseExpression = '|'.join(myRSEs)
+        self.logger.debug('Will use rseExpression = %s', rseExpression)
+        return rseExpression, grouping
 
     def setTaskToTapeRecall(self, ruleId='', msg=''):
+        """ set task status in TASK table of CRAB DB """
         tapeRecallStatus = 'TAPERECALL'
         configreq = {'workflow': self.taskName,
                      'taskstatus': tapeRecallStatus,
@@ -156,18 +156,15 @@ class RucioAction():
             tapeRecallStatusSet = self.crabserver.post(api='task', data=urlencode(configreq))
         except HTTPException as hte:
             self.logger.exception(hte)
-            msg = "HTTP Error while contacting the REST Interface %s:\n%s" % (
-                self.crabserver.server['host'], str(hte))
-            msg += "\nStoring of %s status and ruleId (%s) failed for task %s" % (
-                tapeRecallStatus, ruleId, self.taskName)
-            msg += "\nHTTP Headers are: %s" % hte.headers
+            msg = f"HTTP Error while contacting the REST Interface {self.crabserver.server['host']}:\n{hte}"
+            msg += f"\nStoring of {tapeRecallStatus} status and ruleId ({ruleId}) failed for task {self.taskName}"
+            msg += f"\nHTTP Headers are: {hte.headers}"
             raise TaskWorkerException(msg, retry=True) from hte
         if tapeRecallStatusSet[2] == "OK":
             self.logger.info("Status for task %s set to '%s'", self.taskName, tapeRecallStatus)
         msg += "\nThis task will be automatically submitted as soon as the stage-out is completed."
         self.uploadWarning(msg, self.userproxy, self.taskName)
         raise TapeDatasetException(msg)
-
 
     def recallData(self, dataToRecall=None, sizeToRecall=0, tapeLocations=None, msgHead=''):
 
@@ -177,16 +174,15 @@ class RucioAction():
         """
 
         # friendly units from bytes to TB
-        TBtoRecall = sizeToRecall // 1e12
+        teraBytesToRecall = sizeToRecall // 1e12
         # Sanity check
-        if TBtoRecall > 1e3:
-            msg = msgHead + f"\nDataset size {TBtoRecall} TB. Will not trigger automatic recall for >1PB. Contact DataOps"
+        if teraBytesToRecall > 1e3:
+            msg = msgHead + f"\nDataset size {teraBytesToRecall} TB. Will not trigger automatic recall for >1PB. Contact DataOps"
             raise TaskWorkerException(msg)
 
         # a friendly-formatted string to print the size
-        recallSize = f"{TBtoRecall:.0f} TBytes" if TBtoRecall > 0 else f"{sizeToRecall / 1e9:.0f} GBytes"
+        recallSize = f"{teraBytesToRecall:.0f} TBytes" if teraBytesToRecall > 0 else f"{sizeToRecall / 1e9:.0f} GBytes"
         self.logger.info("Total size of data to recall : %s", recallSize)
-
 
         # prepare container to be recalled
         if isinstance(dataToRecall, str):
@@ -201,7 +197,7 @@ class RucioAction():
             #  by other users for other reasons.
             #  Therefore we stick with naming the container after the task name
             myScope = f"user.{self.rucioAccount}"  # do not mess with cms scope
-            containerName = '/TapeRecall/%s/USER' % self.taskName.replace(':', '.')
+            containerName = f"/TapeRecall/{self.taskName.replace(':', '.')}/USER"
             containerDid = {'scope': myScope, 'name': containerName}
             self.makeContainerFromBlockList(blockList=dataToRecall, containerDid=containerDid)
             # beware blockList being not subscriptable (e.g. dict_keys type)
@@ -213,29 +209,27 @@ class RucioAction():
         comment = f"Recall {recallSize} for user: {self.username} dataset: {dbsDatasetName}"
 
         # define where to recall to, which depends also on where data are on tape
-        (RSE_EXPRESSION, grouping) = self.whereToRecall(tapeLocations=tapeLocations, TBtoRecall=TBtoRecall)
+        (rseExpression, grouping) = self.whereToRecall(tapeLocations=tapeLocations, teraBytesToRecall=teraBytesToRecall)
 
         # create rule
         # make rule last 7 extra days to allow debugging in case TW or Recall action fail
-        LIFETIME = (MAX_DAYS_FOR_TAPERECALL + 7) * 24 * 60 * 60  # in seconds
+        lifetime = (MAX_DAYS_FOR_TAPERECALL + 7) * 24 * 60 * 60  # in seconds
         ruleId = self.createOrReuseRucioRule(did=containerDid, grouping=grouping,
-                                             RSE_EXPRESSION=RSE_EXPRESSION,
-                                             comment=comment, lifetime=LIFETIME)
+                                             rseExpression=rseExpression,
+                                             comment=comment, lifetime=lifetime)
         msg = f"Created Rucio rule ID: {ruleId}"
         self.logger.info(msg)
 
         # this will be printed by "crab status"
         msg = msgHead
         msg += "\nA disk replica has been requested to Rucio.  Check progress via:"
-        msg += "\n  rucio rule-info %s" % ruleId
-        msg += "\nor simply check 'state' line in this page: https://cms-rucio-webui.cern.ch/rule?rule_id=%s" % ruleId
+        msg += f"\n  rucio rule-info {ruleId}"
+        msg += f"\nor simply check 'state' line in this page: https://cms-rucio-webui.cern.ch/rule?rule_id={ruleId}"
 
         # update task status in CRAB DB and store the rule ID
         self.setTaskToTapeRecall(ruleId=ruleId, msg=msg)
 
         return
-
-
 
     def lockData(self, dataToLock=None):
 
@@ -259,7 +253,7 @@ class RucioAction():
             # for this dataset which may have had a different content
             # Therefore we stick with naming the container after the task name
             myScope = f"user.{self.rucioAccount}"  # do not mess with cms scope
-            containerName = '/TapeRecall/%s/USER' % self.taskName.replace(':', '.')
+            containerName = f"/TapeRecall/{self.taskName.replace(':', '.')}/USER"
             containerDid = {'scope': myScope, 'name': containerName}
             self.makeContainerFromBlockList(
                 rucio=self.rucioClient, blockList=dataToLock,
@@ -274,7 +268,7 @@ class RucioAction():
         comment = f"Lock {partOf} dataset: {dbsDatasetName} for user: {self.username}"
 
         # create rule
-        ruleId = self.createOrReuseRucioRule(did=containerDid, RSE_EXPRESSION='rse_type=DISK',
+        ruleId = self.createOrReuseRucioRule(did=containerDid, rseExpression='rse_type=DISK',
                                              comment=comment, lifetime=TASKLIFETIME)
         msg = f"Created Rucio rule ID: {ruleId}"
         self.logger.info(msg)


### PR DESCRIPTION
This is a first step toward https://github.com/dmwm/CRABServer/issues/7733
At this time I'd like to have feedback on the separation of code in two files, the class definition/use etc.

Maybe a single class should be better ? I am not very happy with two classes which only differ on the name of the Rucio account they use internally. But this is the first time I create classes, with inheritance as well.. so I am sure I did in a way which could be vastly improved.

This is supposed not to change functionality wrt what is in v3.230712 and I have done some limited testing using the internal `main()` method. 

Once we have settled on the design, I will tackle remaining pylint issues, which looks straighforward.

Thanks !