### PR TITLE
RUCIO_Transfers.py: skip logfiles transfer

### DIFF
--- a/src/python/ASO/Rucio/Actions/RegisterReplicas.py
+++ b/src/python/ASO/Rucio/Actions/RegisterReplicas.py
@@ -36,7 +36,8 @@ class RegisterReplicas:
         transferGenerator = itertools.islice(self.transfer.transferItems, start, end)
 
         # Prepare
-        preparedReplicasByRSE = self.prepare(transferGenerator)
+        transferItemsWithoutLogfile = self.skipLogTransfers(transferGenerator)
+        preparedReplicasByRSE = self.prepare(transferItemsWithoutLogfile)
         # Add file to rucio by RSE
         successFileDocs = self.addFilesToRucio(preparedReplicasByRSE)
         self.logger.debug(f'successFileDocs: {successFileDocs}')
@@ -46,6 +47,43 @@ class RegisterReplicas:
         self.updateRESTFileDocStateToSubmitted(successFileDocs)
         # After everything is done, bookkeeping LastTransferLine.
         self.transfer.updateLastTransferLine(end)
+
+    def skipLogTransfers(self, transfers):
+        """
+        Temporary solution for filter out logfiles from transferItems when task
+        has `tm_save_logs=T`. Force status logfiles in filetransfersdb to "DONE"
+        (required by PostJob).
+
+        Until we proper implement logs transfers with rucio later.
+
+        :param transfers: iterator of transfers dict
+        :type transfers: list of dict
+
+        :return: new transfers object where logfiles are removed.
+        :rtype: list of dict
+        """
+        newTransfers = []
+        logFileDocs = []
+        for xdict in transfers:
+            if xdict["type"] == 'log':
+                self.logger.info(f'Skipping {xdict["source_lfn"]}. Logs file transfer is not implemented.')
+                logFileDocs.append(xdict['id'])
+            else:
+                newTransfers.append(xdict)
+        num = len(logFileDocs)
+        restFileDoc = {
+            'asoworker': 'rucio',
+            'list_of_ids': [x for x in logFileDocs],
+            'list_of_transfer_state': ['DONE']*num,
+            'list_of_dbs_blockname': None,
+            'list_of_block_complete': None,
+            'list_of_fts_instance': ['https://fts3-cms.cern.ch:8446/']*num,
+            'list_of_failure_reason': None, # omit
+            'list_of_retry_value': None, # omit
+            'list_of_fts_id': ['NA']*num,
+        }
+        uploadToTransfersdb(self.crabRESTClient, 'filetransfers', 'updateTransfers', restFileDoc, self.logger)
+        return newTransfers
 
     def prepare(self, transfers):
         """


### PR DESCRIPTION
We need to skip logfile entries in `transfers.txt` but we need to update transfers state to `DONE` in order to make PostJob.py work properly. This is a bit hack but it easier than change code in PostJob.py.