### PR TITLE
RUCIO_Transfers.py: fix creating new dataset only when needed and close when time passes

### DIFF
--- a/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
+++ b/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
@@ -137,6 +137,10 @@ class MonitorLockStatus:
             elif shouldClose:
                 self.logger.info(f'Closing dataset: {dataset}')
                 self.rucioClient.close(self.transfer.rucioScope, dataset)
+                for f in v:
+                    newF = copy.deepcopy(f)
+                    newF['blockcomplete'] = 'OK'
+                    tmpFileDocs.append(newF)
             else:
                 self.logger.info(f'Dataset {dataset} is still open.')
         return tmpFileDocs

--- a/src/python/ASO/Rucio/Actions/RegisterReplicas.py
+++ b/src/python/ASO/Rucio/Actions/RegisterReplicas.py
@@ -164,9 +164,9 @@ class RegisterReplicas:
                 newFileDocs.append(r)
 
         b = BuildDBSDataset(self.transfer, self.rucioClient)
-        currentDataset = b.getOrCreateDataset(container)
-        self.logger.debug(f'currentDataset: {currentDataset}')
         for chunk in chunks(newFileDocs, config.args.replicas_chunk_size):
+            currentDataset = b.getOrCreateDataset(container)
+            self.logger.debug(f'currentDataset: {currentDataset}')
             dids = [{
                 'scope': self.transfer.rucioScope,
                 'type': "FILE",
@@ -197,8 +197,6 @@ class RegisterReplicas:
             if num >= config.args.max_file_per_dataset:
                 self.logger.info(f'Closing dataset: {currentDataset}')
                 self.rucioClient.close(self.transfer.rucioScope, currentDataset)
-                currentDataset = b.getOrCreateDataset(container)
-                self.logger.debug(f'currentDataset: {currentDataset}')
         return containerFileDocs
 
 

--- a/src/python/ASO/Rucio/Main.py
+++ b/src/python/ASO/Rucio/Main.py
@@ -50,6 +50,8 @@ def main():
     opt.add_argument("--ignore-transfer-ok", dest="ignore_transfer_ok",
                      action='store_true',
                      help="")
+    opt.add_argument("--open-dataset-timeout", dest="open_dataset_timeout", default=6*60*60, type=int, # 6 hours
+                     help="Open dataset timeout in seconds")
     opts = opt.parse_args()
 
     # Put args to config module to share variable across process.


### PR DESCRIPTION
Fix closing dataset issue from [this comment](https://github.com/dmwm/CRABServer/issues/7632#issuecomment-1600582552) (first checkbox).
Creating new dataset only when needed and close when time passes (default 6 hours).