### PR TITLE
Fix WebUI to display Rucio URL to the rule

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -256,7 +256,7 @@
                                     <th>CRAB job ID</th>
                                     <th>File ID</th>
                                     <th>Transfer State</th>
-                                    <th>FTS job</th>
+                                    <th>ASO job</th>
                                     <th>Duration [min]</th>
                                 </tr>
 							</thead>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -256,7 +256,7 @@
                                     <th>CRAB job ID</th>
                                     <th>File ID</th>
                                     <th>Transfer State</th>
-                                    <th>ASO job</th>
+                                    <th>FTS Job / Rucio Rule</th>
                                     <th>Duration [min]</th>
                                 </tr>
 							</thead>

--- a/src/python/Databases/FileTransfersDB/Oracle/FileTransfers/FileTransfers.py
+++ b/src/python/Databases/FileTransfersDB/Oracle/FileTransfers/FileTransfers.py
@@ -249,7 +249,7 @@ class FileTransfers(object):
                    FROM filetransfersdb where tm_id = :id"
 
 # As jobs can be retried we should look only at the last ones. For that specific case this needs to be relooked.
-    GetTaskStatusForTransfers_sql = "SELECT tm_id, tm_jobid, tm_transfer_state, tm_start_time, tm_last_update, tm_fts_id, tm_fts_instance FROM filetransfersdb \
+    GetTaskStatusForTransfers_sql = "SELECT tm_id, tm_jobid, tm_transfer_state, tm_start_time, tm_last_update, tm_fts_id, tm_fts_instance, tm_aso_worker FROM filetransfersdb \
                                      WHERE tm_username = :username AND tm_taskname = :taskname"  # ORDER BY tm_job_retry_count"
     GetTaskStatusForPublication_sql = "SELECT tm_id, tm_jobid, tm_publication_state, tm_start_time, tm_last_update FROM filetransfersdb \
                                        WHERE tm_username = :username AND tm_taskname = :taskname"  # ORDER BY tm_job_retry_count"
@@ -259,4 +259,3 @@ class FileTransfers(object):
 
     GetActiveUserPublications_sql = "SELECT t.tm_username, t.tm_user_role, t.tm_user_group, count(*) FROM filetransfersdb f LEFT OUTER JOIN tasks t ON t.tm_taskname = f.tm_taskname \
                                        WHERE (tm_publication_state=0 OR tm_publication_state = 1) AND tm_aso_worker=:asoworker AND tm_publish = 1 GROUP BY t.tm_username,t.tm_user_role,t.tm_user_group"
-

--- a/src/script/task_info.js
+++ b/src/script/task_info.js
@@ -462,14 +462,14 @@ $(document).ready(function() {
                                     data.result[k][index["tm_fts_id"]] + "> " +
                                     data.result[k][index["tm_fts_id"]] +
                                     " </a>"
-							} else {
+                            }  else {
                                 fts_href = "<a href=" +
                                     data.result[k][index["tm_fts_instance"]].replace("8446","8449") +
                                     "/fts3/ftsmon/#/job/" +
                                     data.result[k][index["tm_fts_id"]] + "> " +
                                     data.result[k][index["tm_fts_id"]] +
                                     " </a>"
-							}
+                            }
                         }
                         content = [
                             data.result[k][index["tm_jobid"]],

--- a/src/script/task_info.js
+++ b/src/script/task_info.js
@@ -456,18 +456,18 @@ $(document).ready(function() {
                         doc_href = "<a href=" + doc_url + "> " + data.result[k][index["tm_id"]] + " </a>"
                         fts_href = null
                         if (data.result[k][index["tm_fts_instance"]]){
-							if (data.result[k][index["tm_aso_worker"]] === "rucio") {
-								fts_href = "<a href=" +
-                                        "https://cms-rucio-webui.cern.ch/rule?rule_id=" +
-                                        data.result[k][index["tm_fts_id"]] + "> " +
-                                        data.result[k][index["tm_fts_id"]] +
+                            if (data.result[k][index["tm_aso_worker"]] === "rucio") {
+                                fts_href = "<a href=" +
+                                    "https://cms-rucio-webui.cern.ch/rule?rule_id=" +
+                                    data.result[k][index["tm_fts_id"]] + "> " +
+                                    data.result[k][index["tm_fts_id"]] +
                                     " </a>"
 							} else {
                                 fts_href = "<a href=" +
-                                        data.result[k][index["tm_fts_instance"]].replace("8446","8449") +
-                                        "/fts3/ftsmon/#/job/" +
-                                        data.result[k][index["tm_fts_id"]] + "> " +
-                                        data.result[k][index["tm_fts_id"]] +
+                                    data.result[k][index["tm_fts_instance"]].replace("8446","8449") +
+                                    "/fts3/ftsmon/#/job/" +
+                                    data.result[k][index["tm_fts_id"]] + "> " +
+                                    data.result[k][index["tm_fts_id"]] +
                                     " </a>"
 							}
                         }

--- a/src/script/task_info.js
+++ b/src/script/task_info.js
@@ -456,12 +456,20 @@ $(document).ready(function() {
                         doc_href = "<a href=" + doc_url + "> " + data.result[k][index["tm_id"]] + " </a>"
                         fts_href = null
                         if (data.result[k][index["tm_fts_instance"]]){
-                            fts_href = "<a href=" +
-                                    data.result[k][index["tm_fts_instance"]].replace("8446","8449") +
-                                    "/fts3/ftsmon/#/job/" +
-                                    data.result[k][index["tm_fts_id"]] + "> " +
-                                    data.result[k][index["tm_fts_id"]] +
-                                " </a>"
+							if (data.result[k][index["tm_aso_worker"]] === "rucio") {
+								fts_href = "<a href=" +
+                                        "https://cms-rucio-webui.cern.ch/rule?rule_id=" +
+                                        data.result[k][index["tm_fts_id"]] + "> " +
+                                        data.result[k][index["tm_fts_id"]] +
+                                    " </a>"
+							} else {
+                                fts_href = "<a href=" +
+                                        data.result[k][index["tm_fts_instance"]].replace("8446","8449") +
+                                        "/fts3/ftsmon/#/job/" +
+                                        data.result[k][index["tm_fts_id"]] + "> " +
+                                        data.result[k][index["tm_fts_id"]] +
+                                    " </a>"
+							}
                         }
                         content = [
                             data.result[k][index["tm_jobid"]],


### PR DESCRIPTION
Subtask of https://github.com/dmwm/CRABServer/issues/7797

Now you can click link in "Transfer Info" tab -> "ASO job" column, to go to Rucio Web UI to see the rule status.

![Screenshot from 2023-08-08 15-29-22](https://github.com/dmwm/CRABServer/assets/2346664/ac59f30e-0fc4-4dac-8786-8abfea39c029)
