### PR TITLE
Bump crabtaskworker baseimage to 20230427-stable

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,8 +1,5 @@
-FROM registry.cern.ch/cmsweb/cmsweb:20220301-stable
+FROM registry.cern.ch/cmsweb/cmsweb:20230427-stable
 MAINTAINER Daina Dirmaite daina.dirmaite@gmail.com
-
-# temporary remove egi's yum repo
-RUN rm -f /etc/yum.repos.d/egi.repo
 
 #keep only voms-proxy basded on c++
 RUN yum remove -y voms-clients-java && yum -y install strace \

--- a/cicd/build/jenkins_build_docker.sh
+++ b/cicd/build/jenkins_build_docker.sh
@@ -12,16 +12,19 @@ echo "(DEBUG)   \- BRANCH: ${BRANCH}"
 echo "(DEBUG)   \- RELEASE_TAG: ${RELEASE_TAG}"
 echo "(DEBUG)   \- RPM_RELEASETAG_HASH: ${RPM_RELEASETAG_HASH}"
 echo "(DEBUG)   \- IMAGE_TAG: $IMAGE_TAG"
+echo "(DEBUG)   \- CI_CRABSERVER_REPO: ${CI_CRABSERVER_REPO}"
+echo "(DEBUG)   \- CI_CRABSERVER_BRANCH: ${CI_CRABSERVER_BRANCH}"
 echo "(DEBUG) jenkin job's env variables:"
 echo "(DEBUG)   \- WORKSPACE: $WORKSPACE"
 echo "(DEBUG) end"
 
+export CI_CRABSERVER_REPO=${CI_CRABSERVER_REPO:-https://github.com/dmwm/CRABServer.git}
+export CI_CRABSERVER_BRANCH=${CI_CRABSERVER_BRANCH:-master}
+git clone "${CI_CRABSERVER_REPO}" -b "${CI_CRABSERVER_BRANCH}" CRABServer
+cd CRABServer/Docker
+
 # use docker config on our WORKSPACE area, avoid replace default creds in ~/.docker that many pipeline depend on it
 export DOCKER_CONFIG=$PWD/docker_login
-
-#build and push crabtaskworker image
-git clone https://github.com/dmwm/CRABServer.git
-cd CRABServer/Docker
 
 #replace where RPMs are stored
 sed -i.bak -e "/export REPO=*/c\export REPO=comp.crab_${BRANCH}" install.sh


### PR DESCRIPTION
Current baseimage is failed to build because snapshot of epel repo is gone, thus make `yum` command fail.
 https://cmssdt.cern.ch/dmwm-jenkins/job/CRABServer_BuildImage/107/console

Current oldest of snapshot is [2022-03-11](http://linuxsoft.cern.ch/internal/yumsnapshot/) but our image is pinned on 2022-03-01.

I also expose  `CI_CRABSERVER_REPO`, `CI_CRABSERVER_BRANCH` from jenkins_build_docker.sh script to test it locally.