### PR TITLE
Fix getNativeRucioClientload load wrong config

### DIFF
--- a/src/python/RucioUtils.py
+++ b/src/python/RucioUtils.py
@@ -24,10 +24,8 @@ def getNativeRucioClient(config=None, logger=None):
     cl = logging.getLogger('charset_normalizer')
     cl.setLevel(logging.ERROR)
 
-    # Need to use config from `config.TaskWorker` object instead to switch to
-    # user cert in PreDag.py
-    rucio_cert = getattr(config.TaskWorker, "Rucio_cert", config.TaskWorker.cmscert)
-    rucio_key = getattr(config.TaskWorker, "Rucio_key", config.TaskWorker.cmskey)
+    rucio_cert = getattr(config.Services, "Rucio_cert", config.TaskWorker.cmscert)
+    rucio_key = getattr(config.Services, "Rucio_key", config.TaskWorker.cmskey)
     logger.debug("Using cert [%s]\n and key [%s] for rucio client.", rucio_cert, rucio_key)
     nativeClient = Client(
         rucio_host=config.Services.Rucio_host,

--- a/src/python/TaskWorker/Actions/PreDAG.py
+++ b/src/python/TaskWorker/Actions/PreDAG.py
@@ -206,15 +206,14 @@ class PreDAG(object):
         config.TaskWorker.cmskey = os.environ.get('X509_USER_PROXY')
         config.TaskWorker.envForCMSWEB = newX509env(X509_USER_CERT=config.TaskWorker.cmscert,
                                                     X509_USER_KEY=config.TaskWorker.cmskey)
-        # also for talking with rucio
-        config.TaskWorker.Rucio_cert = os.environ.get('X509_USER_PROXY')
-        config.TaskWorker.Rucio_key = os.environ.get('X509_USER_PROXY')
-
 
         # need to get username from classAd to setup for Rucio access
+        # and use user cert to talking with rucio
         task_ad = classad.parseOne(open(os.environ['_CONDOR_JOB_AD']))
         username = task_ad['CRAB_UserHN']
         config.Services.Rucio_account = username
+        config.Services.Rucio_cert = os.environ.get('X509_USER_PROXY')
+        config.Services.Rucio_key = os.environ.get('X509_USER_PROXY')
 
         # need the global black list
         config.TaskWorker.scratchDir = './scratchdir'


### PR DESCRIPTION
Fix https://github.com/dmwm/CRABServer/pull/8006

Fix the `getNativeRucioClient()` to load correct config. Also change PreDag.py to assign user cert path to proper config attribute. 