### PR TITLE
add script to delete old Rucio rules

### DIFF
--- a/scripts/Utils/DeleteOldRules.py
+++ b/scripts/Utils/DeleteOldRules.py
@@ -1,0 +1,45 @@
+"""
+ delete all rules created N months ago
+"""
+
+import argparse
+
+from datetime import datetime, timedelta
+
+from rucio.client import Client
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--days', help='rules older than this will be deleted', required=True)
+parser.add_argument('--dry', help='dry run. print what it will do but does nothing', action='store_true')
+args = parser.parse_args()
+nDays = int(args.days)
+retentionDays = timedelta(days=nDays)
+dryRun = args.dry
+
+rucio=Client()
+me=rucio.whoami()
+account=me['account']
+print(f"using Rucio account: {account}")
+
+# get rules for this account
+ruleGen = rucio.list_replication_rules({'account': account})
+rules = list(ruleGen)
+print(f"{len(rules)} rules exist for account: {account}")
+
+# find and delete rules older than retentionDays
+now = datetime.now()
+
+for rule in rules:
+    created=rule['created_at']
+    isOld = (now - created) > retentionDays
+    if isOld:
+        if dryRun:
+            print(f"will delete rule {rule['id']} created on {created}")
+        else:
+            pass
+            res = rucio.delete_replication_rule(rule_id=rule['id'], purge_replicas=True)
+            if res:
+                print(f"deleted rule {rule['id']} created on {created}")
+            else:
+                print(f"ERROR deletion of rule {rule['ruleId']} failed")
+  

--- a/scripts/Utils/DeleteOldRules.py
+++ b/scripts/Utils/DeleteOldRules.py
@@ -30,16 +30,14 @@ print(f"{len(rules)} rules exist for account: {account}")
 now = datetime.now()
 
 for rule in rules:
-    created=rule['created_at']
+    created = rule['created_at']
     isOld = (now - created) > retentionDays
     if isOld:
         if dryRun:
             print(f"will delete rule {rule['id']} created on {created}")
         else:
-            pass
-            res = rucio.delete_replication_rule(rule_id=rule['id'], purge_replicas=True)
-            if res:
+            try:
+                rucio.delete_replication_rule(rule_id=rule['id'], purge_replicas=True)
                 print(f"deleted rule {rule['id']} created on {created}")
-            else:
+            except Exception:  # pylint: disable=broad-except
                 print(f"ERROR deletion of rule {rule['ruleId']} failed")
-  

--- a/scripts/Utils/DeleteOldRules.py
+++ b/scripts/Utils/DeleteOldRules.py
@@ -16,9 +16,9 @@ nDays = int(args.days)
 retentionDays = timedelta(days=nDays)
 dryRun = args.dry
 
-rucio=Client()
-me=rucio.whoami()
-account=me['account']
+rucio = Client()
+me = rucio.whoami()
+account = me['account']
 print(f"using Rucio account: {account}")
 
 # get rules for this account


### PR DESCRIPTION
A small utility script. May be useful for us now. We may want to incorporate in some crabclient-for-rucio functionality later.