### PR TITLE
Multiple Publish Container

### DIFF
--- a/etc/updateOracle.sql
+++ b/etc/updateOracle.sql
@@ -136,3 +136,6 @@ ALTER TABLE filetransfersdb ADD tm_block_complete VARCHAR(10);
 ALTER TABLE tasks ADD tm_transfer_container VARCHAR(1000);
 ALTER TABLE tasks ADD tm_transfer_rule VARCHAR(255);
 ALTER TABLE tasks ADD tm_publish_rule VARCHAR(255);
+
+--Add Rucio ASO's json kv for store container names and its rules.
+ALTER TABLE tasks ADD tm_multipub_rule CLOB;

--- a/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
+++ b/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
@@ -46,7 +46,7 @@ class MonitorLockStatus:
         ## to.
         #publishedFileDocs = self.registerToPublishContainer(needToPublishFileDocs)
         #publishedFileDocs = self.registerToPublishContainer(okFileDocs)
-        publishedFileDocs = self.registerToMutiPubContainers(okFileDocs)
+        publishedFileDocs = self.registerToMultiPubContainers(okFileDocs)
         self.logger.debug(f'publishedFileDocs: {publishedFileDocs}')
         # skip filedocs that already update it status to rest.
         newPublishFileDocs = [doc for doc in publishedFileDocs if not doc['dataset'] in self.transfer.bookkeepingBlockComplete]
@@ -112,7 +112,7 @@ class MonitorLockStatus:
             f['dataset'] = tmpLFN2DatasetMap[f['name']]
         return tmpFileDocs
 
-    def registerToMutiPubContainers(self, fileDocs):
+    def registerToMultiPubContainers(self, fileDocs):
         """
         Register replicas to it own publish container.
 

--- a/src/python/ASO/Rucio/Actions/RegisterReplicas.py
+++ b/src/python/ASO/Rucio/Actions/RegisterReplicas.py
@@ -203,7 +203,7 @@ class RegisterReplicas:
 
         :param fileDocs: a list of fileDoc info an
         :type fileDocs: list of dict
-        :return: same list as fileDocs args but with updated rule iD and dataset
+        :return: same list as fileDocs args but with updated rule ID and dataset
             name
         :rtype: list of dict
         """
@@ -243,7 +243,7 @@ class RegisterReplicas:
                     'id': c['id'],
                     'name': c['name'],
                     'dataset': currentDataset,
-                    'blockcomplete': None,
+                    'blockcomplete': 'NO',
                     'ruleid': self.transfer.containerRuleID,
                 }
                 containerFileDocs.append(success)

--- a/src/python/ASO/Rucio/Actions/RegisterReplicas.py
+++ b/src/python/ASO/Rucio/Actions/RegisterReplicas.py
@@ -180,7 +180,7 @@ class RegisterReplicas:
                     # Note that at this point, it still possible for job to
                     # retry because file is not register in replica yet.
                     self.logger.exception(ex)
-                    self.logger.warning(f'Exception is raised at add_replicas(rse, rs)')
+                    self.logger.warning('Exception is raised at add_replicas(rse, rs)')
                     self.logger.debug(f'rse={rse}, rs={rs}')
                     for idx, r in chunk:
                         fileDoc = {

--- a/src/python/ASO/Rucio/Transfer.py
+++ b/src/python/ASO/Rucio/Transfer.py
@@ -8,7 +8,7 @@ import hashlib
 
 import ASO.Rucio.config as config # pylint: disable=consider-using-from-import
 from ASO.Rucio.exception import RucioTransferException
-from ASO.Rucio.utils import writePath, parseFileNameFromLFN
+from ASO.Rucio.utils import writePath, parseFileNameFromLFN, addSuffixToProcessedDataset
 
 
 class Transfer:
@@ -341,7 +341,6 @@ def manipulateOutputDataset(transfer, forcePubName):
     """
     # import here to prevent import error in prod code.
     import copy # pylint: disable=import-outside-toplevel
-    from ASO.Rucio.utils import addSuffixToProcessedDataset # pylint: disable=import-outside-toplevel
     newTransfer = copy.deepcopy(transfer)
     newhash = hashlib.md5(forcePubName.encode()).hexdigest()[:8]
     if transfer['outputdataset'].startswith('/FakeDataset'):

--- a/src/python/ASO/Rucio/Transfer.py
+++ b/src/python/ASO/Rucio/Transfer.py
@@ -183,7 +183,7 @@ class Transfer:
     def buildMultiPubContainerNames(self):
         """
         Create the `self.multiPubContainers` by reading all transfers
-        dict from the same job id.
+        dict from the first job id available in transfer dicts.
 
         If it starts with '/FakeDatset', append filename to ProcessedName
         section of DBS dataset name.

--- a/src/python/ASO/Rucio/Transfer.py
+++ b/src/python/ASO/Rucio/Transfer.py
@@ -8,7 +8,8 @@ import hashlib
 
 import ASO.Rucio.config as config # pylint: disable=consider-using-from-import
 from ASO.Rucio.exception import RucioTransferException
-from ASO.Rucio.utils import writePath, parseFileNameFromLFN, addSuffixToProcessedDataset
+from ASO.Rucio.utils import writePath, parseFileNameFromLFN
+
 
 class Transfer:
     """
@@ -339,8 +340,8 @@ def manipulateOutputDataset(transfer, forcePubName):
     in normal task submission.
     """
     # import here to prevent import error in prod code.
-    import copy
-    from ASO.Rucio.utils import addSuffixToProcessedDataset
+    import copy # pylint: disable=import-outside-toplevel
+    from ASO.Rucio.utils import addSuffixToProcessedDataset # pylint: disable=import-outside-toplevel
     newTransfer = copy.deepcopy(transfer)
     newhash = hashlib.md5(forcePubName.encode()).hexdigest()[:8]
     if transfer['outputdataset'].startswith('/FakeDataset'):

--- a/src/python/ASO/Rucio/Transfer.py
+++ b/src/python/ASO/Rucio/Transfer.py
@@ -116,6 +116,7 @@ class Transfer:
             with open(path, 'r', encoding='utf-8') as r:
                 for line in r:
                     doc = json.loads(line)
+                    # Manipulate transfers dicts when running integration test
                     if config.args.force_publishname:
                         doc = manipulateOutputDataset(doc, config.args.force_publishname)
                     self.transferItems.append(doc)
@@ -334,13 +335,16 @@ class Transfer:
 
 def manipulateOutputDataset(transfer, forcePubName):
     """
-    This helper function is use only for run integration test.
+    Replace 'outpudataset' key of transfer dicts to the new name.
+    If /FakeDataset, use `forcePubName` to compute hash and append to the name.
+    Else `forcePubName` is used.
 
-    It is protected by `if config.args.force_publishname` and never mean to run
-    in normal task submission.
+    This helper function is used only to run integration tests, never to run
+    in a normal task submission.
     """
     # import here to prevent import error in prod code.
     import copy # pylint: disable=import-outside-toplevel
+    from ASO.Rucio.utils import addSuffixToProcessedDataset # pylint: disable=redefined-outer-name, reimported, import-outside-toplevel
     newTransfer = copy.deepcopy(transfer)
     newhash = hashlib.md5(forcePubName.encode()).hexdigest()[:8]
     if transfer['outputdataset'].startswith('/FakeDataset'):

--- a/src/python/ASO/Rucio/utils.py
+++ b/src/python/ASO/Rucio/utils.py
@@ -3,6 +3,7 @@ The utility function of Rucio ASO.
 """
 import shutil
 import re
+import os
 from contextlib import contextmanager
 import itertools
 
@@ -112,3 +113,64 @@ def LFNToPFNFromPFN(lfn, pfn):
     else:
         fileid = '/'.join(lfn.split("/")[-2:])
     return f'{pfnPrefix}/{fileid}'
+
+def addSuffixToDatasetName(dataset, strsuffix):
+    """
+    Adding suffix to dataset name in the "name" part.
+
+    :param dataset: Fully qualified dataset's name
+    :type dataset: str
+    :param strsuffix: string suffix to add
+    :type strsuffix: str
+
+    :return: new dataset name
+    :rtype: str
+
+    >>> addSuffixToDatasetName('/GenericTTbar/cmsbot-mypublishdbsname-1/USER', '__output.root')
+    '/GenericTTbar/cmsbot-mypublishdbsname-1__output.root/USER'
+
+    """
+    tmp = dataset.split('/')
+    tmp[2] += strsuffix
+    return '/'.join(tmp)
+
+
+def parseFileNameFromLFN(lfn):
+    """
+    Parsing file name from LFN.
+
+    For the job's output files, we append `_{job_id}` before the last file
+    extension. But for the log file, we use the format
+    `cmsRun_{job_id}.log.tar.gz` instead. So, the log file will be hardcode to
+    always return 'cmsRun.log.tar.gz'.
+
+    See https://github.com/dmwm/CRABServer/blob/f5fa82078ff858fd35cf11773020f258abd2c3c7/src/python/TaskWorker/Actions/DagmanCreator.py#L621-L626
+    and https://github.com/dmwm/CRABServer/blob/f5fa82078ff858fd35cf11773020f258abd2c3c7/src/python/TaskWorker/Actions/DagmanCreator.py#L644
+    on how file name is created.
+
+    :param lfn: LFN
+    :type lfn: str
+
+    :return: file name
+    :rtype: str
+
+    >>>parseFileNameFromLFN('/store/user/rucio/cmsbot/somedir/output_3.root')
+    'output.root'
+
+    >>>parseFileNameFromLFN('/store/user/rucio/cmsbot/somedir/file.with.long.ext_3.txt')
+    'file.with.long.ext.txt'
+
+    >>>parseFileNameFromLFN('/store/user/rucio/cmsbot/somedir/cmsRun_3.log.tar.gz')
+    'cmsRun.log.tar.gz'
+
+    """
+    filename = os.path.basename(lfn)
+    regex = re.compile(r'^cmsRun_[0-9]+\.log\.tar\.gz$')
+    if regex.match(filename):
+        return 'cmsRun.log.tar.gz'
+    leftPiece, jobid_fileext = filename.rsplit("_", 1)
+    origFileName = leftPiece
+    if "." in jobid_fileext:
+        fileExt = jobid_fileext.rsplit(".", 1)[-1]
+        origFileName = leftPiece + "." + fileExt
+    return origFileName

--- a/src/python/ASO/Rucio/utils.py
+++ b/src/python/ASO/Rucio/utils.py
@@ -114,20 +114,20 @@ def LFNToPFNFromPFN(lfn, pfn):
         fileid = '/'.join(lfn.split("/")[-2:])
     return f'{pfnPrefix}/{fileid}'
 
-def addSuffixToDatasetName(dataset, strsuffix):
+def addSuffixToProcessedDataset(dataset, strsuffix):
     """
-    Adding suffix to dataset name in the "name" part.
+    Adding suffix to ProcessedDataset name.
 
-    :param dataset: Fully qualified dataset's name
+    :param dataset: DBS dataset name
     :type dataset: str
     :param strsuffix: string suffix to add
     :type strsuffix: str
 
-    :return: new dataset name
+    :return: new DBS dataset name
     :rtype: str
 
-    >>> addSuffixToDatasetName('/GenericTTbar/cmsbot-mypublishdbsname-1/USER', '__output.root')
-    '/GenericTTbar/cmsbot-mypublishdbsname-1__output.root/USER'
+    >>> addSuffixToDatasetName('/GenericTTbar/cmsbot-mypublishdbsname-1/USER', '_output.root')
+    '/GenericTTbar/cmsbot-mypublishdbsname-1_output.root/USER'
 
     """
     tmp = dataset.split('/')
@@ -141,7 +141,7 @@ def parseFileNameFromLFN(lfn):
 
     For the job's output files, we append `_{job_id}` before the last file
     extension. But for the log file, we use the format
-    `cmsRun_{job_id}.log.tar.gz` instead. So, the log file will be hardcode to
+    `cmsRun_{job_id}.log.tar.gz` instead. So, the log file will be hardcoded to
     always return 'cmsRun.log.tar.gz'.
 
     See https://github.com/dmwm/CRABServer/blob/f5fa82078ff858fd35cf11773020f258abd2c3c7/src/python/TaskWorker/Actions/DagmanCreator.py#L621-L626

--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -394,7 +394,7 @@ class RESTTask(RESTEntity):
             raise InvalidParameter("Neither `publishrule` nor `multipubrulejson` are found in the input parameters.")
         # set default value if neither `publishrule` nor `multipubrule` exists
         if 'publishrule' not in kwargs or not kwargs['publishrule']:
-            publishrule = '00000000000000000000000000000000'
+            publishrule = '0'*32
         else:
             publishrule = kwargs['publishrule']
         if 'multipubrulejson' not in kwargs or not kwargs['multipubrulejson']:

--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -7,7 +7,7 @@ from WMCore.REST.Error import InvalidParameter, ExecutionError, NotAcceptable
 from CRABInterface.Utilities import conn_handler, getDBinstance
 from CRABInterface.RESTExtensions import authz_login_valid, authz_owner_match, authz_operator
 from CRABInterface.Regexps import RX_MANYLINES_SHORT, RX_SUBRES_TASK, RX_TASKNAME, RX_STATUS, RX_USERNAME,\
-    RX_RUNS, RX_OUT_DATASET, RX_URL, RX_SCHEDD_NAME, RX_RUCIORULE, RX_DATASET
+    RX_RUNS, RX_OUT_DATASET, RX_URL, RX_SCHEDD_NAME, RX_RUCIORULE, RX_DATASET, RX_ANYTHING_10K
 from ServerUtilities import getUsernameFromTaskname
 
 # external dependecies here
@@ -43,6 +43,8 @@ class RESTTask(RESTEntity):
             validate_str("transfercontainer", param, safe, RX_DATASET, optional=True)
             validate_str("transferrule", param, safe, RX_RUCIORULE, optional=True)
             validate_str("publishrule", param, safe, RX_RUCIORULE, optional=True)
+            # Save json string directly to tm_multipub_rule CLOB column.
+            validate_str("multipubrulejson", param, safe, RX_ANYTHING_10K, optional=True)
         elif method in ['GET']:
             validate_str('subresource', param, safe, RX_SUBRES_TASK, optional=False)
             validate_str("workflow", param, safe, RX_TASKNAME, optional=True)
@@ -359,7 +361,6 @@ class RESTTask(RESTEntity):
 
         return []
 
-
     def addddmreqid(self, **kwargs):
         """ Add DDM request ID to DDM_reqid column in the database. Can be tested with:
             curl -X POST https://balcas-crab.cern.ch/crabserver/dev/task -k --key $X509_USER_PROXY --cert $X509_USER_PROXY \
@@ -385,9 +386,21 @@ class RESTTask(RESTEntity):
             raise InvalidParameter("Transfer container name not found in the input parameters")
         if 'transferrule' not in kwargs or not kwargs['transferrule']:
             raise InvalidParameter("Transfer container's rule id not found in the input parameters")
+        # For backward compatiblity, either `publishrule` or `multipubrulejson`
+        # is enough, and set default value to variable that not supply by
+        # client.
+        if (('publishrule' not in kwargs or not kwargs['publishrule'])
+           and ('multipubrulejson' not in kwargs or not kwargs['multipubrulejson'])):
+            raise InvalidParameter("`publishrule` or `multipubrulejson` are not found in the input parameters.")
+        # set default value if `publishrule` or `multipubrule` does not exists.
         if 'publishrule' not in kwargs or not kwargs['publishrule']:
-            raise InvalidParameter("Transfer container's rule id not found in the input parameters")
-
+            publishrule = '00000000000000000000000000000000'
+        else:
+            publishrule = kwargs['publishrule']
+        if 'multipubrulejson' not in kwargs or not kwargs['multipubrulejson']:
+            multipubrulejson = '{}'
+        else:
+            multipubrulejson = kwargs['multipubrulejson']
         taskname = kwargs['workflow']
         ownerName = getUsernameFromTaskname(taskname)
         authz_operator(username=ownerName, group='crab3', role='operator')
@@ -395,7 +408,7 @@ class RESTTask(RESTEntity):
             self.Task.SetRucioASOInfo_sql,
             tm_transfer_container=[kwargs['transfercontainer']],
             tm_transfer_rule=[kwargs['transferrule']],
-            tm_publish_rule=[kwargs['publishrule']],
+            tm_publish_rule=[publishrule],
+            tm_multipub_rule=[multipubrulejson],
             tm_taskname=[taskname])
-
         return []

--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -387,12 +387,12 @@ class RESTTask(RESTEntity):
         if 'transferrule' not in kwargs or not kwargs['transferrule']:
             raise InvalidParameter("Transfer container's rule id not found in the input parameters")
         # For backward compatiblity, either `publishrule` or `multipubrulejson`
-        # is enough, and set default value to variable that not supply by
+        # is enough, also set default value for variables not supplied by
         # client.
         if (('publishrule' not in kwargs or not kwargs['publishrule'])
            and ('multipubrulejson' not in kwargs or not kwargs['multipubrulejson'])):
-            raise InvalidParameter("`publishrule` or `multipubrulejson` are not found in the input parameters.")
-        # set default value if `publishrule` or `multipubrule` does not exists.
+            raise InvalidParameter("Neither `publishrule` nor `multipubrulejson` are found in the input parameters.")
+        # set default value if neither `publishrule` nor `multipubrule` exists
         if 'publishrule' not in kwargs or not kwargs['publishrule']:
             publishrule = '00000000000000000000000000000000'
         else:

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -10,6 +10,8 @@ RX_ANYTHING = re.compile(r"^.*$")
 # as of 2022-03 it is used for warning and failure messages, which were previously
 # encoded in b64 and matched with RX_TEXT_FAIL. see #7106
 RX_MANYLINES_SHORT = re.compile(r"(?s)^.{0,1100}$")
+
+RX_ANYTHING_10K = re.compile(r"^.{0,10000}$")
 # TODO: we should start replacing most of the regex here with what we have in WMCore.Lexicon
 #       (this probably requires to adapt something on Lexicon)
 pNameRE      = r"(?=.{0,400}$)[a-zA-Z0-9\-_.]+"

--- a/src/python/Databases/TaskDB/Oracle/Create.py
+++ b/src/python/Databases/TaskDB/Oracle/Create.py
@@ -102,6 +102,7 @@ class Create(DBCreator):
         tm_transfer_container VARCHAR(1000),
         tm_transfer_rule VARCHAR(255),
         tm_publish_rule VARCHAR(255),
+        tm_multipub_rule CLOB,
         CONSTRAINT taskname_pk PRIMARY KEY(tm_taskname),
         CONSTRAINT check_tm_publication CHECK (tm_publication IN ('T', 'F')),
         CONSTRAINT check_tm_publish_groupname CHECK (tm_publish_groupname IN ('T', 'F')),

--- a/src/python/Databases/TaskDB/Oracle/Task/Task.py
+++ b/src/python/Databases/TaskDB/Oracle/Task/Task.py
@@ -179,5 +179,6 @@ class Task(object):
                                  SET \
                                      tm_transfer_container = :tm_transfer_container, \
                                      tm_transfer_rule = :tm_transfer_rule, \
-                                     tm_publish_rule = :tm_publish_rule \
+                                     tm_publish_rule = :tm_publish_rule, \
+                                     tm_multipub_rule = :tm_multipub_rule \
                                  WHERE tm_taskname = :tm_taskname"""

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -614,7 +614,7 @@ class ASOServerJob(object):
         # Loop #3. compute the output dataset name for each file and add it to file_info
         for file_info in output_files:
             # use common function with PostJob to ensure uniform dataset name
-            if file_info['filetype'] in ['EDM', 'DQM']:
+            if file_info['filetype'] in ['EDM', 'DQM'] and task['tm_publication'] == 'T':
                 # group name overrides username when present:
                 username = self.job_ad['CRAB_UserHN']
                 if self.dest_dir.startswith('/store/group/') and self.dest_dir.split('/')[3]:
@@ -2749,7 +2749,7 @@ class PostJob():
         outdataset = None
         for file_info in self.output_files_info:
             # use common function with ASOServerJob to ensure uniform dataset name
-            if file_info['filetype'] in ['EDM', 'DQM']:
+            if file_info['filetype'] in ['EDM', 'DQM'] and task['tm_publication'] == 'T':
                 # group name overrides username when present:
                 username = self.job_ad['CRAB_UserHN']
                 if self.dest_dir.startswith('/store/group/') and self.dest_dir.split('/')[3]:

--- a/test/assets/container_ruleid.json
+++ b/test/assets/container_ruleid.json
@@ -1,0 +1,9 @@
+{
+    "containerRuleID": "c88abb899f744efb8f33fd197ee77ecd",
+    "publishRuleID": "141a41b6b54f45f59dc0703182f1257f",
+	"multiPubRuleIDs":  {
+        "/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__cmsRun.log.tar.gz/USER": "9653f39f686944128028fd25888ae2d3",
+        "/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__output.root/USER": "e609d75e4a7a4fa3a880ea0bb6681371",
+        "/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__miniaodfake.root/USER": "6b159d7e5dc940daa2188658a68c4b23"
+    }
+}

--- a/test/assets/transferDicts.json
+++ b/test/assets/transferDicts.json
@@ -1,0 +1,70 @@
+[
+    {
+        "id": "7652449e07afeaf00abe804e8507f4172e5b04f09a2c5e0d883a3193",
+        "username": "tseethon",
+        "taskname": "231012_154207:tseethon_crab_rucio_transfers_hc1kj_withnonedm_test12_20231012_174204",
+        "start_time": 1697125531,
+        "destination": "T2_CH_CERN",
+        "destination_lfn": "/store/user/rucio/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/log/cmsRun_3.log.tar.gz",
+        "source": "T2_CH_CERN",
+        "source_lfn": "/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/log/cmsRun_3.log.tar.gz",
+        "filesize": 10910,
+        "publish": 0,
+        "transfer_state": "NEW",
+        "publication_state": "NOT_REQUIRED",
+        "job_id": "3",
+        "job_retry_count": 0,
+        "type": "log",
+        "publishname": "ruciotransfers-1697125324-00000000000000000000000000000000",
+        "checksums": {
+            "adler32": "abc"
+        },
+        "outputdataset": "/FakeDataset/fakefile-FakePublish-befe3559057072761674520fdaee5005/USER"
+    },
+    {
+        "id": "10ba0d321da1a9d7ecc17e2bf411932ec5268ae12d5be76b5928dc29",
+        "username": "tseethon",
+        "taskname": "231012_154207:tseethon_crab_rucio_transfers_hc1kj_withnonedm_test12_20231012_174204",
+        "start_time": 1697125531,
+        "destination": "T2_CH_CERN",
+        "destination_lfn": "/store/user/rucio/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/miniaodfake_3.root",
+        "source": "T2_CH_CERN",
+        "source_lfn": "/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/miniaodfake_3.root",
+        "filesize": 104857600,
+        "publish": 0,
+        "transfer_state": "NEW",
+        "publication_state": "NOT_REQUIRED",
+        "job_id": "3",
+        "job_retry_count": 0,
+        "type": "output",
+        "publishname": "ruciotransfers-1697125324-00000000000000000000000000000000",
+        "checksums": {
+            "adler32": "141d411c",
+            "cksum": "2726547828"
+        },
+        "outputdataset": "/FakeDataset/fakefile-FakePublish-befe3559057072761674520fdaee5005/USER"
+    },
+    {
+        "id": "091bfc9fb03fe326b1ace7cac5b71e034ce4b44ed46be14ae88b472a",
+        "username": "tseethon",
+        "taskname": "231012_154207:tseethon_crab_rucio_transfers_hc1kj_withnonedm_test12_20231012_174204",
+        "start_time": 1697125531,
+        "destination": "T2_CH_CERN",
+        "destination_lfn": "/store/user/rucio/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/output_3.root",
+        "source": "T2_CH_CERN",
+        "source_lfn": "/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/output_3.root",
+        "filesize": 632378,
+        "publish": 0,
+        "transfer_state": "NEW",
+        "publication_state": "NOT_REQUIRED",
+        "job_id": "3",
+        "job_retry_count": 0,
+        "type": "output",
+        "publishname": "ruciotransfers-1697125324-00000000000000000000000000000000",
+        "checksums": {
+            "adler32": "cd95e2da",
+            "cksum": "2038182269"
+        },
+        "outputdataset": "/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d/USER"
+    }
+]

--- a/test/python/ASO/Rucio/Actions/test_MonitorLockStatus.py
+++ b/test/python/ASO/Rucio/Actions/test_MonitorLockStatus.py
@@ -14,10 +14,11 @@ import json
 import pytest
 import datetime
 from argparse import Namespace
-from unittest.mock import patch, Mock, call
+from unittest.mock import patch, Mock, call, create_autospec
 
 import ASO.Rucio.config as config
-from ASO.Rucio.Actions.MonitorLocksStatus import MonitorLocksStatus
+from ASO.Rucio.Transfer import Transfer
+from ASO.Rucio.Actions.MonitorLockStatus import MonitorLockStatus
 from ASO.Rucio.Actions.RegisterReplicas import RegisterReplicas
 
 @pytest.fixture
@@ -41,12 +42,12 @@ def loadDatasetMetadata():
         return json.load(r)
 
 def test_checkLockStatus_all_ok(mock_Transfer, mock_rucioClient):
-    listRuleIDs = ['b43a554244c54dba954aa29cb2fdde0a']
     outputAllOK = [
         {
+            "name": "/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root",
             "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
-            "dataset": '/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER#c9b28b96-5d16-41cd-89af-2678971132c9',
-            "blockcomplete": 'OK',
+            "dataset": None,
+            "blockcomplete": 'NO',
             "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
         }
     ]
@@ -56,206 +57,298 @@ def test_checkLockStatus_all_ok(mock_Transfer, mock_rucioClient):
     }]
 
     mock_rucioClient.list_replica_locks.side_effect = ((x for x in listReplicaLocksReturnValue), ) # list_replica_locks return generator
-    mock_Transfer.replicaLFN2IDMap = {
-        '/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root' : '98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca'
-    }
     mock_Transfer.replicasInContainer = {
         '/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root' : '/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER#c9b28b96-5d16-41cd-89af-2678971132c9'
     }
     mock_Transfer.containerRuleID = 'b43a554244c54dba954aa29cb2fdde0a'
+    mock_Transfer.LFN2transferItemMap = {
+        '/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root': {
+            'id': '98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca',
+        }
+    }
     config.args = Namespace(max_file_per_dataset=1)
-    m = MonitorLocksStatus(mock_Transfer, mock_rucioClient, Mock())
-    assert m.checkLocksStatus() == (outputAllOK, [])
+    m = MonitorLockStatus(mock_Transfer, mock_rucioClient, Mock())
+    assert m.checkLockStatus() == (outputAllOK, [])
 
 def test_checkLockStatus_all_replicating(mock_Transfer, mock_rucioClient):
-    listRuleIDs = ['b43a554244c54dba954aa29cb2fdde0a']
     outputNotOK = [
         {
+            "name": "/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root",
             "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
-            "dataset": '/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER#c9b28b96-5d16-41cd-89af-2678971132c9',
+            "dataset": None,
             "blockcomplete": 'NO',
             "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
-        }
+        },
     ]
-    getReplicationRuleReturnValue = {
-        'id': 'b43a554244c54dba954aa29cb2fdde0a',
-        'name': '/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER#c9b28b96-5d16-41cd-89af-2678971132c9',
-        'state': 'REPLICATING',
-    }
     listReplicaLocksReturnValue = [{
         'name': '/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root',
         'state': 'REPLICATING',
     }]
-    mock_rucioClient.get_replication_rule.return_value = getReplicationRuleReturnValue
+    mock_Transfer.containerRuleID = 'b43a554244c54dba954aa29cb2fdde0a'
+    mock_Transfer.LFN2transferItemMap = {
+        '/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root': {
+            'id': '98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca',
+        }
+    }
     mock_rucioClient.list_replica_locks.side_effect = ((x for x in listReplicaLocksReturnValue), ) # list_replica_locks return generator
     mock_Transfer.getIDFromLFN.return_value = '98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca'
-    m = MonitorLocksStatus(mock_Transfer, mock_rucioClient, Mock())
-    assert m.checkLocksStatus(listRuleIDs) == ([], outputNotOK, [])
+    m = MonitorLockStatus(mock_Transfer, mock_rucioClient, Mock())
+    assert m.checkLockStatus() == ([], outputNotOK)
 
 @pytest.mark.skip(reason="Skip it for now due deadline.")
 def test_checkLockStatus_mix():
     assert True == False
 
-# bookkeeping rule
-# - bookkeeping per dataset
-# - save rule id if rule ok to another file
-@patch.object(MonitorLocksStatus, 'checkLocksStatus')
-def test_execute_bookkeeping_none(mock_checkLockStatus, mock_Transfer):
-    allRules = ['b43a554244c54dba954aa29cb2fdde0a']
-    okRules = []
-    mock_Transfer.allRules = allRules
-    mock_Transfer.okRules = okRules
-    m = MonitorLocksStatus(mock_Transfer, mock_rucioClient, Mock())
-    mock_checkLockStatus.return_value = ([], [], okRules)
-    m.execute()
-    mock_checkLockStatus.assert_called_once_with(allRules)
-    mock_Transfer.updateOKRules.assert_called_once()
-
-@patch.object(MonitorLocksStatus, 'checkLocksStatus')
-def test_execute_bookkeeping_all(mock_checkLockStatus, mock_Transfer):
-    allRules = ['b43a554244c54dba954aa29cb2fdde0a']
-    okRules = ['b43a554244c54dba954aa29cb2fdde0a']
-    mock_Transfer.allRules = allRules
-    mock_Transfer.okRules = okRules
-    m = MonitorLocksStatus(mock_Transfer, mock_rucioClient, Mock())
-    mock_checkLockStatus.return_value = ([], [], [])
-    m.execute()
-    mock_checkLockStatus.assert_called_once_with([])
-    mock_Transfer.updateOKRules.assert_called_once()
-
-
-def generateExpectedOutput(doctype):
-    if doctype == 'complete':
-        return {
-            'asoworker': 'rucio',
-            'list_of_ids': ['98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca'], # hmm, how do we get this
-            'list_of_transfer_state': ['DONE'],
-            'list_of_dbs_blockname': ['/TestDataset/cmscrab-unittest-1/USER#c9b28b96-5d16-41cd-89af-2678971132ca'],
-            'list_of_block_complete': ['OK'],
-            'list_of_fts_instance': ['https://fts3-cms.cern.ch:8446/'],
-            'list_of_failure_reason': None, # omit
-            'list_of_retry_value': None, # omit
-            'list_of_fts_id': ['NA'],
+@patch.object(RegisterReplicas, 'addReplicasToContainer')
+def test_registerToPublishContainer(mock_addReplicasToContainer, mock_Transfer, mock_rucioClient):
+    mock_Transfer.publishContainer = '/GenericTTbar/integration-test-30_TRANSFER.befe3559/USER'
+    outputAllOK = [
+        {
+            "name": "/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root",
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+            "dataset": None,
+            "blockcomplete": 'NO',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
         }
-    elif doctype == 'notcomplete':
-        return {
-            'asoworker': 'rucio',
-            'list_of_ids': ['98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20cb'], # hmm, how do we get this
-            'list_of_transfer_state': ['SUBMITTED'],
-            'list_of_dbs_blockname': None,
-            'list_of_block_complete': None,
-            'list_of_fts_instance': ['https://fts3-cms.cern.ch:8446/'],
-            'list_of_failure_reason': None, # omit
-            'list_of_retry_value': None, # omit
-            'list_of_fts_id': ['b43a554244c54dba954aa29cb2fdde0b'],
+    ]
+    result = [
+        {
+            "name": "/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root",
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+            "dataset": "/GenericTTbar/integration-test-30_TRANSFER.befe3559/USER#a86fca3a-1e38-467d-a2ac-98a8ff4299bd",
+            "blockcomplete": 'NO',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
         }
+    ]
+    mock_addReplicasToContainer.return_value = result
+    m = MonitorLockStatus(mock_Transfer, mock_rucioClient, Mock())
+    assert m.registerToPublishContainer(outputAllOK) == result
 
-def test_prepareOKFileDoc(mock_Transfer):
-    okFileDoc = generateExpectedOutput('complete')
+def test_checkBlockCompleteStatus_close(mock_Transfer, mock_rucioClient):
+    fileDocs = [
+        {
+            "name": "/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root",
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+            "dataset": "/GenericTTbar/integration-test-30_TRANSFER.befe3559/USER#a86fca3a-1e38-467d-a2ac-98a8ff4299bd",
+            "blockcomplete": 'NO',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
+        }
+    ]
+    result = [
+        {
+            "name": "/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root",
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+            "dataset": "/GenericTTbar/integration-test-30_TRANSFER.befe3559/USER#a86fca3a-1e38-467d-a2ac-98a8ff4299bd",
+            "blockcomplete": 'OK',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
+        }
+    ]
+    config.args = Namespace(open_dataset_timeout=1*60*60)
+    mock_rucioClient.get_metadata.side_effect = [{
+        'is_open': False,
+        'updated_at': datetime.datetime.now()
+    }]
+    m = MonitorLockStatus(mock_Transfer, mock_rucioClient, Mock())
+    assert m.checkBlockCompleteStatus(fileDocs) == result
+
+def test_checkBlockCompleteStatus_shouldClose(mock_Transfer, mock_rucioClient):
+    fileDocs = [
+        {
+            "name": "/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root",
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+            "dataset": "/GenericTTbar/integration-test-30_TRANSFER.befe3559/USER#a86fca3a-1e38-467d-a2ac-98a8ff4299bd",
+            "blockcomplete": 'NO',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
+        }
+    ]
+    result = [
+        {
+            "name": "/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root",
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+            "dataset": "/GenericTTbar/integration-test-30_TRANSFER.befe3559/USER#a86fca3a-1e38-467d-a2ac-98a8ff4299bd",
+            "blockcomplete": 'OK',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
+        }
+    ]
+    config.args = Namespace(open_dataset_timeout=1*60*60)
+    mock_rucioClient.get_metadata.side_effect = [{
+        'is_open': False,
+        'updated_at': datetime.datetime.now() - datetime.timedelta(seconds=config.args.open_dataset_timeout - 1) # 1 hour and 1 second ago
+    }]
+    m = MonitorLockStatus(mock_Transfer, mock_rucioClient, Mock())
+    assert m.checkBlockCompleteStatus(fileDocs) == result
+
+def test_checkBlockCompleteStatus_notclose(mock_Transfer, mock_rucioClient):
+    fileDocs = [
+        {
+            "name": "/store/user/rucio/tseethon/test-workflow/GenericTTbar/autotest-1679671056/230324_151740/0000/output_9.root",
+            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+            "dataset": "/GenericTTbar/integration-test-30_TRANSFER.befe3559/USER#a86fca3a-1e38-467d-a2ac-98a8ff4299bd",
+            "blockcomplete": 'NO',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
+        }
+    ]
+    config.args = Namespace(open_dataset_timeout=1*60*60)
+    mock_rucioClient.get_metadata.side_effect = [{
+        'is_open': True,
+        'updated_at': datetime.datetime.now() - datetime.timedelta(seconds=1) # 1 sec ago
+    }]
+    m = MonitorLockStatus(mock_Transfer, mock_rucioClient, Mock())
+    assert m.checkBlockCompleteStatus(fileDocs) == []
+
+@pytest.mark.skip(reason="We did not use it, for now. Likely to revisit again in the future.")
+def test_filterFilesNeedToPublish():
+    assert True == False
+
+
+@patch('ASO.Rucio.Actions.MonitorLockStatus.updateToREST')
+def test_updateRESTFileDocsStateToDone(mock_updateToREST):
+    expectedRestFileDocs = {
+        'asoworker': 'rucio',
+        'list_of_ids': ['98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca', "0fbdabe9311c07ad901652dc998af04c3f16997ba62f03bf5a13e769"],
+        'list_of_transfer_state': ['DONE', 'DONE'],
+        'list_of_dbs_blockname': None,
+        'list_of_block_complete': None,
+        'list_of_fts_instance': ['https://fts3-cms.cern.ch:8446/', 'https://fts3-cms.cern.ch:8446/'],
+        'list_of_failure_reason': None, # omit
+        'list_of_retry_value': None, # omit
+        'list_of_fts_id': ['b43a554244c54dba954aa29cb2fdde0a', 'b43a554244c54dba954aa29cb2fdde0a'],
+    }
     outputOK = [
         {
             "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+            "name": '/store/user/rucio/tseethon/random/dir/output_9.root',
             "dataset": '/TestDataset/cmscrab-unittest-1/USER#c9b28b96-5d16-41cd-89af-2678971132ca',
             "blockcomplete": 'OK',
             "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
-        }
-    ]
-    m = MonitorLocksStatus(mock_Transfer, Mock(), Mock())
-    assert okFileDoc == m.prepareOKFileDoc(outputOK)
-
-
-def test_prepareNotOKFileDoc(mock_Transfer):
-    notOKFileDoc = generateExpectedOutput('notcomplete')
-    outputNotOK = [
+        },
         {
-            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20cb",
-            "dataset": '/GenericTTbar/tseethon-autotest-1679671056-94ba0e06145abd65ccb1d21786dc7e1d/USER#c9b28b96-5d16-41cd-89af-2678971132c9',
+            "id": "0fbdabe9311c07ad901652dc998af04c3f16997ba62f03bf5a13e769",
+            "name": '/store/user/rucio/tseethon/random/dir/output_10.root',
+            "dataset": '/TestDataset/cmscrab-unittest-1/USER#ebe712e4-d53a-48e4-87d8-32c582ef4fab',
             "blockcomplete": 'NO',
-            "ruleid": "b43a554244c54dba954aa29cb2fdde0b",
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
         }
     ]
-    m = MonitorLocksStatus(mock_Transfer, Mock(), Mock())
-    assert notOKFileDoc == m.prepareNotOKFileDoc(outputNotOK)
+    rest = Mock()
+    m = MonitorLockStatus(Mock(), Mock(), rest)
+    m.updateRESTFileDocsStateToDone(outputOK)
+    mock_updateToREST.assert_called_with(rest, 'filetransfers', 'updateTransfers', expectedRestFileDocs)
 
-def test_addReplicasToPublishContainer():
+
+@patch('ASO.Rucio.Actions.MonitorLockStatus.updateToREST')
+def test_updateRESTFileDocsBlockCompletionInfo(mock_updateToREST):
+    expectedRestFileDocs = {
+        'asoworker': 'rucio',
+        'list_of_ids': ['98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca', "0fbdabe9311c07ad901652dc998af04c3f16997ba62f03bf5a13e769"],
+        'list_of_transfer_state': ['DONE', 'DONE'],
+        'list_of_dbs_blockname': ['/TestDataset/cmscrab-unittest-1/USER#c9b28b96-5d16-41cd-89af-2678971132ca', '/TestDataset/cmscrab-unittest-1/USER#ebe712e4-d53a-48e4-87d8-32c582ef4fab'],
+        'list_of_block_complete': ['OK', 'OK'],
+        'list_of_fts_instance': ['https://fts3-cms.cern.ch:8446/', 'https://fts3-cms.cern.ch:8446/'],
+        'list_of_failure_reason': None, # omit
+        'list_of_retry_value': None, # omit
+        'list_of_fts_id': None,
+    }
     outputOK = [
         {
             "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+            "name": '/store/user/rucio/tseethon/random/dir/output_9.root',
             "dataset": '/TestDataset/cmscrab-unittest-1/USER#c9b28b96-5d16-41cd-89af-2678971132ca',
-            "blockcomplete": 'NO',
+            "blockcomplete": 'OK',
+            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
+        },
+        {
+            "id": "0fbdabe9311c07ad901652dc998af04c3f16997ba62f03bf5a13e769",
+            "name": '/store/user/rucio/tseethon/random/dir/output_10.root',
+            "dataset": '/TestDataset/cmscrab-unittest-1/USER#ebe712e4-d53a-48e4-87d8-32c582ef4fab',
+            "blockcomplete": 'OK',
             "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
         }
     ]
-    m = MonitorLocksStatus(mock_Transfer, mock_rucioClient, Mock())
-    m.addReplicasToPublishContainer(outputOK)
+    rest = Mock()
+    m = MonitorLockStatus(Mock(), Mock(), rest)
+    m.updateRESTFileDocsBlockCompletionInfo(outputOK)
+    mock_updateToREST.assert_called_with(rest, 'filetransfers', 'updateRucioInfo', expectedRestFileDocs)
 
 
-@patch.object(RegisterReplicas, 'addReplicasToDataset')
-def test_updateBlockCompleteStatus(mock_addReplicasToDataset, mock_Transfer, mock_rucioClient, loadDatasetMetadata):
-    outputOK = [
+@patch.object(RegisterReplicas, 'addReplicasToContainer')
+def test_registerToMutiPubContainers(mock_addReplicasToContainer):
+    mock_Transfer.publishContainer = '/GenericTTbar/integration-test-30_TRANSFER.befe3559/USER'
+    outputAllOK = [
         {
-            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
+            "id": "7652449e07afeaf00abe804e8507f4172e5b04f09a2c5e0d883a3193",
+            "name": "/store/user/rucio/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/log/cmsRun_3.log.tar.gz",
             "dataset": None,
             "blockcomplete": 'NO',
             "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
         },
         {
-            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20cb",
+            "id": "10ba0d321da1a9d7ecc17e2bf411932ec5268ae12d5be76b5928dc29",
+            "name": "/store/user/rucio/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/miniaodfake_3.root",
             "dataset": None,
             "blockcomplete": 'NO',
             "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
         },
         {
-            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20cc",
+            "id": "091bfc9fb03fe326b1ace7cac5b71e034ce4b44ed46be14ae88b472a",
+            "name": "/store/user/rucio/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/output_3.root",
             "dataset": None,
             "blockcomplete": 'NO',
             "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
         },
     ]
-    retAddReplicasToDataset = [
+
+    returnValue = [
         {
-            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
-            "dataset": '/TestPrimary/test-dataset_TRANSFER-bc8b2558/USER#c3800048-d946-45f7-9e83-1f420b4fc32e',
+            "id": "7652449e07afeaf00abe804e8507f4172e5b04f09a2c5e0d883a3193",
+            "name": "/store/user/rucio/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/log/cmsRun_3.log.tar.gz",
+            "dataset": "/GenericTTbar/integration-test-30_TRANSFER.befe3559/USER#a86fca3a-1e38-467d-a2ac-98a8ff4299bd",
             "blockcomplete": 'NO',
             "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
         },
         {
-            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20cb",
-            "dataset": '/TestPrimary/test-dataset_TRANSFER-bc8b2558/USER#c3800048-d946-45f7-9e83-1f420b4fc32e',
+            "id": "10ba0d321da1a9d7ecc17e2bf411932ec5268ae12d5be76b5928dc29",
+            "name": "/store/user/rucio/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/miniaodfake_3.root",
+            "dataset": "/GenericTTbar/integration-test-30_TRANSFER.befe3559/USER#a86fca3a-1e38-467d-a2ac-98a8ff4299bd",
             "blockcomplete": 'NO',
             "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
         },
         {
-            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20cc",
-            "dataset": '/TestPrimary/test-dataset_TRANSFER-bc8b2558/USER#b74d9bde-9a36-4e40-af17-3d614f19d380',
-            "blockcomplete": 'NO',
-            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
-        },
-    ]
-    expectedOutput = [
-        {
-            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20ca",
-            "dataset": '/TestPrimary/test-dataset_TRANSFER-bc8b2558/USER#c3800048-d946-45f7-9e83-1f420b4fc32e',
-            "blockcomplete": 'OK',
-            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
-        },
-        {
-            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20cb",
-            "dataset": '/TestPrimary/test-dataset_TRANSFER-bc8b2558/USER#c3800048-d946-45f7-9e83-1f420b4fc32e',
-            "blockcomplete": 'OK',
-            "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
-        },
-        {
-            "id": "98f353b91ec84f0217da80bde84d6b520c0c6640f60ad9aabb7b20cc",
-            "dataset": '/TestPrimary/test-dataset_TRANSFER-bc8b2558/USER#b74d9bde-9a36-4e40-af17-3d614f19d380',
+            "id": "091bfc9fb03fe326b1ace7cac5b71e034ce4b44ed46be14ae88b472a",
+            "name": "/store/user/rucio/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/output_3.root",
+            "dataset": "/GenericTTbar/integration-test-30_TRANSFER.befe3559/USER#a86fca3a-1e38-467d-a2ac-98a8ff4299bd",
             "blockcomplete": 'NO',
             "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
         },
     ]
-    mock_addReplicasToDataset.return_value = retAddReplicasToDataset
-    datasetMetadata = loadDatasetMetadata[:2]
-    datasetMetadata[0]['is_open'] = False
-    datasetMetadata[1]['is_open'] = True
-    mock_rucioClient.get_metadata.side_effect = datasetMetadata
-    m = MonitorLocksStatus(mock_Transfer, mock_rucioClient, Mock())
-    assert m.updateBlockCompleteStatus(outputOK) == expectedOutput
+
+    multiPubContainers = [
+        '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__cmsRun.log.tar.gz/USER',
+        '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__miniaodfake.root/USER',
+        '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__output.root/USER',
+    ]
+
+    def side_effect(*args):
+        container = args[1]
+        index = multiPubContainers.index(container)
+        return [returnValue[index]]
+
+    t = create_autospec(Transfer, instance=True)
+    t.multiPubContainers = multiPubContainers
+    mock_addReplicasToContainer.side_effect = side_effect
+    m = MonitorLockStatus(t, Mock(), Mock())
+    ret = m.registerToMutiPubContainers(outputAllOK)
+
+
+    # check args pass to addReplicasToContainer()
+    allcall = []
+    for i in range(len(returnValue)):
+        allcall.append(call([outputAllOK[i]], multiPubContainers[i]))
+    mock_addReplicasToContainer.assert_has_calls(allcall, any_order=True)
+
+    # check return value
+    assert sorted(ret, key=lambda d: d['id']) == sorted(returnValue, key=lambda d: d['id'])
+
+
+def test_checkBlockCompleteStatus():
+    assert 1 == 0

--- a/test/python/ASO/Rucio/Actions/test_MonitorLockStatus.py
+++ b/test/python/ASO/Rucio/Actions/test_MonitorLockStatus.py
@@ -273,7 +273,6 @@ def test_updateRESTFileDocsBlockCompletionInfo(mock_updateToREST):
 
 @patch.object(RegisterReplicas, 'addReplicasToContainer')
 def test_registerToMutiPubContainers(mock_addReplicasToContainer):
-    mock_Transfer.publishContainer = '/GenericTTbar/integration-test-30_TRANSFER.befe3559/USER'
     outputAllOK = [
         {
             "id": "7652449e07afeaf00abe804e8507f4172e5b04f09a2c5e0d883a3193",
@@ -302,30 +301,30 @@ def test_registerToMutiPubContainers(mock_addReplicasToContainer):
         {
             "id": "7652449e07afeaf00abe804e8507f4172e5b04f09a2c5e0d883a3193",
             "name": "/store/user/rucio/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/log/cmsRun_3.log.tar.gz",
-            "dataset": "/GenericTTbar/integration-test-30_TRANSFER.befe3559/USER#a86fca3a-1e38-467d-a2ac-98a8ff4299bd",
+            "dataset": '/FakeDataset/fakefile-FakePublish-befe3559057072761674520fdaee5005_cmsRun.log.tar.gz/USER',
             "blockcomplete": 'NO',
             "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
         },
         {
             "id": "10ba0d321da1a9d7ecc17e2bf411932ec5268ae12d5be76b5928dc29",
             "name": "/store/user/rucio/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/miniaodfake_3.root",
-            "dataset": "/GenericTTbar/integration-test-30_TRANSFER.befe3559/USER#a86fca3a-1e38-467d-a2ac-98a8ff4299bd",
+            "dataset": '/FakeDataset/fakefile-FakePublish-befe3559057072761674520fdaee5005_miniaodfake.root/USER',
             "blockcomplete": 'NO',
             "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
         },
         {
             "id": "091bfc9fb03fe326b1ace7cac5b71e034ce4b44ed46be14ae88b472a",
             "name": "/store/user/rucio/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/output_3.root",
-            "dataset": "/GenericTTbar/integration-test-30_TRANSFER.befe3559/USER#a86fca3a-1e38-467d-a2ac-98a8ff4299bd",
+            "dataset": '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d',
             "blockcomplete": 'NO',
             "ruleid": "b43a554244c54dba954aa29cb2fdde0a",
         },
     ]
 
     multiPubContainers = [
-        '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__cmsRun.log.tar.gz/USER',
-        '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__miniaodfake.root/USER',
-        '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__output.root/USER',
+        '/FakeDataset/fakefile-FakePublish-befe3559057072761674520fdaee5005_cmsRun.log.tar.gz/USER',
+        '/FakeDataset/fakefile-FakePublish-befe3559057072761674520fdaee5005_miniaodfake.root/USER',
+        '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d/USER',
     ]
 
     def side_effect(*args):
@@ -338,7 +337,6 @@ def test_registerToMutiPubContainers(mock_addReplicasToContainer):
     mock_addReplicasToContainer.side_effect = side_effect
     m = MonitorLockStatus(t, Mock(), Mock())
     ret = m.registerToMutiPubContainers(outputAllOK)
-
 
     # check args pass to addReplicasToContainer()
     allcall = []

--- a/test/python/ASO/Rucio/Actions/test_MonitorLockStatus.py
+++ b/test/python/ASO/Rucio/Actions/test_MonitorLockStatus.py
@@ -272,7 +272,7 @@ def test_updateRESTFileDocsBlockCompletionInfo(mock_updateToREST):
 
 
 @patch.object(RegisterReplicas, 'addReplicasToContainer')
-def test_registerToMutiPubContainers(mock_addReplicasToContainer):
+def test_registerToMultiPubContainers(mock_addReplicasToContainer):
     outputAllOK = [
         {
             "id": "7652449e07afeaf00abe804e8507f4172e5b04f09a2c5e0d883a3193",
@@ -336,7 +336,7 @@ def test_registerToMutiPubContainers(mock_addReplicasToContainer):
     t.multiPubContainers = multiPubContainers
     mock_addReplicasToContainer.side_effect = side_effect
     m = MonitorLockStatus(t, Mock(), Mock())
-    ret = m.registerToMutiPubContainers(outputAllOK)
+    ret = m.registerToMultiPubContainers(outputAllOK)
 
     # check args pass to addReplicasToContainer()
     allcall = []

--- a/test/python/ASO/Rucio/test_Transfer.py
+++ b/test/python/ASO/Rucio/test_Transfer.py
@@ -3,13 +3,13 @@
 import pytest
 import builtins
 import json
-from unittest.mock import patch, mock_open
+from unittest.mock import patch, mock_open, MagicMock
 from argparse import Namespace
 
 from ASO.Rucio.Transfer import Transfer
 from ASO.Rucio.exception import RucioTransferException
 import ASO.Rucio.config as config
-from .fixtures import mock_rucioClient
+#from .fixtures import mock_rucioClient
 
 
 @pytest.fixture
@@ -42,6 +42,19 @@ def listContentFiles():
     path = 'test/assets/rucio_list_content_datasets.json'
     with open(path, 'r', encoding='utf-8') as r:
         return json.load(r)
+
+@pytest.fixture
+def transferDicts():
+    path = 'test/assets/transferDicts.json'
+    with open(path, 'r', encoding='utf-8') as r:
+        return json.load(r)
+
+@pytest.fixture
+def containerRuleIDJSONContent():
+    path = 'test/assets/container_ruleid.json'
+    with open(path, 'r', encoding='utf-8') as r:
+        return r.read()
+
 
 #old relic
 #def test_Transfer_readInfo():
@@ -258,3 +271,52 @@ def test_getContainerInfo(mock_rucioClient, listContentDatasets, listContentFile
 @pytest.mark.skip(reason='I am really lazy')
 def test_buildReplica2IDMap():
     assert 0 == 1
+
+
+def test_buildMultiPubContainers(transferDicts):
+    t = Transfer()
+    t.transferItems = transferDicts
+    t.publishContainer = '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d/USER'
+    t.buildMultiPubContainers()
+    assert t.multiPubContainers == [
+        '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__cmsRun.log.tar.gz/USER',
+        '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__miniaodfake.root/USER',
+        '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__output.root/USER',
+    ]
+
+def test_updateContainerRuleID(containerRuleIDJSONContent, fs):
+    path = '/path/to/container_ruleid.json'
+    config.args = Namespace(container_ruleid_path=path)
+    # we should mock writePath(), not function inside writePath()
+    fs.create_file(path)
+    with open(path, 'w', encoding='utf-8') as mock_file:
+        with patch('ASO.Rucio.Transfer.writePath') as mock_writePath:
+            mock_writePath.return_value.__enter__.return_value = mock_file
+            t = Transfer()
+            t.containerRuleID = 'c88abb899f744efb8f33fd197ee77ecd'
+            t.publishRuleID = '141a41b6b54f45f59dc0703182f1257f'
+            t.multiPubRuleIDs = {
+                '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__cmsRun.log.tar.gz/USER': '9653f39f686944128028fd25888ae2d3',
+                '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__output.root/USER': 'e609d75e4a7a4fa3a880ea0bb6681371',
+                '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__miniaodfake.root/USER': '6b159d7e5dc940daa2188658a68c4b23',
+            }
+            t.updateContainerRuleID()
+            mock_writePath.assert_called_once_with(path)
+    with open(path, 'r', encoding='utf-8') as mock_file:
+        x = json.loads(mock_file.read())
+        y = json.loads(containerRuleIDJSONContent)
+        assert x == y
+
+def test_readContainerRuleID(containerRuleIDJSONContent, fs):
+    path = '/path/to/container_ruleid.json'
+    config.args = Namespace(container_ruleid_path=path, force_publishname=False)
+    with patch('ASO.Rucio.Transfer.open', new_callable=mock_open, read_data=containerRuleIDJSONContent):
+        t = Transfer()
+        t.readContainerRuleID()
+        assert t.containerRuleID == 'c88abb899f744efb8f33fd197ee77ecd'
+        assert t.publishRuleID == '141a41b6b54f45f59dc0703182f1257f'
+        assert t.multiPubRuleIDs == {
+            '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__cmsRun.log.tar.gz/USER': '9653f39f686944128028fd25888ae2d3',
+            '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__output.root/USER': 'e609d75e4a7a4fa3a880ea0bb6681371',
+            '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__miniaodfake.root/USER': '6b159d7e5dc940daa2188658a68c4b23',
+        }

--- a/test/python/ASO/Rucio/test_Transfer.py
+++ b/test/python/ASO/Rucio/test_Transfer.py
@@ -273,16 +273,16 @@ def test_buildReplica2IDMap():
     assert 0 == 1
 
 
-def test_buildMultiPubContainers(transferDicts):
+def test_buildMultiPubContainerNames(transferDicts):
     t = Transfer()
     t.transferItems = transferDicts
     t.publishContainer = '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d/USER'
-    t.buildMultiPubContainers()
-    assert t.multiPubContainers == [
-        '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__cmsRun.log.tar.gz/USER',
-        '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__miniaodfake.root/USER',
-        '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__output.root/USER',
-    ]
+    t.populateMultiPubContainers()
+    assert sorted(t.multiPubContainers) == sorted([
+        '/FakeDataset/fakefile-FakePublish-befe3559057072761674520fdaee5005_cmsRun.log.tar.gz/USER',
+        '/FakeDataset/fakefile-FakePublish-befe3559057072761674520fdaee5005_miniaodfake.root/USER',
+        '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d/USER',
+    ])
 
 def test_updateContainerRuleID(containerRuleIDJSONContent, fs):
     path = '/path/to/container_ruleid.json'
@@ -296,9 +296,9 @@ def test_updateContainerRuleID(containerRuleIDJSONContent, fs):
             t.containerRuleID = 'c88abb899f744efb8f33fd197ee77ecd'
             t.publishRuleID = '141a41b6b54f45f59dc0703182f1257f'
             t.multiPubRuleIDs = {
-                '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__cmsRun.log.tar.gz/USER': '9653f39f686944128028fd25888ae2d3',
-                '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__output.root/USER': 'e609d75e4a7a4fa3a880ea0bb6681371',
-                '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__miniaodfake.root/USER': '6b159d7e5dc940daa2188658a68c4b23',
+                '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d_cmsRun.log.tar.gz/USER': '9653f39f686944128028fd25888ae2d3',
+                '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d_output.root/USER': 'e609d75e4a7a4fa3a880ea0bb6681371',
+                '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d_miniaodfake.root/USER': '6b159d7e5dc940daa2188658a68c4b23',
             }
             t.updateContainerRuleID()
             mock_writePath.assert_called_once_with(path)
@@ -316,7 +316,7 @@ def test_readContainerRuleID(containerRuleIDJSONContent, fs):
         assert t.containerRuleID == 'c88abb899f744efb8f33fd197ee77ecd'
         assert t.publishRuleID == '141a41b6b54f45f59dc0703182f1257f'
         assert t.multiPubRuleIDs == {
-            '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__cmsRun.log.tar.gz/USER': '9653f39f686944128028fd25888ae2d3',
-            '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__output.root/USER': 'e609d75e4a7a4fa3a880ea0bb6681371',
-            '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d__miniaodfake.root/USER': '6b159d7e5dc940daa2188658a68c4b23',
+            '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d_cmsRun.log.tar.gz/USER': '9653f39f686944128028fd25888ae2d3',
+            '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d_output.root/USER': 'e609d75e4a7a4fa3a880ea0bb6681371',
+            '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d_miniaodfake.root/USER': '6b159d7e5dc940daa2188658a68c4b23',
         }


### PR DESCRIPTION
Fix https://github.com/dmwm/CRABServer/issues/7976

In summary, this PR is changed in following ASO code:
-  Add new column `tm_multipub_rule` to `TASKS` table.
- Construct `Transfer.multiPubContainers` attribute  to store all publish container names.
- Create container for all `Transfer.multiPubContainers` and store rule ids in `Transfer.multiPubRuleIDs` attribute.
- New `MonitorLockStatus.registerToMultiPubContainers()` method to register transferred success replicas to its own publish container.
And the code in REST:
  - New `multipubrulejson` args for `tasks/?subresource=addrucioasoinfo`

~~The new Publish Container names will have `__<filename>` append to container "name" section (see docstring in newly added method `registerToMutiPubContainers()` for more detail).~~

New Rucio Publish Container Scheme: https://github.com/dmwm/CRABServer/issues/7976#issuecomment-1819487757

And please ignore pytest.