### PR TITLE
Fix PreDAG.py to always use user proxy for rucio client

### DIFF
--- a/src/python/RucioUtils.py
+++ b/src/python/RucioUtils.py
@@ -24,8 +24,10 @@ def getNativeRucioClient(config=None, logger=None):
     cl = logging.getLogger('charset_normalizer')
     cl.setLevel(logging.ERROR)
 
-    rucio_cert = getattr(config.Services, "Rucio_cert", config.TaskWorker.cmscert)
-    rucio_key = getattr(config.Services, "Rucio_key", config.TaskWorker.cmskey)
+    # Need to use config from `config.TaskWorker` object instead to switch to
+    # user cert in PreDag.py
+    rucio_cert = getattr(config.TaskWorker, "Rucio_cert", config.TaskWorker.cmscert)
+    rucio_key = getattr(config.TaskWorker, "Rucio_key", config.TaskWorker.cmskey)
     logger.debug("Using cert [%s]\n and key [%s] for rucio client.", rucio_cert, rucio_key)
     nativeClient = Client(
         rucio_host=config.Services.Rucio_host,

--- a/src/python/TaskWorker/Actions/PreDAG.py
+++ b/src/python/TaskWorker/Actions/PreDAG.py
@@ -204,10 +204,12 @@ class PreDAG(object):
         # need to use user proxy as credential for talking with cmsweb
         config.TaskWorker.cmscert = os.environ.get('X509_USER_PROXY')
         config.TaskWorker.cmskey = os.environ.get('X509_USER_PROXY')
-        config.TaskWorker.Rucio_cert = os.environ.get('X509_USER_PROXY')
-        config.TaskWorker.Rucio_key = os.environ.get('X509_USER_PROXY')
         config.TaskWorker.envForCMSWEB = newX509env(X509_USER_CERT=config.TaskWorker.cmscert,
                                                     X509_USER_KEY=config.TaskWorker.cmskey)
+        # also for talking with rucio
+        config.TaskWorker.Rucio_cert = os.environ.get('X509_USER_PROXY')
+        config.TaskWorker.Rucio_key = os.environ.get('X509_USER_PROXY')
+
 
         # need to get username from classAd to setup for Rucio access
         task_ad = classad.parseOne(open(os.environ['_CONDOR_JOB_AD']))

--- a/src/python/TaskWorker/Actions/PreDAG.py
+++ b/src/python/TaskWorker/Actions/PreDAG.py
@@ -204,6 +204,8 @@ class PreDAG(object):
         # need to use user proxy as credential for talking with cmsweb
         config.TaskWorker.cmscert = os.environ.get('X509_USER_PROXY')
         config.TaskWorker.cmskey = os.environ.get('X509_USER_PROXY')
+        config.TaskWorker.Rucio_cert = os.environ.get('X509_USER_PROXY')
+        config.TaskWorker.Rucio_key = os.environ.get('X509_USER_PROXY')
         config.TaskWorker.envForCMSWEB = newX509env(X509_USER_CERT=config.TaskWorker.cmscert,
                                                     X509_USER_KEY=config.TaskWorker.cmskey)
 


### PR DESCRIPTION
Relate to https://github.com/dmwm/CRABServer/issues/7894

This PR fixes the bug when we alter TW config to use user cert here: https://github.com/dmwm/CRABServer/blob/412bd3a45c19d65a411d528dd9b96efaef16b1b4/src/python/TaskWorker/Actions/PreDAG.py#L204-L208
But, it gets override by `config.Services.Rucio_cert` in `TaskWorkerConfig.py` file in here:
https://github.com/dmwm/CRABServer/blob/412bd3a45c19d65a411d528dd9b96efaef16b1b4/src/python/RucioUtils.py#L27  