### PR TITLE
Move Rucio check write logic to ServerUtilities.py

### DIFF
--- a/src/python/TaskWorker/Actions/StageoutCheck.py
+++ b/src/python/TaskWorker/Actions/StageoutCheck.py
@@ -85,20 +85,13 @@ class StageoutCheck(TaskAction):
         if self.task['tm_output_lfn'].startswith('/store/user/rucio') or \
            self.task['tm_output_lfn'].startswith('/store/group/rucio'):
             # copy from TapeRecallManager
-            #if not self.privilegedRucioClient:
-            #    tapeRecallConfig = copy.deepcopy(self.config)
-            #    tapeRecallConfig.Services.Rucio_account = 'crab_input'
-            #    self.privilegedRucioClient = getNativeRucioClient(tapeRecallConfig, self.logger)
-            # patch for test with non superuser account, will remove later
-            userRucioConfig = copy.deepcopy(self.config)
-            userRucioConfig.TaskWorker.Rucio_cert = self.task['user_proxy']
-            userRucioConfig.TaskWorker.Rucio_key = self.task['user_proxy']
-            userRucioConfig.Services.Rucio_account, _ = getRucioAccountFromLFN(self.task['tm_output_lfn'])
-            userRucioClient = getNativeRucioClient(userRucioConfig, self.logger)
-            ###
+            if not self.privilegedRucioClient:
+                tapeRecallConfig = copy.deepcopy(self.config)
+                tapeRecallConfig.Services.Rucio_account = 'crab_input'
+                self.privilegedRucioClient = getNativeRucioClient(tapeRecallConfig, self.logger)
             rucioAccount = getRucioAccountFromLFN(self.task['tm_output_lfn'])
             self.logger.info(f"Checking Rucio quota from account {rucioAccount}.")
-            _, isEnough, isQuotaWarning, quota = isEnoughRucioQuota(userRucioClient, self.task['tm_asyncdest'], rucioAccount)
+            _, isEnough, isQuotaWarning, quota = isEnoughRucioQuota(self.privilegedRucioClient, self.task['tm_asyncdest'], rucioAccount)
             _, _, freeGB = quota
             if not isEnough:
                 msg = f"Not enough Rucio quota at {self.task['tm_asyncdest']}:{self.task['tm_output_lfn']}."\


### PR DESCRIPTION
Fix https://github.com/dmwm/CRABServer/issues/6172

2 news function:
- **`isEnoughRucioQuota()`** check Rucio quota with destination site. Reuse in client client `checkwrite` and `status` command. 
- **`getRucioAccountFromLFN()`** Parsing LFN to get correct Rucio account where group account always has suffix `_group` but LFN prefix will not have this suffix.
    - In example, `crab_test_group` LFN prefix is `/store/group/rucio/crab_test/`

See how we use in client side in PR https://github.com/dmwm/CRABClient/pull/5247.
