### PR TITLE
RUCIO_Transfers.py: Fix bookkeeping block complete

### DIFF
--- a/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
+++ b/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
@@ -47,7 +47,7 @@ class MonitorLockStatus:
         self.logger.debug(f'fileDocs to update block completion: {blockCompleteFileDocs}')
         self.updateRESTFileDocsBlockCompletionInfo(blockCompleteFileDocs)
         # Bookkeeping published replicas (only replicas with blockcomplete "ok")
-        newBlockComplete = list({doc['dataset'] for doc in self.transfer.bookkeepingBlockComplete})
+        newBlockComplete = list({doc['dataset'] for doc in blockCompleteFileDocs})
         self.transfer.updateBlockComplete(newBlockComplete)
 
     def checkLockStatus(self):

--- a/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
+++ b/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
@@ -31,12 +31,13 @@ class MonitorLockStatus:
         self.updateRESTFileDocsStateToDone(newDoneFileDocs)
         self.transfer.updateOKLocks([x['name'] for x in newDoneFileDocs])
 
-        # move publication to filedocs
+        # Filter only files need to publish
         needToPublishFileDocs = self.filterFilesNeedToPublish(okFileDocs)
         self.logger.debug(f'needToPublishFileDocs: {needToPublishFileDocs}')
         # Register transfer complete replicas to publish container.
-        # Note that for replica that already add to publish container will do
-        # nothing but return fileDoc with the block name.
+        # Note that replicas that already add to publish container will do
+        # nothing but return fileDoc containing the block name replica belongs
+        # to.
         publishedFileDocs = self.registerToPublishContainer(needToPublishFileDocs)
         self.logger.debug(f'publishedFileDocs: {publishedFileDocs}')
         # skip filedocs that already update it status to rest.

--- a/src/python/ASO/Rucio/Main.py
+++ b/src/python/ASO/Rucio/Main.py
@@ -50,7 +50,13 @@ def main():
     opt.add_argument("--ignore-transfer-ok", dest="ignore_transfer_ok",
                      action='store_true',
                      help="")
-    opt.add_argument("--open-dataset-timeout", dest="open_dataset_timeout", default=6*60*60, type=int, # 6 hours
+    opt.add_argument("--bookkeeping-block-complete-path", dest="bookkeeping_block_complete_path",
+                     default='task_process/transfers/block_complete.txt',
+                     help="")
+    opt.add_argument("--ignore-bookkeeping-block-complete", dest="ignore_bookkeeping_block_complete",
+                     action='store_true',
+                     help="")
+    opt.add_argument("--open-dataset-timeout", dest="open_dataset_timeout", default=2*60*60, type=int, # 6 hours
                      help="Open dataset timeout in seconds")
     opts = opt.parse_args()
 

--- a/src/python/ASO/Rucio/Transfer.py
+++ b/src/python/ASO/Rucio/Transfer.py
@@ -218,6 +218,40 @@ class Transfer:
             for l in self.bookkeepingOKLocks:
                 w.write(f'{l}\n')
 
+    def readBlockComplete(self):
+        """
+        Read bookkeepingBlockComplete from task_process/transfers/transfers_ok.txt.
+        Initialize empty list in case of path not found or
+        `--ignore-transfer-ok` is `True`.
+        """
+        if config.args.ignore_bookkeeping_block_complete:
+            self.bookkeepingBlockComplete = []
+            return
+        path = config.args.bookkeeping_block_complete_path
+        try:
+            with open(path, 'r', encoding='utf-8') as r:
+                self.bookkeepingBlockComplete = r.read().splitlines()
+                self.logger.info(f'Got list of block complete from bookkeeping: {self.bookkeepingBlockComplete}')
+        except FileNotFoundError:
+            self.bookkeepingBlockComplete = []
+            self.logger.info(f'Bookkeeping block complete path "{path}" does not exist. Assume this is first time it run.')
+
+    def updateBlockComplete(self, newLocks):
+        """
+        update bookkeepingBlockComplete to task_process/transfers/transfers_ok.txt
+
+        :param newLocks: list of LFN
+        :type newLocks: list of string
+        """
+        self.bookkeepingBlockComplete += newLocks
+        path = config.args.bookkeeping_block_complete_path
+        self.logger.info (f'Bookkeeping block complete to file: {path}')
+        self.logger.debug(f'{self.bookkeepingBlockComplete}')
+        with writePath(path) as w:
+            for l in self.bookkeepingBlockComplete:
+                w.write(f'{l}\n')
+
+
     def populateLFN2DatasetMap(self, container, rucioClient):
         """
         Get the list of replicas in the container and return as key-value pair

--- a/src/python/ASO/Rucio/Transfer.py
+++ b/src/python/ASO/Rucio/Transfer.py
@@ -237,14 +237,14 @@ class Transfer:
             self.bookkeepingBlockComplete = []
             self.logger.info(f'Bookkeeping block complete path "{path}" does not exist. Assume this is first time it run.')
 
-    def updateBlockComplete(self, newLocks):
+    def updateBlockComplete(self, newBlocks):
         """
         update bookkeepingBlockComplete to task_process/transfers/transfers_ok.txt
 
-        :param newLocks: list of LFN
-        :type newLocks: list of string
+        :param newBlocks: list of LFN
+        :type newBlocks: list of string
         """
-        self.bookkeepingBlockComplete += newLocks
+        self.bookkeepingBlockComplete += newBlocks
         path = config.args.bookkeeping_block_complete_path
         self.logger.info (f'Bookkeeping block complete to file: {path}')
         self.logger.debug(f'{self.bookkeepingBlockComplete}')

--- a/src/python/ASO/Rucio/Transfer.py
+++ b/src/python/ASO/Rucio/Transfer.py
@@ -37,6 +37,7 @@ class Transfer:
         self.lastTransferLine = 0
         self.containerRuleID = ''
         self.bookkeepingOKLocks = None
+        self.bookkeepingBlockComplete = None
 
         # map of lfn to original info in transferItems
         self.LFN2transferItemMap = None
@@ -53,12 +54,12 @@ class Transfer:
         # read into memory
         self.readLastTransferLine()
         self.readTransferItems()
-        self.buildLFN2IDMap()
-        self.buildLFN2transferItem()
+        self.buildLFN2transferItemMap()
         self.readRESTInfo()
         self.readInfoFromTransferItems()
         self.readContainerRuleID()
         self.readOKLocks()
+        self.readBlockComplete()
 
     def readInfoFromRucio(self, rucioClient):
         """


### PR DESCRIPTION
Untangle MonitorLockStatus actions and break into 2 steps:
- Monitoring transfer status and update status "DONE" to the REST.
- Add new successful transfer replica to publish container.

Bookkeeping and readability is much more cleaner now.