### PR TITLE
RUCIO_Transfers.py: fix pylint before merge to master

### DIFF
--- a/scripts/task_process/RUCIO_Transfers.py
+++ b/scripts/task_process/RUCIO_Transfers.py
@@ -1,5 +1,9 @@
 #! /usr/bin/python
 
+"""
+Entrypoint of Rucio ASO
+"""
+
 from ASO.Rucio.Main import main
 
 if __name__ == "__main__":

--- a/src/python/ASO/Rucio/Actions/BuildDBSDataset.py
+++ b/src/python/ASO/Rucio/Actions/BuildDBSDataset.py
@@ -1,3 +1,6 @@
+"""
+Create Rucio's container and dataset.
+"""
 import logging
 import uuid
 
@@ -7,7 +10,7 @@ from ASO.Rucio.exception import RucioTransferException
 
 class BuildDBSDataset():
     """
-    Create Rucio's container and dataset.
+    Class to create Rucio's container and dataset.
 
     :param transfer: Transfer Object to get infomation.
     :type object: class:`ASO.Rucio.Transfer`
@@ -104,7 +107,7 @@ class BuildDBSDataset():
             metadata = []
             for ds in datasets:
                 metadata.append(self.rucioClient.get_metadata(self.transfer.rucioScope, ds["name"]))
-        openDatasets = [md['name'] for md in metadata if md['is_open'] == True]
+        openDatasets = [md['name'] for md in metadata if md['is_open']]
         self.logger.debug(f"open datasets: {datasets}")
         if len(openDatasets) == 0:
             self.logger.info("No dataset available yet, creating one")

--- a/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
+++ b/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
@@ -1,8 +1,11 @@
+"""
+Monitoring replicas' transfer status and adding them to publish the container.
+"""
 import logging
 import copy
 import datetime
 
-import ASO.Rucio.config as config
+import ASO.Rucio.config as config # pylint: disable=consider-using-from-import
 from ASO.Rucio.utils import uploadToTransfersdb
 from ASO.Rucio.Actions.RegisterReplicas import RegisterReplicas
 

--- a/src/python/ASO/Rucio/Actions/RegisterReplicas.py
+++ b/src/python/ASO/Rucio/Actions/RegisterReplicas.py
@@ -1,11 +1,14 @@
+"""
+Registering files to Rucio.
+"""
+
 import logging
 import itertools
 import copy
-from ASO.Rucio.Actions.BuildDBSDataset import BuildDBSDataset
 from rucio.rse.rsemanager import find_matching_scheme
-from rucio.common.exception import FileAlreadyExists
 
-import ASO.Rucio.config as config
+import ASO.Rucio.config as config # pylint: disable=consider-using-from-import
+from ASO.Rucio.Actions.BuildDBSDataset import BuildDBSDataset
 from ASO.Rucio.exception import RucioTransferException
 from ASO.Rucio.utils import chunks, uploadToTransfersdb, tfcLFN2PFN, LFNToPFNFromPFN
 
@@ -73,7 +76,7 @@ class RegisterReplicas:
         num = len(logFileDocs)
         restFileDoc = {
             'asoworker': 'rucio',
-            'list_of_ids': [x for x in logFileDocs],
+            'list_of_ids': logFileDocs,
             'list_of_transfer_state': ['DONE']*num,
             'list_of_dbs_blockname': None,
             'list_of_block_complete': None,
@@ -111,7 +114,7 @@ class RegisterReplicas:
             if not rse in bucket:
                 bucket[rse] = []
             bucket[rse].append(xdict)
-        for rse in bucket:
+        for rse, _ in bucket.items():
             xdict = bucket[rse][0]
             # We determine PFN of Temp RSE from normal RSE.
             # Simply remove temp suffix before passing to getSourcePFN function.

--- a/src/python/ASO/Rucio/Main.py
+++ b/src/python/ASO/Rucio/Main.py
@@ -1,11 +1,18 @@
+"""
+Main module.
+"""
+
 import logging
 from argparse import ArgumentParser
 
-import ASO.Rucio.config as config
+import ASO.Rucio.config as config # pylint: disable=consider-using-from-import
 from ASO.Rucio.RunTransfer import RunTransfer
 from ASO.Rucio.exception import RucioTransferException
 
 def initLogger():
+    """
+    Initialize root logger
+    """
     logger = logging.getLogger('RucioTransfer')
     logger.setLevel(logging.DEBUG)
     hldr = logging.StreamHandler()

--- a/src/python/ASO/Rucio/RunTransfer.py
+++ b/src/python/ASO/Rucio/RunTransfer.py
@@ -1,3 +1,7 @@
+"""
+Initialize neccessary clients, put all actions together and execute it.
+"""
+
 import logging
 import os
 from rucio.client.client import Client as RucioClient
@@ -8,6 +12,7 @@ from ASO.Rucio.exception import RucioTransferException
 from ASO.Rucio.Actions.BuildDBSDataset import BuildDBSDataset
 from ASO.Rucio.Actions.RegisterReplicas import RegisterReplicas
 from ASO.Rucio.Actions.MonitorLockStatus import MonitorLockStatus
+
 
 class RunTransfer:
     """
@@ -49,7 +54,19 @@ class RunTransfer:
         # do 2
         MonitorLockStatus(self.transfer, self.rucioClient, self.crabRESTClient).execute()
 
-    def _initRucioClient(self, username, proxypath=None):
+    def _initRucioClient(self, username, proxypath='/tmp/x509_uXXXX'):
+        """
+        Initialize Rucio client. Note that X509_USER_PROXY has higher
+        precedence than `proxypath` variable.
+
+        :param username: username
+        :type username: string
+        :param proxypath: x509 proxyfile path
+        :type proxypath: string
+
+        :return: rucio client object
+        :rtype: rucio.client.client.Client
+        """
         # maybe we can share with getNativeRucioClient
         rucioLogger = logging.getLogger('RucioTransfer.RucioClient')
         rucioLogger.setLevel(logging.INFO)
@@ -69,9 +86,20 @@ class RunTransfer:
         self.logger.debug(f'RucioClient.whoami(): {rc.whoami()}')
         return rc
 
-    def _initCrabRESTClient(self, host, dbInstance, proxypath='/tmp/x509_u999999'):
+    def _initCrabRESTClient(self, host, dbInstance, proxypath='/tmp/x509_uXXXX'):
         """
-        Initialize client for CRAB REST
+        Initialize CRAB REST client.
+
+        :param host: hostname and port of REST instance,
+            e.g. `cmsweb-test12.cern.ch:8443`
+        :type host: string
+        :param dbInstance: database instance name e.g. `devthree`
+        :type dbInstance: string
+        :param proxypath: x509 proxyfile path
+        :type proxypath: string
+
+        :return: rest client object
+        :rtype: RESTInteractions.CRABRest
         """
         restLogger = logging.getLogger('RucioTransfer.RESTClient')
         restLogger.setLevel(logging.DEBUG)

--- a/src/python/ASO/Rucio/Transfer.py
+++ b/src/python/ASO/Rucio/Transfer.py
@@ -1,13 +1,16 @@
+"""
+Transfer object to share information between action classes.
+"""
 import logging
 import json
 import os
 import hashlib
 
+import ASO.Rucio.config as config # pylint: disable=consider-using-from-import
 from ASO.Rucio.exception import RucioTransferException
 from ASO.Rucio.utils import writePath
-import ASO.Rucio.config as config
 
-class Transfer:
+class Transfer: # pylint: disable=too-many-instance-attributes
     """
     Use Transfer object to store state of process in memory.
     It responsible for read info from file and set its attribute.
@@ -21,6 +24,8 @@ class Transfer:
         self.restDBInstance = ''
         self.restProxyFile = ''
 
+        # content of transfers.txt
+        self.transferItems = []
 
         # from transfer info
         self.username = ''
@@ -68,13 +73,12 @@ class Transfer:
         :param rucioClient: Rucio client
         :type rucioClient: rucio.client.client.Client
         """
-        pass
 
     def readLastTransferLine(self):
         """
         Reading lastTransferLine from task_process/transfers/last_transfer.txt
         """
-        if config.args.force_last_line != None: #  Need explicitly compare to None
+        if not config.args.force_last_line is None: # Need explicitly compare to None
             self.lastTransferLine = config.args.force_last_line
             return
         path = config.args.last_line_path
@@ -102,7 +106,6 @@ class Transfer:
         Reading transferItems (whole files) from task_process/transfers.txt
         """
         path = config.args.transfers_txt_path
-        self.transferItems = []
         try:
             with open(path, 'r', encoding='utf-8') as r:
                 for line in r:

--- a/src/python/ASO/Rucio/exception.py
+++ b/src/python/ASO/Rucio/exception.py
@@ -2,4 +2,3 @@ class RucioTransferException(Exception):
     """
     Generic exception for RUCIO_Transfers process
     """
-    pass

--- a/src/python/ASO/Rucio/utils.py
+++ b/src/python/ASO/Rucio/utils.py
@@ -1,3 +1,6 @@
+"""
+The utility function of Rucio ASO.
+"""
 import shutil
 import re
 from contextlib import contextmanager
@@ -50,7 +53,7 @@ def chunks(l, n=1):
             else:
                 break
 
-def uploadToTransfersdb(client, api, subresource, fileDoc, logger=None):
+def uploadToTransfersdb(client, api, subresource, fileDoc):
     """
     Upload fileDoc to REST
 
@@ -81,7 +84,6 @@ def tfcLFN2PFN(lfn, tfc, proto, depth=0):
     for rule in tfc:
         if rule['proto'] == proto:
             if 'chain' in rule:
-                import pdb; pdb.set_trace()
                 lfn = tfcLFN2PFN(lfn, tfc, rule['chain'], depth + 1)
             regex = re.compile(rule['path'])
             if regex.match(lfn):


### PR DESCRIPTION
Ignore some warnings:

- C0103:  Module name "<module_name>" doesn't conform to '[A-Z][a-zA-Z0-9]+$' pattern
- R0402, Use 'from ASO.Rucio import config' instead (see note below)
- (and more)

Also I did not try to correct pylint warning from `cmscp.py`,  `PostJob.py` (Will check it after warning from new files is solve at it later), and files in `src/test` directory.

Note for `R0402, line 8: Use 'from ASO.Rucio import config' instead`, when change to `from..import`, object reference still point to old object instead the new one where I modified it in [ASO/Rucio/Main.py#L73](https://github.com/dmwm/CRABServer/blob/ed4915d91af1deb425212c2e363e656415e7a87f/src/python/ASO/Rucio/Main.py#L73), so it got `None` instead of object return from `ArgumentParser.parse_args()`. Maybe I misunderstand something but I will do it later.