### PR TITLE
remove all uses of -p, --parameter-set with cmsRun

### DIFF
--- a/scripts/CMSRunAnalysis.py
+++ b/scripts/CMSRunAnalysis.py
@@ -646,7 +646,7 @@ if __name__ == "__main__":
         print(f"==== {applicationName} Execution started at {UTCNow()} ====")
         cmd = "stdbuf -oL -eL "
         if not options.scriptExe :
-            cmd += 'cmsRun -p PSet.py -j FrameworkJobReport.xml'
+            cmd += 'cmsRun -j FrameworkJobReport.xml PSet.py'
         else:
             # make sure scriptexe is executable
             st = os.stat(options.scriptExe)

--- a/test-old/templates/config/input_files/fake_exit_code.sh
+++ b/test-old/templates/config/input_files/fake_exit_code.sh
@@ -1,6 +1,6 @@
 set -x
 echo "================= CMSRUN starting ===================="
-cmsRun -j FrameworkJobReport.xml -p PSet.py
+cmsRun -j FrameworkJobReport.xml PSet.py
 echo "================= CMSRUN finished ===================="
 
 #Prepare exit codes

--- a/test-old/templates/config/input_files/simple_script.sh
+++ b/test-old/templates/config/input_files/simple_script.sh
@@ -13,7 +13,7 @@ echo "================= Dumping PSet ===================="
 python -c "import PSet; print PSet.process.dumpPython()"
 
 # Ok, let's stop fooling around and execute the job:
-cmsRun -j FrameworkJobReport.xml -p PSet.py
+cmsRun -j FrameworkJobReport.xml PSet.py
 
 # $@ will point to the all job passed job parameters
 echo "I am a simple output for job "$@ > simpleoutput.txt

--- a/test/testUtils.py
+++ b/test/testUtils.py
@@ -131,7 +131,7 @@ echo "====== arg checking: \$1 = $1" >> My_output.txt
 echo "====== arg checking: \$2 = $2" >> My_output.txt
 echo "====== arg checking: \$3 = $3" >> My_output.txt
 
-cmsRun -j FrameworkJobReport.xml -p PSet.py
+cmsRun -j FrameworkJobReport.xml PSet.py
 ExeExit=$?
 echo "============ SB CMSRUN finished =================" >> My_output.txt
 echo "============ SB CMSRUN exit code was: $ExeExit ==" >> My_output.txt


### PR DESCRIPTION
This PR is the CRAB version of https://github.com/cms-sw/cmssw/pull/42798.

It is already unnecessary to use the `-p` or `--parameter-set` flag before specifying the `config.py` file for `cmsRun`, so this PR can be merged immediately with no change in functionality.

After https://github.com/cms-sw/cmssw/pull/42650 is merged, subsequent CMSSW releases will no longer support the `-p`, `--parameter-set` flags; the `config.py` file will always be provided as a positional argument. (This goes toward better command-line argument support following Python standards.)