### PR TITLE
Including -stable suffix to crabserver images

### DIFF
--- a/cicd/build/jenkins_build_docker.sh
+++ b/cicd/build/jenkins_build_docker.sh
@@ -53,4 +53,4 @@ echo "(DEBUG) end"
 
 # relogin to using cmsweb robot account
 docker login registry.cern.ch --username $HARBOR_CMSWEB_USERNAME --password-stdin <<< $HARBOR_CMSWEB_PASSWORD
-CMSK8STAG=${IMAGE_TAG} ./build.sh "crabserver"
+CMSK8STAG=${IMAGE_TAG}-stable ./build.sh "crabserver"


### PR DESCRIPTION
I got a request from @arooshap to add `-stable` suffix to the crabserver image tag to comply with the new retention policy of cmsweb's space.
(Aroosha, please correct me if I am misunderstanding.) The new retention policy guarantees keeping the latest 3 tags, and older tags **without getting pulled** longer than 30 days will get deleted.