### PR TITLE
WIP: Multiple Publish Container

### DIFF
--- a/etc/updateOracle.sql
+++ b/etc/updateOracle.sql
@@ -136,3 +136,6 @@ ALTER TABLE filetransfersdb ADD tm_block_complete VARCHAR(10);
 ALTER TABLE tasks ADD tm_transfer_container VARCHAR(1000);
 ALTER TABLE tasks ADD tm_transfer_rule VARCHAR(255);
 ALTER TABLE tasks ADD tm_publish_rule VARCHAR(255);
+
+--Add Rucio ASO's json kv for store container names and its rules.
+ALTER TABLE tasks ADD tm_multipub_rule CLOB;

--- a/src/python/ASO/Rucio/Actions/BuildDBSDataset.py
+++ b/src/python/ASO/Rucio/Actions/BuildDBSDataset.py
@@ -40,9 +40,9 @@ class BuildDBSDataset():
                 'publishrule': self.transfer.publishRuleID,
             }
             # multi pub container
-            for containerName  in self.transfer.mutiPubContainers:
+            for containerName  in self.transfer.multiPubContainers:
                 ruleID = self.checkOrCreateContainer(containerName)
-                self.transfer.mutliPubRuleIds[containerName] = ruleID
+                self.transfer.multiPubRuleIDs[containerName] = ruleID
             # upload rule id and transfer container name to TasksDB
             # TODO: need to figure it out how to display this info in crab client
             updateToREST(self.crabRESTClient, 'task', 'addrucioasoinfo', configreq)

--- a/src/python/ASO/Rucio/Actions/BuildDBSDataset.py
+++ b/src/python/ASO/Rucio/Actions/BuildDBSDataset.py
@@ -52,13 +52,6 @@ class BuildDBSDataset():
         # create log dataset in transfer container
         self.createDataset(self.transfer.transferContainer, self.transfer.logsDataset)
 
-    def buildMultiPubContainer(self):
-
-        publishContainerRuleIDs = {}
-        mutiPubContainers = ['/a/b_output.root/USER']
-        self.transfer.bookkeepingmultipubcontainer(publishContainerRuleIDs)
-
-
     def checkOrCreateContainer(self, container):
         """
         Creating container and attach replication rules. ignore if it already

--- a/src/python/ASO/Rucio/Actions/BuildDBSDataset.py
+++ b/src/python/ASO/Rucio/Actions/BuildDBSDataset.py
@@ -30,7 +30,7 @@ class BuildDBSDataset():
         LOGS dataset.
         """
         # create container
-        if not self.transfer.containerRuleID or not self.transfer.publishRuleID:
+        if not self.transfer.containerRuleID:
             self.transfer.containerRuleID = self.checkOrCreateContainer(self.transfer.transferContainer)
             self.transfer.publishRuleID = self.checkOrCreateContainer(self.transfer.publishContainer)
             configreq = {
@@ -39,12 +39,25 @@ class BuildDBSDataset():
                 'transferrule': self.transfer.containerRuleID,
                 'publishrule': self.transfer.publishRuleID,
             }
+            # multi pub container
+            for containerName  in self.transfer.mutiPubContainers:
+                ruleID = self.checkOrCreateContainer(containerName)
+                self.transfer.mutliPubRuleIds[containerName] = ruleID
             # upload rule id and transfer container name to TasksDB
+            # TODO: need to figure it out how to display this info in crab client
             updateToREST(self.crabRESTClient, 'task', 'addrucioasoinfo', configreq)
             # bookkeeping
             self.transfer.updateContainerRuleID()
+
         # create log dataset in transfer container
         self.createDataset(self.transfer.transferContainer, self.transfer.logsDataset)
+
+    def buildMultiPubContainer(self):
+
+        publishContainerRuleIDs = {}
+        mutiPubContainers = ['/a/b_output.root/USER']
+        self.transfer.bookkeepingmultipubcontainer(publishContainerRuleIDs)
+
 
     def checkOrCreateContainer(self, container):
         """

--- a/src/python/ASO/Rucio/Actions/BuildDBSDataset.py
+++ b/src/python/ASO/Rucio/Actions/BuildDBSDataset.py
@@ -38,17 +38,17 @@ class BuildDBSDataset():
             for containerName  in self.transfer.multiPubContainers:
                 ruleID = self.checkOrCreateContainer(containerName)
                 self.transfer.multiPubRuleIDs[containerName] = ruleID
-            # upload rule id and transfer container name to TasksDB
+            # Upload rule id and transfer container name to TasksDB.
+            # Note that we upload multiPubRuleIDs as json string to REST and
+            # manually load back in client side later.
             configreq = {
                 'workflow': self.transfer.taskname,
                 'transfercontainer': self.transfer.transferContainer,
                 'transferrule': self.transfer.containerRuleID,
                 'publishrule': self.transfer.publishRuleID,
-                'mulipubrule_name'
-                'mulipubrule_ruleid': self.transfer.multiPubRuleIDs)
+                'multipubrulejson': json.dumps(self.transfer.multiPubRuleIDs),
             }
             updateToREST(self.crabRESTClient, 'task', 'addrucioasoinfo', configreq)
-            import pdb; pdb.set_trace()
             # bookkeeping
             self.transfer.updateContainerRuleID()
 

--- a/src/python/ASO/Rucio/Actions/BuildDBSDataset.py
+++ b/src/python/ASO/Rucio/Actions/BuildDBSDataset.py
@@ -3,6 +3,7 @@ Create Rucio's container and dataset.
 """
 import logging
 import uuid
+import json
 
 from rucio.common.exception import DataIdentifierAlreadyExists, InvalidObject, DuplicateRule, DuplicateContent
 
@@ -43,9 +44,11 @@ class BuildDBSDataset():
                 'transfercontainer': self.transfer.transferContainer,
                 'transferrule': self.transfer.containerRuleID,
                 'publishrule': self.transfer.publishRuleID,
-                'mulipubrule': self.transfer.multiPubRuleIDs
+                'mulipubrule_name'
+                'mulipubrule_ruleid': self.transfer.multiPubRuleIDs)
             }
             updateToREST(self.crabRESTClient, 'task', 'addrucioasoinfo', configreq)
+            import pdb; pdb.set_trace()
             # bookkeeping
             self.transfer.updateContainerRuleID()
 

--- a/src/python/ASO/Rucio/Actions/BuildDBSDataset.py
+++ b/src/python/ASO/Rucio/Actions/BuildDBSDataset.py
@@ -33,18 +33,18 @@ class BuildDBSDataset():
         if not self.transfer.containerRuleID:
             self.transfer.containerRuleID = self.checkOrCreateContainer(self.transfer.transferContainer)
             self.transfer.publishRuleID = self.checkOrCreateContainer(self.transfer.publishContainer)
-            configreq = {
-                'workflow': self.transfer.taskname,
-                'transfercontainer': self.transfer.transferContainer,
-                'transferrule': self.transfer.containerRuleID,
-                'publishrule': self.transfer.publishRuleID,
-            }
             # multi pub container
             for containerName  in self.transfer.multiPubContainers:
                 ruleID = self.checkOrCreateContainer(containerName)
                 self.transfer.multiPubRuleIDs[containerName] = ruleID
             # upload rule id and transfer container name to TasksDB
-            # TODO: need to figure it out how to display this info in crab client
+            configreq = {
+                'workflow': self.transfer.taskname,
+                'transfercontainer': self.transfer.transferContainer,
+                'transferrule': self.transfer.containerRuleID,
+                'publishrule': self.transfer.publishRuleID,
+                'mulipubrule': self.transfer.multiPubRuleIDs
+            }
             updateToREST(self.crabRESTClient, 'task', 'addrucioasoinfo', configreq)
             # bookkeeping
             self.transfer.updateContainerRuleID()

--- a/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
+++ b/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
@@ -45,7 +45,8 @@ class MonitorLockStatus:
         ## nothing but return fileDoc containing the block name replica belongs
         ## to.
         #publishedFileDocs = self.registerToPublishContainer(needToPublishFileDocs)
-        publishedFileDocs = self.registerToPublishContainer(okFileDocs)
+        #publishedFileDocs = self.registerToPublishContainer(okFileDocs)
+        publishedFileDocs = self.registerToMutiPubContainers(okFileDocs)
         self.logger.debug(f'publishedFileDocs: {publishedFileDocs}')
         # skip filedocs that already update it status to rest.
         newPublishFileDocs = [doc for doc in publishedFileDocs if not doc['dataset'] in self.transfer.bookkeepingBlockComplete]

--- a/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
+++ b/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
@@ -117,7 +117,20 @@ class MonitorLockStatus:
 
     def registerToMutiPubContainers(self, fileDocs):
         """
+        Register replicas to it own publish container.
 
+        In example, we have
+        - output dataset name `/GenericTTbar/cmsbot-integration-1/USER`
+        - 2 output files:
+          - `output.root` (EDM)
+          - `myfile.txt` (Misc)
+        All `output_{job_id}.root` files will registering to `/GenericTTbar/cmsbot-integration-1__output.root/USER`
+
+        :param fileDocs: replicas info return from `checkLockStatus` method.
+        :type fileDocs: list of dict (fileDoc)
+
+        :return: replicas info with updated dataset name.
+        :rtype: list of dict
         """
         r = RegisterReplicas(self.transfer, self.rucioClient, None)
         publishContainerFileDocs = []

--- a/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
+++ b/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
@@ -103,17 +103,14 @@ class MonitorLockStatus:
         :return: replicas info with updated dataset name.
         :rtype: list of dict
         """
-
         r = RegisterReplicas(self.transfer, self.rucioClient, None)
         publishContainerFileDocs = r.addReplicasToContainer(fileDocs, self.transfer.publishContainer)
-
         # Update dataset name for each replicas
-        #tmpLFN2DatasetMap = {x['name']:x['dataset'] for x in publishContainerFileDocs}
-        #tmpFileDocs = copy.deepcopy(fileDocs)
-        #for f in tmpFileDocs:
-        #    f['dataset'] = tmpLFN2DatasetMap[f['name']]
-        #return tmpFileDocs
-        return publishContainerFileDocs
+        tmpLFN2DatasetMap = {x['name']:x['dataset'] for x in publishContainerFileDocs}
+        tmpFileDocs = copy.deepcopy(fileDocs)
+        for f in tmpFileDocs:
+            f['dataset'] = tmpLFN2DatasetMap[f['name']]
+        return tmpFileDocs
 
     def registerToMutiPubContainers(self, fileDocs):
         """

--- a/src/python/ASO/Rucio/Transfer.py
+++ b/src/python/ASO/Rucio/Transfer.py
@@ -192,7 +192,8 @@ class Transfer:
         """
         Read containerRuleID from task_process/transfers/container_ruleid.txt
         """
-        # skip reading rule from bookkeeping in case rerun with new transferContainerName.
+        # Skip reading rule from bookkeeping in case to intend to create
+        # different container name when test.
         if config.args.force_publishname:
             return
         path = config.args.container_ruleid_path
@@ -201,9 +202,11 @@ class Transfer:
                 tmp = json.load(r)
                 self.containerRuleID = tmp['containerRuleID']
                 self.publishRuleID = tmp['publishRuleID']
-                self.logger.info('Got container rule ID from bookkeeping.'\
-                                 f' Transfer Container rule ID: {self.containerRuleID}'\
-                                 f' Publish Container rule ID: {self.publishRuleID}')
+                self.multiPubRuleIDs = tmp['multiPubRuleIDs']
+                self.logger.info('Got container rule ID from bookkeeping:')
+                self.logger.info(f'  Transfer Container rule ID: {self.containerRuleID}')
+                self.logger.info(f'  Publish Container rule ID: {self.publishRuleID}')
+                self.logger.info(f'  Publish Container rule ID: {self.multiPubRuleIDs}')
         except FileNotFoundError:
             self.logger.info(f'Bookkeeping rules "{path}" does not exist. Assume it is first time it run.')
 

--- a/src/python/ASO/Rucio/Transfer.py
+++ b/src/python/ASO/Rucio/Transfer.py
@@ -44,6 +44,7 @@ class Transfer:
         self.lastTransferLine = 0
         self.containerRuleID = ''
         self.publishRuleID = ''
+        self.multiPubRuleIDs = {}
         self.bookkeepingOKLocks = None
         self.bookkeepingBlockComplete = None
 
@@ -216,6 +217,7 @@ class Transfer:
             json.dump({
                 'containerRuleID': self.containerRuleID,
                 'publishRuleID': self.publishRuleID,
+                'multiPubRuleIDs': self.multiPubRuleIDs,
             }, w)
 
     def readOKLocks(self):

--- a/src/python/ASO/Rucio/Transfer.py
+++ b/src/python/ASO/Rucio/Transfer.py
@@ -214,7 +214,7 @@ class Transfer:
                 self.logger.info('Got container rule ID from bookkeeping:')
                 self.logger.info(f'  Transfer Container rule ID: {self.containerRuleID}')
                 self.logger.info(f'  Publish Container rule ID: {self.publishRuleID}')
-                self.logger.info(f'  Publish Container rule ID: {self.multiPubRuleIDs}')
+                self.logger.info(f'  Multiple Publish Container rule ID: {self.multiPubRuleIDs}')
         except FileNotFoundError:
             self.logger.info(f'Bookkeeping rules "{path}" does not exist. Assume it is first time it run.')
 

--- a/src/python/ASO/Rucio/Transfer.py
+++ b/src/python/ASO/Rucio/Transfer.py
@@ -8,7 +8,7 @@ import hashlib
 
 import ASO.Rucio.config as config # pylint: disable=consider-using-from-import
 from ASO.Rucio.exception import RucioTransferException
-from ASO.Rucio.utils import writePath
+from ASO.Rucio.utils import writePath, parseFileNameFromLFN, addSuffixToDatasetName
 
 class Transfer:
     """
@@ -35,6 +35,7 @@ class Transfer:
         self.publishContainer = ''
         self.transferContainer = ''
         self.logsDataset = ''
+        self.multiPubContainers = []
 
         # dynamically change throughout the scripts
         self.currentDataset = ''
@@ -174,6 +175,17 @@ class Transfer:
         self.transferContainer = '/'.join(tmp)
         self.logger.info(f'Publish container: {self.publishContainer}, Transfer container: {self.transferContainer}')
         self.logsDataset = f'{self.transferContainer}#LOGS'
+
+    def buildMultiPubContainers(self):
+        multiPubContainers = []
+        jobID = self.transferItems[0]['job_id']
+        for item in self.transferItems:
+            if item['job_id'] != jobID:
+                break
+            filename = parseFileNameFromLFN(item['destination_lfn'])
+            containerName = addSuffixToDatasetName(self.publishContainer, f'__{filename}')
+            multiPubContainers.append(containerName)
+        self.multiPubContainers = multiPubContainers
 
     def readContainerRuleID(self):
         """

--- a/src/python/ASO/Rucio/Transfer.py
+++ b/src/python/ASO/Rucio/Transfer.py
@@ -179,6 +179,13 @@ class Transfer:
         self.logsDataset = f'{self.transferContainer}#LOGS'
 
     def buildMultiPubContainers(self):
+        """
+        Create the self.multiPubContainers attribute by reading all transfers
+        dict from the same job id.
+
+        Note that this method does not check the limit of the new container name
+        length, but only relies on validation from REST.
+        """
         multiPubContainers = []
         jobID = self.transferItems[0]['job_id']
         for item in self.transferItems:

--- a/src/python/ASO/Rucio/Transfer.py
+++ b/src/python/ASO/Rucio/Transfer.py
@@ -66,6 +66,7 @@ class Transfer:
         self.buildLFN2transferItemMap()
         self.readRESTInfo()
         self.readInfoFromTransferItems()
+        self.buildMultiPubContainers()
         self.readContainerRuleID()
         self.readOKLocks()
         self.readBlockComplete()

--- a/src/python/ASO/Rucio/utils.py
+++ b/src/python/ASO/Rucio/utils.py
@@ -133,8 +133,3 @@ def parseFileNameFromLFN(lfn):
         fileExt = jobid_fileext.rsplit(".", 1)[-1]
         origFileName = leftPiece + "." + fileExt
     return origFileName
-
-
-def parseFileNameFromDatasetName(dataset):
-    tmp = dataset.split('/')
-    return tmp[2].split('__')[-1]

--- a/src/python/ASO/Rucio/utils.py
+++ b/src/python/ASO/Rucio/utils.py
@@ -3,6 +3,7 @@ The utility function of Rucio ASO.
 """
 import shutil
 import re
+import os
 from contextlib import contextmanager
 import itertools
 
@@ -112,3 +113,28 @@ def LFNToPFNFromPFN(lfn, pfn):
     else:
         fileid = '/'.join(lfn.split("/")[-2:])
     return f'{pfnPrefix}/{fileid}'
+
+def addSuffixToDatasetName(dataset, txt):
+    tmp = dataset.split('/')
+    tmp[2] += txt
+    return '/'.join(tmp)
+
+
+def parseFileNameFromLFN(lfn):
+    # cmsRun_3.log.tar.gz => cmsRun.log.tar.gz
+    # output_3.root => output.root
+    filename = os.path.basename(lfn)
+    regex = re.compile(r'^cmsRun_[0-9]+\.log\.tar\.gz$')
+    if regex.match(filename):
+        return 'cmsRun.log.tar.gz'
+    leftPiece, jobid_fileext = filename.rsplit("_", 1)
+    origFileName = leftPiece
+    if "." in jobid_fileext:
+        fileExt = jobid_fileext.rsplit(".", 1)[-1]
+        origFileName = leftPiece + "." + fileExt
+    return origFileName
+
+
+def parseFileNameFromDatasetName(dataset):
+    tmp = dataset.split('/')
+    return tmp[2].split('__')[-1]

--- a/src/python/ASO/Rucio/utils.py
+++ b/src/python/ASO/Rucio/utils.py
@@ -114,15 +114,56 @@ def LFNToPFNFromPFN(lfn, pfn):
         fileid = '/'.join(lfn.split("/")[-2:])
     return f'{pfnPrefix}/{fileid}'
 
-def addSuffixToDatasetName(dataset, txt):
+def addSuffixToDatasetName(dataset, strsuffix):
+    """
+    Adding suffix to dataset name in the "name" part.
+
+    :param dataset: Fully qualified dataset's name
+    :type dataset: str
+    :param strsuffix: string suffix to add
+    :type strsuffix: str
+
+    :return: new dataset name
+    :rtype: str
+
+    >>> addSuffixToDatasetName('/GenericTTbar/cmsbot-mypublishdbsname-1/USER', '__output.root')
+    '/GenericTTbar/cmsbot-mypublishdbsname-1__output.root/USER'
+
+    """
     tmp = dataset.split('/')
-    tmp[2] += txt
+    tmp[2] += strsuffix
     return '/'.join(tmp)
 
 
 def parseFileNameFromLFN(lfn):
-    # cmsRun_3.log.tar.gz => cmsRun.log.tar.gz
-    # output_3.root => output.root
+    """
+    Parsing file name from LFN.
+
+    For the job's output files, we append `_{job_id}` before the last file
+    extension. But for the log file, we use the format
+    `cmsRun_{job_id}.log.tar.gz` instead. So, the log file will be hardcode to
+    always return 'cmsRun.log.tar.gz'.
+
+    See https://github.com/dmwm/CRABServer/blob/f5fa82078ff858fd35cf11773020f258abd2c3c7/src/python/TaskWorker/Actions/DagmanCreator.py#L621-L626
+    and https://github.com/dmwm/CRABServer/blob/f5fa82078ff858fd35cf11773020f258abd2c3c7/src/python/TaskWorker/Actions/DagmanCreator.py#L644
+    on how file name is created.
+
+    :param lfn: LFN
+    :type lfn: str
+
+    :return: file name
+    :rtype: str
+
+    >>>parseFileNameFromLFN('/store/user/rucio/cmsbot/somedir/output_3.root')
+    'output.root'
+
+    >>>parseFileNameFromLFN('/store/user/rucio/cmsbot/somedir/file.with.long.ext_3.txt')
+    'file.with.long.ext.txt'
+
+    >>>parseFileNameFromLFN('/store/user/rucio/cmsbot/somedir/cmsRun_3.log.tar.gz')
+    'cmsRun.log.tar.gz'
+
+    """
     filename = os.path.basename(lfn)
     regex = re.compile(r'^cmsRun_[0-9]+\.log\.tar\.gz$')
     if regex.match(filename):

--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -386,6 +386,7 @@ class RESTTask(RESTEntity):
             raise InvalidParameter("Transfer container's rule id not found in the input parameters")
         # Fail validation if  both `publishrule` and `multipubrule` does not exists.
         # We want to deprecate `publishrule` in the future
+        import pdb; pdb.set_trace()
         if (('publishrule' not in kwargs or not kwargs['publishrule'])
            and ('multipubrule' not in kwargs or not kwargs['multipubrule'])):
             raise InvalidParameter("`publishrule` and `multipubrule` are not found in the input parameters")

--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -13,7 +13,6 @@ from ServerUtilities import getUsernameFromTaskname
 # external dependecies here
 import re
 import logging
-import json
 from ast import literal_eval
 
 

--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -44,8 +44,7 @@ class RESTTask(RESTEntity):
             validate_str("transfercontainer", param, safe, RX_DATASET, optional=True)
             validate_str("transferrule", param, safe, RX_RUCIORULE, optional=True)
             validate_str("publishrule", param, safe, RX_RUCIORULE, optional=True)
-            validate_strlist("multipubrule_name", param, safe, RX_ANYTHING)
-            validate_strlist("multipubrule_id", param, safe, RX_ANYTHING)
+            validate_str("multipubrulejson", param, safe, RX_MANYLINES_SHORT, optional=True)
         elif method in ['GET']:
             validate_str('subresource', param, safe, RX_SUBRES_TASK, optional=False)
             validate_str("workflow", param, safe, RX_TASKNAME, optional=True)
@@ -391,20 +390,17 @@ class RESTTask(RESTEntity):
         # Fail validation if  both `publishrule` and `multipubrule` does not exists.
         # We want to deprecate `publishrule` in the future
         if (('publishrule' not in kwargs or not kwargs['publishrule'])
-           and (('multipubrule_name' not in kwargs or not kwargs['multipubrule_name'])
-                or ('multipubrule_id' not in kwargs or not kwargs['multipubrule_id']))):
-            raise InvalidParameter("`publishrule` or (`multipubrule_name`,`multipubrule_id`) are not found in the input parameters")
+           and ('multipubrulejson' not in kwargs or not kwargs['multipubrulejson'])):
+            raise InvalidParameter("`publishrule` or `multipubrulejson` are not found in the input parameters.")
         # set default value if `publishrule` or `multipubrule` does not exists.
         if 'publishrule' not in kwargs or not kwargs['publishrule']:
             publishrule = '00000000000000000000000000000000'
         else:
             publishrule = kwargs['publishrule']
-        if 'multipubrule_name' not in kwargs or not kwargs['multipubrule_name']:
-            multipubrule = {}
-        elif len(kwargs['multipubrule_name']) != len(kwargs['multipubrule_id']):
-            raise InvalidParameter("Length of list `multipubrule_name` and `multipubrule_id` is not equal")
+        if 'multipubrulejson' not in kwargs or not kwargs['multipubrulejson']:
+            multipubrulejson = '{}'
         else:
-            multipubrule = { kwargs['multipubrule_name'][i]: kwargs['multipubrule_id'][i] for i in range(len(kwargs['multipubrule_name'])) }
+            multipubrulejson = kwargs['multipubrulejson']
         taskname = kwargs['workflow']
         ownerName = getUsernameFromTaskname(taskname)
         authz_operator(username=ownerName, group='crab3', role='operator')
@@ -413,6 +409,6 @@ class RESTTask(RESTEntity):
             tm_transfer_container=[kwargs['transfercontainer']],
             tm_transfer_rule=[kwargs['transferrule']],
             tm_publish_rule=[publishrule],
-            tm_multipub_rule=[json.dumps(multipubrule)],
+            tm_multipub_rule=[multipubrulejson],
             tm_taskname=[taskname])
         return []

--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -44,6 +44,7 @@ class RESTTask(RESTEntity):
             validate_str("transfercontainer", param, safe, RX_DATASET, optional=True)
             validate_str("transferrule", param, safe, RX_RUCIORULE, optional=True)
             validate_str("publishrule", param, safe, RX_RUCIORULE, optional=True)
+            # Save json string directly to tm_multipub_rule CLOB column.
             validate_str("multipubrulejson", param, safe, RX_ANYTHING_10K, optional=True)
         elif method in ['GET']:
             validate_str('subresource', param, safe, RX_SUBRES_TASK, optional=False)
@@ -386,9 +387,9 @@ class RESTTask(RESTEntity):
             raise InvalidParameter("Transfer container name not found in the input parameters")
         if 'transferrule' not in kwargs or not kwargs['transferrule']:
             raise InvalidParameter("Transfer container's rule id not found in the input parameters")
-        import pdb; pdb.set_trace()
-        # Fail validation if  both `publishrule` and `multipubrule` does not exists.
-        # We want to deprecate `publishrule` in the future
+        # For backward compatiblity, either `publishrule` or `multipubrulejson`
+        # is enough, and set default value to variable that not supply by
+        # client.
         if (('publishrule' not in kwargs or not kwargs['publishrule'])
            and ('multipubrulejson' not in kwargs or not kwargs['multipubrulejson'])):
             raise InvalidParameter("`publishrule` or `multipubrulejson` are not found in the input parameters.")

--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -43,6 +43,8 @@ class RESTTask(RESTEntity):
             validate_str("transfercontainer", param, safe, RX_DATASET, optional=True)
             validate_str("transferrule", param, safe, RX_RUCIORULE, optional=True)
             validate_str("publishrule", param, safe, RX_RUCIORULE, optional=True)
+            validate_strlist("multipubrule_name", param, safe, RX_ANYTHING)
+            validate_strlist("multipubrule_id", param, safe, RX_ANYTHING)
         elif method in ['GET']:
             validate_str('subresource', param, safe, RX_SUBRES_TASK, optional=False)
             validate_str("workflow", param, safe, RX_TASKNAME, optional=True)
@@ -384,23 +386,24 @@ class RESTTask(RESTEntity):
             raise InvalidParameter("Transfer container name not found in the input parameters")
         if 'transferrule' not in kwargs or not kwargs['transferrule']:
             raise InvalidParameter("Transfer container's rule id not found in the input parameters")
+        import pdb; pdb.set_trace()
         # Fail validation if  both `publishrule` and `multipubrule` does not exists.
         # We want to deprecate `publishrule` in the future
-        import pdb; pdb.set_trace()
         if (('publishrule' not in kwargs or not kwargs['publishrule'])
-           and ('multipubrule' not in kwargs or not kwargs['multipubrule'])):
-            raise InvalidParameter("`publishrule` and `multipubrule` are not found in the input parameters")
+           and (('multipubrule_name' not in kwargs or not kwargs['multipubrule_name'])
+                or ('multipubrule_id' not in kwargs or not kwargs['multipubrule_id']))):
+            raise InvalidParameter("`publishrule` or (`multipubrule_name`,`multipubrule_id`) are not found in the input parameters")
         # set default value if `publishrule` or `multipubrule` does not exists.
         if 'publishrule' not in kwargs or not kwargs['publishrule']:
             publishrule = '00000000000000000000000000000000'
         else:
             publishrule = kwargs['publishrule']
-        if 'multipubrule' not in kwargs or not kwargs['multipubrule']:
-            multipubrule = '{}'
+        if 'multipubrule_name' not in kwargs or not kwargs['multipubrule_name']:
+            multipubrule = {}
+        elif len(kwargs['multipubrule_name']) != (kwargs['multipubrule_id']):
+            raise InvalidParameter("Length of list `multipubrule_name` and `multipubrule_id` is not equal")
         else:
-            multipubrule = kwargs['multipubrule']
-            if not isinstance(multipubrule, str):
-                raise InvalidParameter(f"`multipubrule` expect str, got {type(multipubrule)}")
+            multipubrule = { kwargs['multipubrule_name']: kwargs['multipubrule_id'] for i in range(len(multipubrule_name)) }
         taskname = kwargs['workflow']
         ownerName = getUsernameFromTaskname(taskname)
         authz_operator(username=ownerName, group='crab3', role='operator')
@@ -409,6 +412,6 @@ class RESTTask(RESTEntity):
             tm_transfer_container=[kwargs['transfercontainer']],
             tm_transfer_rule=[kwargs['transferrule']],
             tm_publish_rule=[publishrule],
-            tm_multipub_rule=[multipubrule],
+            tm_multipub_rule=[json.dumps(multipubrule)],
             tm_taskname=[taskname])
         return []

--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -403,7 +403,7 @@ class RESTTask(RESTEntity):
         elif len(kwargs['multipubrule_name']) != len(kwargs['multipubrule_id']):
             raise InvalidParameter("Length of list `multipubrule_name` and `multipubrule_id` is not equal")
         else:
-            multipubrule = { kwargs['multipubrule_name']: kwargs['multipubrule_id'] for i in range(len(kwargs['multipubrule_name'])) }
+            multipubrule = { kwargs['multipubrule_name'][i]: kwargs['multipubrule_id'][i] for i in range(len(kwargs['multipubrule_name'])) }
         taskname = kwargs['workflow']
         ownerName = getUsernameFromTaskname(taskname)
         authz_operator(username=ownerName, group='crab3', role='operator')

--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -7,7 +7,7 @@ from WMCore.REST.Error import InvalidParameter, ExecutionError, NotAcceptable
 from CRABInterface.Utilities import conn_handler, getDBinstance
 from CRABInterface.RESTExtensions import authz_login_valid, authz_owner_match, authz_operator
 from CRABInterface.Regexps import RX_MANYLINES_SHORT, RX_SUBRES_TASK, RX_TASKNAME, RX_STATUS, RX_USERNAME,\
-    RX_RUNS, RX_OUT_DATASET, RX_URL, RX_SCHEDD_NAME, RX_RUCIORULE, RX_DATASET
+    RX_RUNS, RX_OUT_DATASET, RX_URL, RX_SCHEDD_NAME, RX_RUCIORULE, RX_DATASET, RX_ANYTHING
 from ServerUtilities import getUsernameFromTaskname
 
 # external dependecies here

--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -13,6 +13,7 @@ from ServerUtilities import getUsernameFromTaskname
 # external dependecies here
 import re
 import logging
+import json
 from ast import literal_eval
 
 

--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -403,7 +403,7 @@ class RESTTask(RESTEntity):
         elif len(kwargs['multipubrule_name']) != len(kwargs['multipubrule_id']):
             raise InvalidParameter("Length of list `multipubrule_name` and `multipubrule_id` is not equal")
         else:
-            multipubrule = { kwargs['multipubrule_name']: kwargs['multipubrule_id'] for i in range(len(multipubrule_name)) }
+            multipubrule = { kwargs['multipubrule_name']: kwargs['multipubrule_id'] for i in range(len(kwargs['multipubrule_name'])) }
         taskname = kwargs['workflow']
         ownerName = getUsernameFromTaskname(taskname)
         authz_operator(username=ownerName, group='crab3', role='operator')

--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -7,7 +7,7 @@ from WMCore.REST.Error import InvalidParameter, ExecutionError, NotAcceptable
 from CRABInterface.Utilities import conn_handler, getDBinstance
 from CRABInterface.RESTExtensions import authz_login_valid, authz_owner_match, authz_operator
 from CRABInterface.Regexps import RX_MANYLINES_SHORT, RX_SUBRES_TASK, RX_TASKNAME, RX_STATUS, RX_USERNAME,\
-    RX_RUNS, RX_OUT_DATASET, RX_URL, RX_SCHEDD_NAME, RX_RUCIORULE, RX_DATASET, RX_ANYTHING
+    RX_RUNS, RX_OUT_DATASET, RX_URL, RX_SCHEDD_NAME, RX_RUCIORULE, RX_DATASET, RX_ANYTHING_10K
 from ServerUtilities import getUsernameFromTaskname
 
 # external dependecies here
@@ -44,7 +44,7 @@ class RESTTask(RESTEntity):
             validate_str("transfercontainer", param, safe, RX_DATASET, optional=True)
             validate_str("transferrule", param, safe, RX_RUCIORULE, optional=True)
             validate_str("publishrule", param, safe, RX_RUCIORULE, optional=True)
-            validate_str("multipubrulejson", param, safe, RX_MANYLINES_SHORT, optional=True)
+            validate_str("multipubrulejson", param, safe, RX_ANYTHING_10K, optional=True)
         elif method in ['GET']:
             validate_str('subresource', param, safe, RX_SUBRES_TASK, optional=False)
             validate_str("workflow", param, safe, RX_TASKNAME, optional=True)

--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -400,7 +400,7 @@ class RESTTask(RESTEntity):
             publishrule = kwargs['publishrule']
         if 'multipubrule_name' not in kwargs or not kwargs['multipubrule_name']:
             multipubrule = {}
-        elif len(kwargs['multipubrule_name']) != (kwargs['multipubrule_id']):
+        elif len(kwargs['multipubrule_name']) != len(kwargs['multipubrule_id']):
             raise InvalidParameter("Length of list `multipubrule_name` and `multipubrule_id` is not equal")
         else:
             multipubrule = { kwargs['multipubrule_name']: kwargs['multipubrule_id'] for i in range(len(multipubrule_name)) }

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -10,6 +10,8 @@ RX_ANYTHING = re.compile(r"^.*$")
 # as of 2022-03 it is used for warning and failure messages, which were previously
 # encoded in b64 and matched with RX_TEXT_FAIL. see #7106
 RX_MANYLINES_SHORT = re.compile(r"(?s)^.{0,1100}$")
+
+RX_ANYTHING_10K = re.compile(r"^.{0,10000}$")
 # TODO: we should start replacing most of the regex here with what we have in WMCore.Lexicon
 #       (this probably requires to adapt something on Lexicon)
 pNameRE      = r"(?=.{0,400}$)[a-zA-Z0-9\-_.]+"

--- a/src/python/Databases/TaskDB/Oracle/Create.py
+++ b/src/python/Databases/TaskDB/Oracle/Create.py
@@ -102,6 +102,7 @@ class Create(DBCreator):
         tm_transfer_container VARCHAR(1000),
         tm_transfer_rule VARCHAR(255),
         tm_publish_rule VARCHAR(255),
+        tm_multipub_rule CLOB,
         CONSTRAINT taskname_pk PRIMARY KEY(tm_taskname),
         CONSTRAINT check_tm_publication CHECK (tm_publication IN ('T', 'F')),
         CONSTRAINT check_tm_publish_groupname CHECK (tm_publish_groupname IN ('T', 'F')),

--- a/src/python/Databases/TaskDB/Oracle/Task/Task.py
+++ b/src/python/Databases/TaskDB/Oracle/Task/Task.py
@@ -179,5 +179,6 @@ class Task(object):
                                  SET \
                                      tm_transfer_container = :tm_transfer_container, \
                                      tm_transfer_rule = :tm_transfer_rule, \
-                                     tm_publish_rule = :tm_publish_rule \
+                                     tm_publish_rule = :tm_publish_rule, \
+                                     tm_multipub_rule = :tm_multipub_rule \
                                  WHERE tm_taskname = :tm_taskname"""

--- a/src/python/TaskWorker/Actions/RetryJob.py
+++ b/src/python/TaskWorker/Actions/RetryJob.py
@@ -17,15 +17,18 @@ JOB_RETURN_CODES = namedtuple('JobReturnCodes', 'OK RECOVERABLE_ERROR FATAL_ERRO
 # Without this environment variable set, HTCondor takes a write lock per logfile entry
 os.environ['_condor_ENABLE_USERLOG_LOCKING'] = 'false'
 
-##==============================================================================
+# ==============================================================================
+
 
 class FatalError(Exception):
     pass
 
+
 class RecoverableError(Exception):
     pass
 
-##==============================================================================
+
+# ==============================================================================
 
 class RetryJob():
     """
@@ -35,27 +38,27 @@ class RetryJob():
         """
         Class constructor.
         """
-        self.logger              = None
-        self.reqname             = None
-        self.job_return_code     = None
-        self.dag_retry           = None
-        self.crab_retry          = None
-        self.job_id              = None
-        self.dag_jobid           = None
-        self.dag_clusterid       = None
-        self.site                = None
-        self.ads                 = []
-        self.ad                  = {}
-        self.report              = {}
-        self.validreport         = True
+        self.logger = None
+        self.reqname = None
+        self.job_return_code = None
+        self.dag_retry = None
+        self.crab_retry = None
+        self.job_id = None
+        self.dag_jobid = None
+        self.dag_clusterid = None
+        self.site = None
+        self.username = None
+        self.ads = []
+        self.ad = {}
+        self.report = {}
+        self.validreport = True
         self.integrated_job_time = 0
 
         self.MAX_DISK_SPACE = MAX_DISK_SPACE
-        self.MAX_WALLTIME   = MAX_WALLTIME
-        self.MAX_MEMORY     = MAX_MEMORY
+        self.MAX_WALLTIME = MAX_WALLTIME
+        self.MAX_MEMORY = MAX_MEMORY
 
-
-    ##= = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
     def get_job_ad_from_condor_q(self):
         """
@@ -63,16 +66,15 @@ class RetryJob():
         """
         if self.dag_clusterid == -1:
             return
-
         shutil.copy("job_log", "job_log.%s" % str(self.dag_jobid))
-
-        p = subprocess.Popen(["condor_q", "-debug", "-l", "-userlog", "job_log.%s" % str(self.dag_jobid), str(self.dag_jobid)], stdout=subprocess.PIPE, stderr=sys.stderr)
+        p = subprocess.Popen(["condor_q", "-debug", "-l", "-userlog", "job_log.%s" %
+                              str(self.dag_jobid), str(self.dag_jobid)], stdout=subprocess.PIPE, stderr=sys.stderr)
         output, _ = p.communicate()
         status = p.returncode
 
         try:
             os.unlink("job_log.%s" % str(self.dag_jobid))
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             pass
 
         if status:
@@ -87,7 +89,7 @@ class RetryJob():
                 self.ads.append(ad)
         self.ad = self.ads[-1]
 
-    ##= = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
     def get_job_ad_from_file(self):
         """
@@ -104,7 +106,7 @@ class RetryJob():
                 try:
                     with open(job_ad_file, encoding='utf-8') as fd:
                         ad = classad.parseOld(fd)
-                except Exception:
+                except Exception:  # pylint: disable=broad-except
                     msg = "Unable to parse classads from file %s. Continuing." % (job_ad_file)
                     self.logger.warning(msg)
                     continue
@@ -114,7 +116,7 @@ class RetryJob():
                 msg = "File %s does not exist. Continuing." % (job_ad_file)
                 self.logger.warning(msg)
 
-    ##= = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
     def get_report(self):
         """
@@ -132,7 +134,7 @@ class RetryJob():
         except IOError:
             self.validreport = False
 
-    ##= = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
     def record_site(self, job_status):
         """
@@ -145,17 +147,17 @@ class RetryJob():
         try:
             with os.fdopen(os.open("task_statistics.%s.%s" % (self.site, job_status_name), os.O_APPEND | os.O_CREAT | os.O_RDWR, 0o644), 'a') as fd:
                 fd.write("%s\n" % (self.job_id))
-        except Exception as ex:
+        except Exception as ex:  # pylint: disable=broad-except
             self.logger.error(str(ex))
             # Swallow the exception - record_site is advisory only
         try:
             with os.fdopen(os.open("task_statistics.%s" % (job_status_name), os.O_APPEND | os.O_CREAT | os.O_RDWR, 0o644), 'a') as fd:
                 fd.write("%s\n" % (self.job_id))
-        except Exception as ex:
+        except Exception as ex:  # pylint: disable=broad-except
             self.logger.error(str(ex))
             # Swallow the exception - record_site is advisory only
 
-    ##= = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
     def create_fake_fjr(self, exitMsg, exitCode, jobExitCode=None, fatalError=True):
         """
@@ -172,8 +174,8 @@ class RetryJob():
             fake_fjr['exitCode'] = exitCode
         jobReport = "job_fjr.%s.%d.json" % (self.job_id, self.crab_retry)
         if os.path.isfile(jobReport) and os.path.getsize(jobReport) > 0:
-            #File exists and it is not empty
-            msg  = "%s file exists and it is not empty!" % (jobReport)
+            # File exists and it is not empty
+            msg = "%s file exists and it is not empty!" % (jobReport)
             msg += " CRAB3 will overwrite it, because the job got FatalError"
             self.logger.info(msg)
             with open(jobReport, 'r', encoding='utf-8') as fd:
@@ -188,7 +190,7 @@ class RetryJob():
         if fatalError:
             raise FatalError(exitMsg)
 
-    ##= = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
     def check_cpu_report(self):
         """
@@ -219,11 +221,11 @@ class RetryJob():
         if total_job_time > self.MAX_WALLTIME:
             exitMsg = "Not retrying a long running job (job ran for %d hours)" % (total_job_time / 3600)
             self.create_fake_fjr(exitMsg, 50664)  # this raises FatalError
-        if integrated_job_time > 1.5*self.MAX_WALLTIME:
+        if integrated_job_time > (1.5 * self.MAX_WALLTIME):
             exitMsg = "Not retrying a job because the integrated time (across all retries) is %d hours." % (integrated_job_time / 3600)
             self.create_fake_fjr(exitMsg, 50664)  # this raises FatalError
 
-    ##= = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
     def check_memory_report(self):
         """
@@ -231,7 +233,7 @@ class RetryJob():
         """
         # If job was killed on the worker node, we probably don't have a FJR.
         if self.ad.get("RemoveReason", "").startswith("Removed due to memory use"):
-            job_rss = int(self.ad.get("ResidentSetSize","0")) // 1000
+            job_rss = int(self.ad.get("ResidentSetSize", "0")) // 1000
             exitMsg = "Job killed by HTCondor due to excessive memory use"
             exitMsg += " (RSS=%d MB)." % job_rss
             exitMsg += " Will not retry it."
@@ -250,7 +252,7 @@ class RetryJob():
             exitMsg = "Not retrying job due to excessive memory use (%d MB vs %d MB requested)" % (total_job_memory, self.MAX_MEMORY)
             self.create_fake_fjr(exitMsg, 50660, 50660)
 
-    ##= = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
     def check_disk_report(self):
         """
@@ -275,8 +277,7 @@ class RetryJob():
                 msg = "Unable to get DiskUsage from job classads. Will not perform Disk Usage check."
                 self.logger.debug(msg)
 
-
-    ##= = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
     def check_expired_report(self):
         """
@@ -286,7 +287,7 @@ class RetryJob():
             exitMsg = "Not retrying job due to excessive idle time (job automatically killed on the grid scheduler)"
             self.create_fake_fjr(exitMsg, 50665, 50665)
 
-    ##= = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
     def check_exit_code(self):
         """
@@ -310,15 +311,15 @@ class RetryJob():
             self.logger.info(msg)
             return 0
 
-        msg  = "Job or stageout wrapper finished with exit code %d." % (exitCode)
+        msg = "Job or stageout wrapper finished with exit code %d." % (exitCode)
         msg += " Trying to determine the meaning of the exit code and if it is a recoverable or fatal error."
         self.logger.info(msg)
 
-        ## Wrapper script sometimes returns the posix return code (8 bits).
+        # Wrapper script sometimes returns the posix return code (8 bits).
         if exitCode in [8020, 8021, 8028] or exitCode in [84, 85, 92]:
             try:  # the following is still a bit experimental, make sure it never crashes the PJ
                 corruptedInputFile = self.check_corrupted_file(exitCode)
-            except Exception as e:
+            except Exception as e:  # pylint: disable=broad-except
                 msg = f"check_corrupted_file raised an exception:\n{e}\nIgnore and go on"
                 self.logger.error(msg)
                 corruptedInputFile = False
@@ -347,8 +348,8 @@ class RetryJob():
                         if line.startswith("== CMSSW:  A fatal system signal has occurred: illegal instruction"):
                             recoverable_signal = True
                             break
-            except Exception:
-                msg  = "Error analyzing abort signal."
+            except Exception:  # pylint: disable=broad-except
+                msg = "Error analyzing abort signal."
                 msg += "\nDetails follow:"
                 self.logger.exception(msg)
             if recoverable_signal:
@@ -364,8 +365,8 @@ class RetryJob():
                         if cvmfs_issue_re.match(line):
                             cvmfs_issue = True
                             break
-            except Exception:
-                msg  = "Error analyzing output for CVMFS issues."
+            except Exception:  # pylint: disable=broad-except
+                msg = "Error analyzing output for CVMFS issues."
                 msg += "\nDetails follow:"
                 self.logger.exception(msg)
             if cvmfs_issue:
@@ -395,7 +396,7 @@ class RetryJob():
 
         return 0
 
-    ##= = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
     def check_corrupted_file(self, exitCode):
         """
@@ -440,6 +441,7 @@ class RetryJob():
                         fragment2 = fragment1.split('.root')[0]
                         inputFileName = f"/store/{fragment2}.root"
                         self.logger.info(f"RSE: {RSE} - ec: {exitCode} - file: {inputFileName}")
+
                     else:
                         corruptedFile = False
                         suspiciousFile = True
@@ -449,9 +451,10 @@ class RetryJob():
                     break
         if corruptedFile or suspiciousFile:
             # add pointers to logs
-            schedId = socket.gethostname().split('.')[0][-3:]  # last 3 char of hostname e.g. vomcs195.cern.ch --> 195
+            schedHostname = socket.gethostname().split('.')[0]
+            schedId = schedHostname.split('0')[1]  # vomcs059 --> 59, vocms0144 --> 144 etc,
             username = self.reqname.split(':')[1].split('_')[0]
-            webDirUrl = f"http://cmsweb.cern.ch:8443/scheddmon/{schedId}/{username}/{self.reqname}"
+            webDirUrl = f"https://cmsweb.cern.ch:8443/scheddmon/0{schedId}/{username}/{self.reqname}"
             stdoutUrl = f"{webDirUrl}/job_out.{self.job_id}.{self.crab_retry}.txt"
             postJobUrl = f"{webDirUrl}/postjob.{self.job_id}.{self.crab_retry}.txt"
             errorLines.append(f"stdout: {stdoutUrl}")
@@ -459,7 +462,7 @@ class RetryJob():
             # note things  down
             reportFileName = f'{self.reqname}.job.{self.job_id}.{self.crab_retry}.json'
             corruptionMessage = {'DID': f'cms:{inputFileName}', 'RSE': RSE,
-                                  'exitCode': exitCode, 'message': errorLines}
+                                 'exitCode': exitCode, 'message': errorLines}
             with open(reportFileName, 'w', encoding='utf-8') as fp:
                 json.dump(corruptionMessage, fp)
             self.logger.info('corruption message prepared, gfal-copy to EOS')
@@ -477,7 +480,7 @@ class RetryJob():
                 self.logger.error(f'gfal-copy failed with out: {out} err: {err}')
         return corruptedFile
 
-    ##= = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
     def check_empty_report(self):
         """
@@ -486,20 +489,20 @@ class RetryJob():
         if not self.report or not self.validreport:
             raise RecoverableError("Job did not produce a usable framework job report.")
 
-    ##= = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
     def execute_internal(self, logger, reqname, username, job_return_code, dag_retry, crab_retry, job_id, dag_jobid, job_ad, used_job_ad):
         """
         Need a doc string here.
         """
-        self.logger          = logger
-        self.reqname         = reqname
-        self.username        = username
+        self.logger = logger
+        self.reqname = reqname
+        self.username = username
         self.job_return_code = job_return_code
-        self.dag_retry       = dag_retry
-        self.crab_retry      = crab_retry
-        self.job_id          = job_id
-        self.dag_jobid       = dag_jobid
+        self.dag_retry = dag_retry
+        self.crab_retry = crab_retry
+        self.job_id = job_id
+        self.dag_jobid = dag_jobid
 
         try:
             self.dag_clusterid = int(self.dag_jobid.split(".")[0])
@@ -507,7 +510,7 @@ class RetryJob():
             pass
 
         if used_job_ad:
-            #We can determine walltime and max memory from job ad.
+            # We can determine walltime and max memory from job ad.
             self.ad = job_ad
             if 'MaxWallTimeMinsRun' in self.ad:
                 self.MAX_WALLTIME = int(self.ad['MaxWallTimeMinsRun']) * 60
@@ -527,8 +530,8 @@ class RetryJob():
             self.logger.debug(msg)
             self.get_job_ad_from_condor_q()
 
-        ## Do we still need identification of site in self.get_report()?
-        ## We can always get it from job ad.
+        # Do we still need identification of site in self.get_report()?
+        # We can always get it from job ad.
         if 'JOBGLIDEIN_CMSSite' in self.ad:
             self.site = self.ad['JOBGLIDEIN_CMSSite']
 
@@ -540,8 +543,8 @@ class RetryJob():
 
         try:
             self.check_empty_report()
-            ## Raises a RecoverableError or FatalError exception depending on the exitCode
-            ## saved in the job report.
+            # Raises a RecoverableError or FatalError exception depending on the exitCode
+            # saved in the job report.
             check_exit_code_retval = self.check_exit_code()
         except RecoverableError as e:
             orig_msg = str(e)
@@ -550,28 +553,28 @@ class RetryJob():
                 self.check_cpu_report()
                 self.check_disk_report()
                 self.check_expired_report()
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 msg = "Original error: %s" % (orig_msg)
                 self.logger.error(msg)
                 raise
             raise
 
-        ## The fact that check_exit_code() has not raised RecoverableError or FatalError
-        ## doesn't necessarily mean that the job was successful; check_exit_code() reads
-        ## the job exit code from the job report and it might be that the exit code is
-        ## not there, in which case check_exit_code() returns silently. So as a safety
-        ## measure we check here the job return code passed to the post-job via the
-        ## DAGMan $RETURN argument macro. This is equal to the return code of the job
-        ## when the job was executed, and is equal to -100[1,2,3,4] when ["job failed to
-        ## be submitted to the batch system", "job externally removed from the batch
-        ## system queue", "error in the job log monitor", "job not executed because PRE
-        ## script returned non-zero"] respectively. In the particular case of job return
-        ## code = -1004 and job exit code from (previous job retry) job report = 0, we
-        ## should continue and not do the check. The reason is: the pre-job is not
-        ## expected to fail; if the pre-job returned non-zero we assume it was done so
-        ## in order to intentionally skip the job execution.
+        # The fact that check_exit_code() has not raised RecoverableError or FatalError
+        # doesn't necessarily mean that the job was successful; check_exit_code() reads
+        # the job exit code from the job report and it might be that the exit code is
+        # not there, in which case check_exit_code() returns silently. So as a safety
+        # measure we check here the job return code passed to the post-job via the
+        # DAGMan $RETURN argument macro. This is equal to the return code of the job
+        # when the job was executed, and is equal to -100[1,2,3,4] when ["job failed to
+        # be submitted to the batch system", "job externally removed from the batch
+        # system queue", "error in the job log monitor", "job not executed because PRE
+        # script returned non-zero"] respectively. In the particular case of job return
+        # code = -1004 and job exit code from (previous job retry) job report = 0, we
+        # should continue and not do the check. The reason is: the pre-job is not
+        # expected to fail; if the pre-job returned non-zero we assume it was done so
+        # in order to intentionally skip the job execution.
         if not (self.job_return_code == -1004 and check_exit_code_retval == 0):
-            if self.job_return_code != JOB_RETURN_CODES.OK: # Probably means stageout failed!
+            if self.job_return_code != JOB_RETURN_CODES.OK:  # Probably means stageout failed!
                 msg = "Payload job was successful, but wrapper exited with non-zero status %d" % (self.job_return_code)
                 if self.job_return_code > 0:
                     msg += " (stageout failure)?"
@@ -579,7 +582,7 @@ class RetryJob():
 
         return JOB_RETURN_CODES.OK
 
-    ##= = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
     def execute(self, *args, **kw):
         """
@@ -597,6 +600,6 @@ class RetryJob():
             self.logger.error(str(e))
             self.record_site(JOB_RETURN_CODES.FATAL_ERROR)
             return JOB_RETURN_CODES.FATAL_ERROR
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-except
             self.logger.exception(str(e))
             return 0  # Why do we return 0 here ?

--- a/test/assets/container_ruleid.json
+++ b/test/assets/container_ruleid.json
@@ -1,0 +1,9 @@
+{
+    "containerRuleID": "c88abb899f744efb8f33fd197ee77ecd",
+    "publishRuleID": "141a41b6b54f45f59dc0703182f1257f",
+	"multiPubRuleIDs":  {
+        "/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__cmsRun.log.tar.gz/USER": "9653f39f686944128028fd25888ae2d3",
+        "/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__output.root/USER": "e609d75e4a7a4fa3a880ea0bb6681371",
+        "/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__miniaodfake.root/USER": "6b159d7e5dc940daa2188658a68c4b23"
+    }
+}

--- a/test/assets/transferDicts.json
+++ b/test/assets/transferDicts.json
@@ -1,0 +1,70 @@
+[
+    {
+        "id": "7652449e07afeaf00abe804e8507f4172e5b04f09a2c5e0d883a3193",
+        "username": "tseethon",
+        "taskname": "231012_154207:tseethon_crab_rucio_transfers_hc1kj_withnonedm_test12_20231012_174204",
+        "start_time": 1697125531,
+        "destination": "T2_CH_CERN",
+        "destination_lfn": "/store/user/rucio/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/log/cmsRun_3.log.tar.gz",
+        "source": "T2_CH_CERN",
+        "source_lfn": "/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/log/cmsRun_3.log.tar.gz",
+        "filesize": 10910,
+        "publish": 0,
+        "transfer_state": "NEW",
+        "publication_state": "NOT_REQUIRED",
+        "job_id": "3",
+        "job_retry_count": 0,
+        "type": "log",
+        "publishname": "ruciotransfers-1697125324-00000000000000000000000000000000",
+        "checksums": {
+            "adler32": "abc"
+        },
+        "outputdataset": "/FakeDataset/fakefile-FakePublish-befe3559057072761674520fdaee5005/USER"
+    },
+    {
+        "id": "10ba0d321da1a9d7ecc17e2bf411932ec5268ae12d5be76b5928dc29",
+        "username": "tseethon",
+        "taskname": "231012_154207:tseethon_crab_rucio_transfers_hc1kj_withnonedm_test12_20231012_174204",
+        "start_time": 1697125531,
+        "destination": "T2_CH_CERN",
+        "destination_lfn": "/store/user/rucio/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/miniaodfake_3.root",
+        "source": "T2_CH_CERN",
+        "source_lfn": "/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/miniaodfake_3.root",
+        "filesize": 104857600,
+        "publish": 0,
+        "transfer_state": "NEW",
+        "publication_state": "NOT_REQUIRED",
+        "job_id": "3",
+        "job_retry_count": 0,
+        "type": "output",
+        "publishname": "ruciotransfers-1697125324-00000000000000000000000000000000",
+        "checksums": {
+            "adler32": "141d411c",
+            "cksum": "2726547828"
+        },
+        "outputdataset": "/FakeDataset/fakefile-FakePublish-befe3559057072761674520fdaee5005/USER"
+    },
+    {
+        "id": "091bfc9fb03fe326b1ace7cac5b71e034ce4b44ed46be14ae88b472a",
+        "username": "tseethon",
+        "taskname": "231012_154207:tseethon_crab_rucio_transfers_hc1kj_withnonedm_test12_20231012_174204",
+        "start_time": 1697125531,
+        "destination": "T2_CH_CERN",
+        "destination_lfn": "/store/user/rucio/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/output_3.root",
+        "source": "T2_CH_CERN",
+        "source_lfn": "/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/output_3.root",
+        "filesize": 632378,
+        "publish": 0,
+        "transfer_state": "NEW",
+        "publication_state": "NOT_REQUIRED",
+        "job_id": "3",
+        "job_retry_count": 0,
+        "type": "output",
+        "publishname": "ruciotransfers-1697125324-00000000000000000000000000000000",
+        "checksums": {
+            "adler32": "cd95e2da",
+            "cksum": "2038182269"
+        },
+        "outputdataset": "/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d/USER"
+    }
+]

--- a/test/python/ASO/Rucio/Actions/test_MonitorLockStatus.py
+++ b/test/python/ASO/Rucio/Actions/test_MonitorLockStatus.py
@@ -348,3 +348,7 @@ def test_registerToMutiPubContainers(mock_addReplicasToContainer):
 
     # check return value
     assert sorted(ret, key=lambda d: d['id']) == sorted(returnValue, key=lambda d: d['id'])
+
+
+def test_checkBlockCompleteStatus():
+    assert 1 == 0

--- a/test/python/ASO/Rucio/test_Transfer.py
+++ b/test/python/ASO/Rucio/test_Transfer.py
@@ -9,7 +9,7 @@ from argparse import Namespace
 from ASO.Rucio.Transfer import Transfer
 from ASO.Rucio.exception import RucioTransferException
 import ASO.Rucio.config as config
-from .fixtures import mock_rucioClient
+#from .fixtures import mock_rucioClient
 
 
 @pytest.fixture
@@ -40,6 +40,12 @@ def listContentDatasets():
 @pytest.fixture
 def listContentFiles():
     path = 'test/assets/rucio_list_content_datasets.json'
+    with open(path, 'r', encoding='utf-8') as r:
+        return json.load(r)
+
+@pytest.fixture
+def transferDicts():
+    path = 'test/assets/transferDicts.json'
     with open(path, 'r', encoding='utf-8') as r:
         return json.load(r)
 
@@ -258,3 +264,15 @@ def test_getContainerInfo(mock_rucioClient, listContentDatasets, listContentFile
 @pytest.mark.skip(reason='I am really lazy')
 def test_buildReplica2IDMap():
     assert 0 == 1
+
+
+def test_buildMultiPubContainers(transferDicts):
+    t = Transfer()
+    t.transferItems = transferDicts
+    t.publishContainer = '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d/USER'
+    t.buildMultiPubContainers()
+    assert t.multiPubContainers == [
+        '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__cmsRun.log.tar.gz/USER',
+        '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__miniaodfake.root/USER',
+        '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__output.root/USER',
+    ]

--- a/test/python/ASO/Rucio/test_Transfer.py
+++ b/test/python/ASO/Rucio/test_Transfer.py
@@ -306,3 +306,17 @@ def test_updateContainerRuleID(containerRuleIDJSONContent, fs):
         x = json.loads(mock_file.read())
         y = json.loads(containerRuleIDJSONContent)
         assert x == y
+
+def test_readContainerRuleID(containerRuleIDJSONContent, fs):
+    path = '/path/to/container_ruleid.json'
+    config.args = Namespace(container_ruleid_path=path, force_publishname=False)
+    with patch('ASO.Rucio.Transfer.open', new_callable=mock_open, read_data=containerRuleIDJSONContent):
+        t = Transfer()
+        t.readContainerRuleID()
+        assert t.containerRuleID == 'c88abb899f744efb8f33fd197ee77ecd'
+        assert t.publishRuleID == '141a41b6b54f45f59dc0703182f1257f'
+        assert t.multiPubRuleIDs == {
+            '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__cmsRun.log.tar.gz/USER': '9653f39f686944128028fd25888ae2d3',
+            '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__output.root/USER': 'e609d75e4a7a4fa3a880ea0bb6681371',
+            '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__miniaodfake.root/USER': '6b159d7e5dc940daa2188658a68c4b23',
+        }

--- a/test/testingConfigs
+++ b/test/testingConfigs
@@ -3,6 +3,7 @@ CMSSW_release=CMSSW_12_6_4;SCRAM_ARCH=el8_amd64_gcc10;inputDataset=/GenericTTbar
 CMSSW_release=CMSSW_12_5_0;SCRAM_ARCH=el8_amd64_gcc10;inputDataset=/GenericTTbar/HC-CMSSW_9_2_6_91X_mcRun1_realistic_v2-v2/AODSIM;master=no;
 CMSSW_release=CMSSW_11_3_4;SCRAM_ARCH=slc7_amd64_gcc900;inputDataset=/GenericTTbar/HC-CMSSW_9_2_6_91X_mcRun1_realistic_v2-v2/AODSIM;master=no;
 CMSSW_release=CMSSW_10_6_26;SCRAM_ARCH=slc7_amd64_gcc700;inputDataset=/GenericTTbar/HC-CMSSW_9_2_6_91X_mcRun1_realistic_v2-v2/AODSIM;master=yes;
+CMSSW_release=CMSSW_10_1_0;SCRAM_ARCH=slc7_amd64_gcc630;inputDataset=/GenericTTbar/HC-CMSSW_9_2_6_91X_mcRun1_realistic_v2-v2/AODSIM;master=no;
 CMSSW_release=CMSSW_9_4_21;SCRAM_ARCH=slc7_amd64_gcc630;inputDataset=/GenericTTbar/HC-CMSSW_9_2_6_91X_mcRun1_realistic_v2-v2/AODSIM;master=no;
 CMSSW_release=CMSSW_8_0_36;SCRAM_ARCH=slc7_amd64_gcc530;inputDataset=/GenericTTbar/HC-CMSSW_7_0_4_START70_V7-v1/GEN-SIM-RECO;master=no;
 CMSSW_release=CMSSW_7_6_7;SCRAM_ARCH=slc6_amd64_gcc493;inputDataset=/GenericTTbar/HC-CMSSW_5_3_1_START53_V5-v1/GEN-SIM-RECO;master=no;


### PR DESCRIPTION
Fix https://github.com/dmwm/CRABServer/issues/7976

In summary, this PR is changed in following code part:
-  Add new column `tm_multipub_rule`
- Construct `Transfer.multiPubContainers` to store all publish container names.
- Create container for all `Transfer.multiPubContainers` and store rule ids in `Transfer.multiPubRuleIDs`.
- New `MonitorLockStatus.registerToMutiPubContainers()` to register transferred success replicas to its own publish container.

Please ignore pytest for now.