### PR TITLE
Taperecall: allow to recall any data tier if size less than threshold

### DIFF
--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -452,6 +452,21 @@ class DBSDataDiscovery(DataDiscovery):
             raise TaskWorkerException(msg)
 
     def executeTapeRecallPolicy(self, inputDataset, inputBlocks, totalSizeBytes):
+        """
+        Execute taperecall policy. If it passes, the method will return
+        taperecall `msg` to pass to `self.requestTapeRecall`; otherwise, raise
+        an exception.
+
+        :param inputDataset: input dataset
+        :type inputDataset: str
+        :param inputBlocks: input blocks
+        :type inputBlocks: list of str or None
+        :param totalSizeBytes: size of input data
+        :type totalSizeBytes: int
+
+        :return: task's warning message
+        :rtype: str
+        """
         dataTier = inputDataset.split('/')[3]
         maxTierToBlockRecallSizeTB = getattr(self.config.TaskWorker, 'maxTierToBlockRecallSizeTB', 0)
         maxTierToBlockRecallSize = maxTierToBlockRecallSizeTB * 1e12

--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -468,14 +468,14 @@ class DBSDataDiscovery(DataDiscovery):
                 msg += "\n https://twiki.cern.ch/twiki/bin/view/CMSPublic/CRAB3FAQ#crab_submit_fails_with_Task_coul"
             else:
                 msg = "Some blocks are on TAPE only and will not be processed."
-                msg += f"\nThere is no automatic recall from TAPE for data tier '{dataTier}' if 'Data.inputBlocks' is provided,"
-                msg += f"\nbut the recall size ({totalSizeBytes/1e12:.3f} TB) is larger than the maximum allowed size ({maxTierToBlockRecallSizeTB} TB)."
-                msg += f"\nIf you need these blocks, contact Data Transfer team via {FEEDBACKMAIL}"
+                msg += f"\n'The 'Data.inputBlocks' size is larger than allowed size ({totalSizeBytes/1e12:.3f}TB/{maxTierToBlockRecallSizeTB}TB)"\
+                        "to issue automatically recall from TAPE."
+                msg += f"\nIf you need these blocks, contact Data Transfer team via https://its.cern.ch/jira/browse/CMSTRANSF"
                 raise TaskWorkerException(msg)
         else:
             msg = "Some blocks are on TAPE only and will not be processed."
-            msg += f"\nThere is no automatic recall from tape for data tier '{dataTier}' if 'Data.inputBlocks' is not provided."
-            msg += f"\nIf you need the full dataset, contact Data Transfer team via {FEEDBACKMAIL}"
+            msg += f"\nThis dataset is too large for automatic recall from TAPE. If you can do with only a piece, use Data.inputBlocks configuration."
+            msg += f"\nIf you need the full dataset, contact Data Transfer team via https://its.cern.ch/jira/browse/CMSTRANSF"
             raise TaskWorkerException(msg)
         return msg
 

--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -331,7 +331,9 @@ class DBSDataDiscovery(DataDiscovery):
             dataTier = inputDataset.split('/')[3]
             maxTierToBlockRecallSizeTB = getattr(self.config.TaskWorker, 'maxTierToBlockRecallSizeTB', 0)
             maxTierToBlockRecallSize = maxTierToBlockRecallSizeTB * 1e12
-            if dataTier in getattr(self.config.TaskWorker, 'tiersToRecall', []):
+            maxAnyTierRecallSizeTB = getattr(self.config.TaskWorker, 'maxAnyTierRecallSizeTB', 0)
+            maxAnyTierRecallSize = maxAnyTierRecallSizeTB * 1e12
+            if dataTier in getattr(self.config.TaskWorker, 'tiersToRecall', []) or totalSizeBytes < maxAnyTierRecallSize:
                 msg = f"Task could not be submitted because not all blocks of dataset {inputDataset} are on DISK"
                 msg += "\nWill request a full disk copy for you. See"
                 msg += "\n https://twiki.cern.ch/twiki/bin/view/CMSPublic/CRAB3FAQ#crab_submit_fails_with_Task_coul"

--- a/test/python/TaskWorker/Actions/test_DBSDataDiscovery.py
+++ b/test/python/TaskWorker/Actions/test_DBSDataDiscovery.py
@@ -1,0 +1,53 @@
+"""
+Test DBSDataDiscovery
+
+Tape recall policy
+1. If recall (partial)dataset are in (|MINI|NANO)AOD(|SIM) tier allow recall any size
+2. allow to recall any (partial)dataset with size less than 50 TB
+"""
+
+import pytest
+import json
+import os
+from unittest.mock import patch, Mock
+from argparse import Namespace
+
+from WMCore.Configuration import ConfigurationEx
+from TaskWorker.Actions.DBSDataDiscovery import DBSDataDiscovery
+from TaskWorker.WorkerExceptions import TaskWorkerException
+
+
+@pytest.fixture
+def config_DBSDataDiscovery():
+    config = ConfigurationEx()
+    config.section_("TaskWorker")
+    # policy
+    config.TaskWorker.tiersToRecall = ['AOD', 'AODSIM', 'MINIAOD', 'MINIAODSIM', 'NANOAOD', 'NANOAODSIM']
+    config.TaskWorker.maxTierToBlockRecallSizeTB = 50
+    config.TaskWorker.maxAnyTierRecallSizeTB = 50
+    return config
+
+testdataAllow = [
+    ('/GenericTTbar/Run3-Unittest-dataset/AODSIM', None, 1e15),   # anysize, in tierToRecall
+    ('/GenericTTbar/Run3-Unittest-dataset/ALCARECO', None, 1e12), # 1TB, not in tierToRecall, less than maxAnyTierRecallSizeTB
+    ('/GenericTTbar/Run3-Unittest-dataset/ANY', ['/GenericTTbar/Run3-Unittest-dataset/ANY#2b4bf54e-ebad-4948-8730-432434bbcb2f'], 1e12),
+]
+
+testdataDeny = [
+    ('/GenericTTbar/Run3-Unittest-dataset/ALCARECO', None, 1e15), # 1PB, not in tierToRecall
+    ('/GenericTTbar/Run3-Unittest-dataset/ANY', ['/GenericTTbar/Run3-Unittest-dataset/ANY#2b4bf54e-ebad-4948-8730-432434bbcb2f'], 100e12),
+    ('/GenericTTbar/Run3-Unittest-dataset/ANY', ['/GenericTTbar/Run3-Unittest-dataset/ANY#2b4bf54e-ebad-4948-8730-432434bbcb2f'], 70e12),
+]
+
+@pytest.mark.parametrize("inputDataset, inputBlocks, totalSizeBytes", testdataAllow)
+def test_executeTapeRecallPolicy_allow(inputDataset, inputBlocks, totalSizeBytes, config_DBSDataDiscovery):
+    config = config_DBSDataDiscovery
+    d = DBSDataDiscovery(config)
+    d.executeTapeRecallPolicy(inputDataset, inputBlocks, totalSizeBytes)
+
+@pytest.mark.parametrize("inputDataset, inputBlocks, totalSizeBytes", testdataDeny)
+def test_executeTapeRecallPolicy_deny(inputDataset, inputBlocks, totalSizeBytes, config_DBSDataDiscovery):
+    config = config_DBSDataDiscovery
+    d = DBSDataDiscovery(config)
+    with pytest.raises(TaskWorkerException):
+        d.executeTapeRecallPolicy(inputDataset, inputBlocks, totalSizeBytes)


### PR DESCRIPTION
Fix https://github.com/dmwm/CRABServer/issues/7841

The current policy is (correct me if I am wrong):
1. Allow to recall any dataset with size less than threshold.
2. If recall dataset are in `*AOD*` tier allow recall any size.

This PR is special. Actually, the [first commit](https://github.com/dmwm/CRABServer/commit/e0dcafa7a88cbcdd066e5424f17b2c9e7919ba5a) is already do the job. But I want to show a small but valuable use case of unittest that helps me code with fewer mistakes and get faster feedback (no need to submit the tasks).

PS. Thanks to Stefano for refactoring tape recall condition (especially the part involve `usePartialDataset`). It is much more easier to change the code.