### PR TITLE
restcache, download sandbox - check username present if not upload

### DIFF
--- a/src/python/CRABInterface/RESTCache.py
+++ b/src/python/CRABInterface/RESTCache.py
@@ -157,7 +157,7 @@ class RESTCache(RESTEntity):
                 # need to build a single URL string to return
                 preSignedUrl = response
             except ClientError as e:
-                raise ExecutionError("Connection to s3.cern.ch failed:\n%s" % str(e))
+                raise ExecutionError(f"Connection to s3.cern.ch failed:\n{str(e)}") from e
             # somehow it does not work to return preSignedUrl as a single object
             return [preSignedUrl['url'], preSignedUrl['fields']]
 
@@ -176,7 +176,7 @@ class RESTCache(RESTEntity):
                         ExpiresIn=expiration)
                 preSignedUrl = response
             except ClientError as e:
-                raise ExecutionError("Connection to s3.cern.ch failed:\n%s" % str(e))
+                raise ExecutionError(f"Connection to s3.cern.ch failed:\n{str(e)}") from e
             return preSignedUrl
 
         if subresource == 'retrieve':
@@ -187,7 +187,7 @@ class RESTCache(RESTEntity):
                 with MeasureTime(self.logger, modulename=__name__, label="get.retrieve.download_file") as _:
                     self.s3_client.download_file(self.s3_bucket, s3_objectKey, tempFile)
             except ClientError as e:
-                raise ExecutionError("Connection to s3.cern.ch failed:\n%s" % str(e))
+                raise ExecutionError(f"Connection to s3.cern.ch failed:\n{str(e)}") from e
             with open(tempFile) as f:
                 txt = f.read()
             os.remove(tempFile)

--- a/src/python/CRABInterface/RESTCache.py
+++ b/src/python/CRABInterface/RESTCache.py
@@ -114,6 +114,8 @@ class RESTCache(RESTEntity):
                 if not tarballname:
                     raise MissingParameter("tarballname is missing")
                 ownerName = authenticatedUserName if subresource == 'upload' else username
+                if not ownerName:
+                    raise MissingParameter("username is missing")
                 # sandbox goes in bucket/username/sandboxes/
                 objectPath = ownerName + '/sandboxes/' + tarballname
             else:


### PR DESCRIPTION
Related to #6540 

While developing the command `crab getsandbox`, I made by mistake a call that made the crabserver fail with an http error 500. I do not think that our production code ever makes suche a request, but it would be better to make the crabserver fail properly.

Basically, it is possible that `ownerName` is empty and that the line `objectPath = ownerName + '/sandboxes/' + tarballname` fails with "can append string to None".