### PR TITLE
RUCIO_Transfers.py: read transfer info from file that need to publish and filter out not-to-publish files from publish container

### DIFF
--- a/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
+++ b/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
@@ -26,8 +26,10 @@ class MonitorLockStatus:
         self.logger.debug(f'okFileDocs: {okFileDocs}')
         self.logger.debug(f'notOKFileDocs: {notOKFileDocs}')
 
+        needToPublishFileDocs = self.filterFilesNeedToPublish(okFileDocs)
+        self.logger.debug(f'needToPublishFileDocs: {needToPublishFileDocs}')
         # Register transfer complete replicas to publish container.
-        publishedFileDocs = self.registerToPublishContainer(okFileDocs)
+        publishedFileDocs = self.registerToPublishContainer(needToPublishFileDocs)
         self.logger.debug(f'publishedFileDocs: {publishedFileDocs}')
         # update fileDoc for ok filedocs
         self.updateRESTFileDocsStateToDone(publishedFileDocs)
@@ -66,7 +68,7 @@ class MonitorLockStatus:
             if lock['name'] in self.transfer.transferOKReplicas:
                 continue
             fileDoc = {
-                'id': self.transfer.replicaLFN2IDMap[lock['name']],
+                'id': self.transfer.LFN2transferItemMap[lock['name']]['id'],
                 'name': lock['name'],
                 'dataset': None,
                 'blockcomplete': 'NO',
@@ -130,6 +132,23 @@ class MonitorLockStatus:
                     tmpFileDocs.append(item)
 
         return tmpFileDocs
+
+    def filterFilesNeedToPublish(self, fileDocs):
+        """
+        Return only fileDocs that need to publish by publisher
+
+        :param fileDocs: list of fileDoc
+        :type fileDocs: list of dict
+
+        :return: fileDocs
+        :rtype: list of dict
+        """
+        tmpPublishFileDocs = []
+        for doc in fileDocs:
+            transferItem = self.transfer.LFN2transferItemMap[doc['name']]
+            if transferItem['delayed_publicationflag_update']:
+                tmpPublishFileDocs.append(doc)
+        return tmpPublishFileDocs
 
     def updateRESTFileDocsStateToDone(self, fileDocs):
         """

--- a/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
+++ b/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
@@ -135,7 +135,9 @@ class MonitorLockStatus:
 
     def filterFilesNeedToPublish(self, fileDocs):
         """
-        Return only fileDocs that need to publish by publisher
+        Return only fileDoc that need to publish by publisher.
+        Use the fact that non-edm files and logfiles will have '/FakeDataset'
+        as outputdataset.
 
         :param fileDocs: list of fileDoc
         :type fileDocs: list of dict
@@ -146,7 +148,7 @@ class MonitorLockStatus:
         tmpPublishFileDocs = []
         for doc in fileDocs:
             transferItem = self.transfer.LFN2transferItemMap[doc['name']]
-            if transferItem['delayed_publicationflag_update']:
+            if not transferItem['outputdataset'].startswith('/FakeDataset'):
                 tmpPublishFileDocs.append(doc)
         return tmpPublishFileDocs
 

--- a/src/python/ASO/Rucio/Transfer.py
+++ b/src/python/ASO/Rucio/Transfer.py
@@ -139,7 +139,18 @@ class Transfer:
         Convert info from first transferItems to this object attribute.
         Need to execute readTransferItems before this method.
         """
+        # Need to get publish container name from the file that need to publish.
         info = self.transferItems[0]
+        firstJobID = info['job_id']
+        for t in self.transferItems:
+            # break the loop and use first transfers.txt in case there is no
+            # file need to publish.
+            if t['job_id'] != firstJobID:
+                break
+            if t['delayed_publicationflag_update']:
+                info = t
+                break
+
         self.username = info['username']
         self.rucioScope = f'user.{self.username}'
         self.destination = info['destination']

--- a/src/python/ASO/Rucio/Transfer.py
+++ b/src/python/ASO/Rucio/Transfer.py
@@ -38,8 +38,8 @@ class Transfer:
         self.containerRuleID = ''
         self.bookkeepingOKLocks = None
 
-        # map lfn to id
-        self.replicaLFN2IDMap = None
+        # map of lfn to original info in transferItems
+        self.LFN2transferItemMap = None
 
     def readInfo(self):
         """
@@ -54,6 +54,7 @@ class Transfer:
         self.readLastTransferLine()
         self.readTransferItems()
         self.buildLFN2IDMap()
+        self.buildLFN2transferItem()
         self.readRESTInfo()
         self.readInfoFromTransferItems()
         self.readContainerRuleID()
@@ -111,14 +112,13 @@ class Transfer:
         if len(self.transferItems) == 0:
             raise RucioTransferException(f'{path} does not contain new entry.')
 
-    def buildLFN2IDMap(self):
+    def buildLFN2transferItemMap(self):
         """
-        Create `self.replicaLFN2IDMap` map from LFN to REST ID using using info
-        in self.transferItems
+        Create map from LFN to transferItem
         """
-        self.replicaLFN2IDMap = {}
+        self.LFN2transferItemMap = {}
         for x in self.transferItems:
-            self.replicaLFN2IDMap[x['destination_lfn']] = x['id']
+            self.LFN2transferItemMap[x['destination_lfn']] = x
 
     def readRESTInfo(self):
         """

--- a/src/python/ASO/Rucio/Transfer.py
+++ b/src/python/ASO/Rucio/Transfer.py
@@ -139,15 +139,10 @@ class Transfer:
         Convert info from first transferItems to this object attribute.
         Need to execute readTransferItems before this method.
         """
-        # Need to get publish container name from the file that need to publish.
+        # Get publish container name from the file that need to publish.
         info = self.transferItems[0]
-        firstJobID = info['job_id']
         for t in self.transferItems:
-            # break the loop and use first transfers.txt in case there is no
-            # file need to publish.
-            if t['job_id'] != firstJobID:
-                break
-            if t['delayed_publicationflag_update']:
+            if t['outputdataset'].startswith('/FakeDataset'):
                 info = t
                 break
 

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -821,7 +821,6 @@ class ASOServerJob(object):
                            'publication_state': 'not_published',
                            'publication_retry_count': [],
                            'type': file_type,
-                           'delayed_publicationflag_update' : delayed_publicationflag_update,
                           }
                     ## TODO: We do the following, only because that's what ASO does when a file has
                     ## been successfully transferred. But this modified LFN makes no sence when it
@@ -981,8 +980,6 @@ class ASOServerJob(object):
                 newDoc['destination'] = doc['destination']
             if not 'outputdataset' in newDoc:
                 newDoc['outputdataset'] = doc['outputdataset']
-            if not 'delayed_publicationflag_update' in  newDoc:
-                newDoc['delayed_publicationflag_update'] = doc['delayed_publicationflag_update']
             with open('task_process/transfers.txt', 'a+') as transfers_file:
                 transfer_dump = json.dumps(newDoc)
                 transfers_file.write(transfer_dump+"\n")

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -821,6 +821,7 @@ class ASOServerJob(object):
                            'publication_state': 'not_published',
                            'publication_retry_count': [],
                            'type': file_type,
+                           'delayed_publicationflag_update' : delayed_publicationflag_update,
                           }
                     ## TODO: We do the following, only because that's what ASO does when a file has
                     ## been successfully transferred. But this modified LFN makes no sence when it
@@ -980,6 +981,8 @@ class ASOServerJob(object):
                 newDoc['destination'] = doc['destination']
             if not 'outputdataset' in newDoc:
                 newDoc['outputdataset'] = doc['outputdataset']
+            if not 'delayed_publicationflag_update' in  newDoc:
+                newDoc['delayed_publicationflag_update'] = doc['delayed_publicationflag_update']
             with open('task_process/transfers.txt', 'a+') as transfers_file:
                 transfer_dump = json.dumps(newDoc)
                 transfers_file.write(transfer_dump+"\n")


### PR DESCRIPTION
Fix https://github.com/dmwm/CRABServer/issues/7741