### PR TITLE
fix #7948 also restrict partialDataset to disk data

### DIFF
--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -405,7 +405,7 @@ class DBSDataDiscovery(DataDiscovery):
                 if not usePartialDataset:
                     dataToLock = inputDataset
                 else:
-                    dataToLock = list[locationsMap]  # this is a list of blocks
+                    dataToLock = list(locationsMap)  # this is a list of blocks
             try:
                 locker = RucioAction(config=self.config, crabserver=self.crabserver,
                                      rucioAcccount='crab_input',


### PR DESCRIPTION
There are three things in this PR

* fix for #7948
* some small pylint 
* I added line 312 in DBSDataDiscovery https://github.com/belforte/CRABServer/blob/e9e96fbc9beee5c2fea1d8cd0cfe8cae32da4e6f/src/python/TaskWorker/Actions/DBSDataDiscovery.py#L312 which IMHO fixes a but. As it was there was the possibility that we try to process a block which is partially on tape, not very likely, but if it happens hard to understand. I have not tested, but I think that current code would have anyhow added tape sites to the location list, confusing, but not harmful if there's also disk, nobody would notice.


