### PR TITLE
StageoutCheck use privilege Rucio account

### DIFF
--- a/src/python/TaskWorker/Actions/Handler.py
+++ b/src/python/TaskWorker/Actions/Handler.py
@@ -4,6 +4,7 @@ import time
 import logging
 import tempfile
 import traceback
+import copy
 
 from RESTInteractions import CRABRest
 from RucioUtils import getNativeRucioClient
@@ -157,8 +158,15 @@ def handleNewTask(resthost, dbInstance, config, task, procnum, *args, **kwargs):
     crabserver.setDbInstance(dbInstance)
     handler = TaskHandler(task, procnum, crabserver, config, 'handleNewTask', createTempDir=True)
     rucioClient = getNativeRucioClient(config=config, logger=handler.logger)
+    # Temporary use `crab_input` account to checking other account quota.
+    # See discussion in https://mattermost.web.cern.ch/cms-o-and-c/pl/ej7zwkr747rifezzcyyweisx9r
+    tmpConfig = copy.deepcopy(config)
+    tmpConfig.Services.Rucio_account = 'crab_input'
+    privilegedRucioClient = getNativeRucioClient(tmpConfig, handler.logger)
+
+    # start to work
     handler.addWork(MyProxyLogon(config=config, crabserver=crabserver, procnum=procnum, myproxylen=60 * 60 * 24))
-    handler.addWork(StageoutCheck(config=config, crabserver=crabserver, procnum=procnum, rucioClient=rucioClient))
+    handler.addWork(StageoutCheck(config=config, crabserver=crabserver, procnum=procnum, rucioClient=privilegedRucioClient))
     if task['tm_job_type'] == 'Analysis':
         if task.get('tm_user_files'):
             handler.addWork(UserDataDiscovery(config=config, crabserver=crabserver, procnum=procnum))

--- a/src/python/TaskWorker/Actions/StageoutCheck.py
+++ b/src/python/TaskWorker/Actions/StageoutCheck.py
@@ -83,13 +83,13 @@ class StageoutCheck(TaskAction):
         if self.task['tm_output_lfn'].startswith('/store/user/rucio') or \
            self.task['tm_output_lfn'].startswith('/store/group/rucio'):
             rucioAccount = getRucioAccountFromLFN(self.task['tm_output_lfn'])
-            self.logger.info(f"Checking Rucio quota from account {rucioAccount}.")
+            self.logger.info("Checking Rucio quota from account %s.", rucioAccount)
             quotaCheck = isEnoughRucioQuota(self.rucioClient, self.task['tm_asyncdest'], rucioAccount)
             if not quotaCheck['isEnough']:
                 msg = f"Not enough Rucio quota at {self.task['tm_asyncdest']}:{self.task['tm_output_lfn']}."\
                       f" Remain quota: {quotaCheck['free']} GB."
                 raise TaskWorkerException(msg)
-            self.logger.info(f" Remain quota: {quotaCheck['free']} GB.")
+            self.logger.info(" Remain quota: %s GB.", quotaCheck['free'])
             if quotaCheck['isQuotaWarning']:
                 msg = 'Rucio Quota is very little and although CRAB will submit, stageout may fail.'
                 self.logger.warning(msg)
@@ -118,7 +118,7 @@ class StageoutCheck(TaskAction):
                     self.logger.info("Executing rm command: %s ", rmCmd)
                     self.checkPermissions(rmCmd)
             except IOError as er:
-                raise TaskWorkerException("TaskWorker disk is full: %s" % er)
+                raise TaskWorkerException("TaskWorker disk is full.") from er
             finally:
                 removeDummyFile(filename, self.logger)
             return

--- a/src/python/TaskWorker/Actions/StageoutCheck.py
+++ b/src/python/TaskWorker/Actions/StageoutCheck.py
@@ -19,7 +19,6 @@ class StageoutCheck(TaskAction):
     def __init__(self, config, crabserver, procnum=-1, rucioClient=None):
         TaskAction.__init__(self, config, crabserver, procnum)
         self.rucioClient = rucioClient
-        self.privilegedRucioClient = None
         self.task = None
         self.proxy = None
         self.workflow = None


### PR DESCRIPTION
Workaround on the [permission issue in CMSRucio](https://mattermost.web.cern.ch/cms-o-and-c/pl/ej7zwkr747rifezzcyyweisx9r) where `get_local_account_usage()` still need a privilege account.
It is pretty safe to pass `privilegedRucioClient` to the whole `StageoutCheck` class because it only uses read-only APIs.