### PR TITLE
Rucio ASO: Cleanup temp area

### DIFF
--- a/src/python/ASO/Rucio/Actions/Cleanup.py
+++ b/src/python/ASO/Rucio/Actions/Cleanup.py
@@ -1,5 +1,5 @@
 """
-Clean up.
+Clean it up.
 """
 import logging
 
@@ -10,8 +10,9 @@ from ASO.Rucio.utils import callGfalRm
 class Cleanup:
     """
     Clean up temp RSE and Rucio entry.
-    Currently we need to delete file from Temp RSE by ourselves using `gfal-rm` command.
-    Rucio replicas need to wait until CMSRucio allow delete replicas from user scope.
+
+    :param transfer: Transfer Object to get infomation.
+    :type object: class:`ASO.Rucio.Transfer`
     """
     def __init__(self, transfer):
         self.logger = logging.getLogger("RucioTransfer.Actions.Cleanup")
@@ -19,12 +20,13 @@ class Cleanup:
 
     def execute(self):
         """
-        Gets inputs from `self.transfer` object where
-        - `UpdateOKLocks`: )
-        - `where its is updated by previous action
-        `MonitorLockStatus`.
+        Gets inputs from `self.transfer.bookkeepingOKLocks` where its is updated
+        by previous `MonitorLockStatus` action.
         """
-        # TODO: change name `deleteOKLock` in MonitoLockStatus to something else.
+        # Currently we need to delete file from Temp RSE by ourselves using `gfal-rm` command.
+        # Rucio replicas need to wait until CMSRucio allow delete replicas from user scope.
+
+        # TODO: change the name `bookkeepingOKLocks` in MonitorLockStatus to something else.
         toBeDeleted = []
         for name in self.transfer.bookkeepingOKLocks:
             if not name in self.transfer.cleanedFiles:

--- a/src/python/ASO/Rucio/Actions/Cleanup.py
+++ b/src/python/ASO/Rucio/Actions/Cleanup.py
@@ -1,0 +1,61 @@
+"""
+Clean up.
+"""
+import logging
+
+import ASO.Rucio.config as config # pylint: disable=consider-using-from-import
+from ASO.Rucio.utils import callGfalRm
+
+
+class Cleanup:
+    """
+    Clean up temp RSE and Rucio entry.
+    Currently we need to delete file from Temp RSE by ourselves using `gfal-rm` command.
+    Rucio replicas need to wait until CMSRucio allow delete replicas from user scope.
+    """
+    def __init__(self, transfer):
+        self.logger = logging.getLogger("RucioTransfer.Actions.Cleanup")
+        self.transfer = transfer
+
+    def execute(self):
+        """
+        Gets inputs from `self.transfer` object where
+        - `UpdateOKLocks`: )
+        - `where its is updated by previous action
+        `MonitorLockStatus`.
+        """
+        # TODO: change name `deleteOKLock` in MonitoLockStatus to something else.
+        toBeDeleted = []
+        for name in self.transfer.bookkeepingOKLocks:
+            if not name in self.transfer.cleanedFiles:
+                toBeDeleted.append(name)
+        self.deleteFileInTempArea(toBeDeleted)
+        self.transfer.cleanedFiles += toBeDeleted
+        self.transfer.updateCleanedFiles()
+
+    def deleteFileInTempArea(self, fileList):
+        """
+        This method call `callGfalRm`, fire-and-forget function to delete
+        file from temp area from provided PFN.`
+
+        `fileList` is the list of the "key" of fileDocs to lookup original
+        transfer dict to get `source_lfn`.
+
+        :param fileList: list of key of fileDoc.
+        :type fileList: list
+        """
+        self.logger.info('Cleaning up temp area.')
+        # Return if there is no file to delete, to prevent weird log line in
+        # `gfal.log`
+        if len(fileList) == 0:
+            self.logger.info('No file to clean up.')
+            return
+        pfns = []
+        for key in fileList:
+            transferItem = self.transfer.LFN2transferItemMap[key]
+            rse = f'{transferItem["source"]}_Temp'
+            lfn = transferItem['source_lfn']
+            pfn = self.transfer.LFN2PFNMap[rse][lfn]
+            pfns.append(pfn)
+            self.logger.debug(f'PFN to delete: {pfn}.')
+        callGfalRm(pfns, self.transfer.restProxyFile, config.args.gfal_log_path)

--- a/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
+++ b/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
@@ -34,6 +34,7 @@ class MonitorLockStatus:
         # skip locks that already update status to rest
         newDoneFileDocs = [doc for doc in okFileDocs if not doc['name'] in self.transfer.bookkeepingOKLocks]
         self.updateRESTFileDocsStateToDone(newDoneFileDocs)
+        # bookkeeping, also to be used in `Cleanup` action.
         self.transfer.updateOKLocks([x['name'] for x in newDoneFileDocs])
 
         # NOTE: See https://github.com/dmwm/CRABServer/issues/7940
@@ -215,7 +216,7 @@ class MonitorLockStatus:
         as outputdataset.
 
         :param fileDocs: list of fileDoc
-        :type fileDocs: list of dict
+        :type fileDocs: list
 
         :return: fileDocs
         :rtype: list of dict

--- a/src/python/ASO/Rucio/Actions/RegisterReplicas.py
+++ b/src/python/ASO/Rucio/Actions/RegisterReplicas.py
@@ -42,6 +42,10 @@ class RegisterReplicas:
         # Prepare
         transferItemsWithoutLogfile = self.skipLogTransfers(transferGenerator)
         preparedReplicasByRSE = self.prepare(transferItemsWithoutLogfile)
+
+        # store pfn in `self.transfer`.
+        self.bookkeepingPFN(preparedReplicasByRSE)
+
         # Add file to rucio by RSE
         successFileDocs, failFileDocs = self.addFilesToRucio(preparedReplicasByRSE)
         self.logger.debug(f'successFileDocs: {successFileDocs}')
@@ -372,3 +376,23 @@ class RegisterReplicas:
             #'list_of_fts_id': None,
         }
         updateToREST(self.crabRESTClient, 'filetransfers', 'updateTransfers', restFileDoc)
+
+    def bookkeepingPFN(self, prepareReplicas):
+        """
+        Store lfn to pfn map to `self.transfer.LFN2PFNMap` and bookkeeping it to
+        disk. `prepareReplicas` is the same dict that passing to
+        `addFilesToRucio()`.
+
+        :param prepareReplicas: dict return from `prepare()` method.
+        :type prepareReplicas: dict
+        """
+        for rse, replicas in prepareReplicas.items():
+            tmpdict = {}
+            for r in replicas.values():
+                sourceLFN = self.transfer.LFN2transferItemMap[r['name']]['source_lfn']
+                tmpdict[sourceLFN] = r['pfn']
+            if rse in self.transfer.LFN2PFNMap:
+                self.transfer.LFN2PFNMap[rse].update(tmpdict)
+            else:
+                self.transfer.LFN2PFNMap[rse] = tmpdict
+        self.transfer.updateLFN2PFNMap()

--- a/src/python/ASO/Rucio/Main.py
+++ b/src/python/ASO/Rucio/Main.py
@@ -65,6 +65,24 @@ def main():
                      help="")
     opt.add_argument("--open-dataset-timeout", dest="open_dataset_timeout", default=1*60*60, type=int, # 1 hours
                      help="Open dataset timeout in seconds")
+    opt.add_argument("--lfn2pfn-map-path", dest="lfn2pfn_map_path",
+                     default='task_process/transfers/lfn2pfn_map.json',
+                     help="Bookkeeping path of lfn2pfnMap")
+    opt.add_argument("--ignore-lfn2pfn-map", dest="ignore_lfn2pfn_map",
+                     action='store_true',
+                     help="")
+    opt.add_argument("--cleaned-files-path", dest="cleaned_files_path",
+                     default='task_process/transfers/cleaned_files.json',
+                     help="Bookkeeping path of cleanedFiles")
+    opt.add_argument("--ignore-cleaned-files", dest="ignore_cleaned_files",
+                     action='store_true',
+                     help="")
+    opt.add_argument("--gfal-log-path", dest="gfal_log_path",
+                     default='task_process/transfers/gfal.log',
+                     help="gfal log path")
+    opt.add_argument("--purge-transfers-dir", dest="purge_transfers_dir",
+                     action='store_true',
+                     help="purge task_process/transfers directory")
     opts = opt.parse_args()
 
     # Put args to config module to share variable across process.

--- a/src/python/ASO/Rucio/RunTransfer.py
+++ b/src/python/ASO/Rucio/RunTransfer.py
@@ -12,6 +12,7 @@ from ASO.Rucio.exception import RucioTransferException
 from ASO.Rucio.Actions.BuildDBSDataset import BuildDBSDataset
 from ASO.Rucio.Actions.RegisterReplicas import RegisterReplicas
 from ASO.Rucio.Actions.MonitorLockStatus import MonitorLockStatus
+from ASO.Rucio.Actions.Cleanup import Cleanup
 
 
 class RunTransfer:
@@ -53,6 +54,9 @@ class RunTransfer:
         RegisterReplicas(self.transfer, self.rucioClient, self.crabRESTClient).execute()
         # do 2
         MonitorLockStatus(self.transfer, self.rucioClient, self.crabRESTClient).execute()
+        # cleanup
+        # For now, only delete files in temp RSE
+        Cleanup(self.transfer).execute()
 
     def _initRucioClient(self, username, proxypath='/tmp/x509_uXXXX'):
         """

--- a/src/python/ASO/Rucio/RunTransfer.py
+++ b/src/python/ASO/Rucio/RunTransfer.py
@@ -48,14 +48,14 @@ class RunTransfer:
             self.transfer.restDBInstance,
             self.transfer.restProxyFile,
         )
-        # build dataset
+        # Build Rucio container and its own Rucio dataset.
         BuildDBSDataset(self.transfer, self.rucioClient, self.crabRESTClient).execute()
-        # do 1
+        # Add files from Temp_RSE to Rucio container
         RegisterReplicas(self.transfer, self.rucioClient, self.crabRESTClient).execute()
-        # do 2
+        # Check transfer statuses from Rucio `lock` objects
+        # If transfer complete, add replicas to Rucio Publish Containers.
         MonitorLockStatus(self.transfer, self.rucioClient, self.crabRESTClient).execute()
-        # cleanup
-        # For now, only delete files in temp RSE
+        # Cleanup
         Cleanup(self.transfer).execute()
 
     def _initRucioClient(self, username, proxypath='/tmp/x509_uXXXX'):

--- a/src/python/ASO/Rucio/utils.py
+++ b/src/python/ASO/Rucio/utils.py
@@ -4,8 +4,9 @@ The utility function of Rucio ASO.
 import shutil
 import re
 import os
-from contextlib import contextmanager
 import itertools
+import subprocess
+from contextlib import contextmanager
 
 from ServerUtilities import encodeRequest
 from ASO.Rucio.exception import RucioTransferException
@@ -114,6 +115,7 @@ def LFNToPFNFromPFN(lfn, pfn):
         fileid = '/'.join(lfn.split("/")[-2:])
     return f'{pfnPrefix}/{fileid}'
 
+
 def addSuffixToProcessedDataset(dataset, strsuffix):
     """
     Adding suffix to ProcessedDataset name.
@@ -174,3 +176,23 @@ def parseFileNameFromLFN(lfn):
         fileExt = jobid_fileext.rsplit(".", 1)[-1]
         origFileName = leftPiece + "." + fileExt
     return origFileName
+
+
+def callGfalRm(pfns, proxy, logPath):
+    """
+    Calling `gfal-rm` to delete files by passing list PFNs as arguments.
+    Ignore thhe exit code and pipe all logs to `logPath`.
+
+    :param pfs: list of pfn need to delete
+    :type pfs: list
+    :param proxy: X509 proxy path
+    :type proxy: str
+    :param logPath: logs path to append the logs
+    :type logPath: str
+    """
+    # checking gfal-rm command,
+    subprocess.check_call('command -v gfal-rm', shell=True)
+    timeout = len(pfns) * 3 * 60 # 3 minutes per file
+    pfnsArg = ' '.join(pfns)
+    command = f'set -x; X509_USER_PROXY={proxy} timeout {timeout} gfal-rm -v -t 180 {pfnsArg} >> {logPath} 2>&1 &'
+    subprocess.call(command, shell=True)

--- a/test/python/ASO/Rucio/Actions/test_Cleanup.py
+++ b/test/python/ASO/Rucio/Actions/test_Cleanup.py
@@ -1,0 +1,64 @@
+"""
+unittest
+"""
+
+import json
+import pytest
+from argparse import Namespace
+from unittest.mock import patch, Mock, create_autospec
+
+import ASO.Rucio.config as config
+from ASO.Rucio.Transfer import Transfer
+from ASO.Rucio.Actions.Cleanup import Cleanup
+
+# copy from test_Transfers
+def cleanedFiles():
+    path = 'test/assets/transferDicts.json'
+    with open(path, 'r', encoding='utf-8') as r:
+        transfersItem = json.load(r)
+    return [xdict['destination_lfn'] for xdict in transfersItem]
+
+@pytest.fixture(name='bookkeepingOKLock')
+def fixture_bookkeepingOKLock():
+    """
+    Same fixture as fixture_cleanedFiles.
+    Will find the way to share those later.
+    """
+    return cleanedFiles()
+
+@pytest.fixture(name='LFN2transferItemMap')
+def fixture_LFN2transferItemMap():
+    with open('test/assets/LFN2transferItemMap.json') as r:
+        return json.load(r)
+
+
+def test_deleteFileFromTempArea(bookkeepingOKLock, LFN2transferItemMap):
+    t = create_autospec(Transfer, instance=True)
+    # input1
+    # input2 fileDocs
+    # return nothing but have log.
+    # mock subprocess.run
+    LFN2PFNMap = {
+        'T2_CH_CERN_Temp': {
+            '/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/log/cmsRun_3.log.tar.gz': 'davs://eoscms.cern.ch:443/eos/cms/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/log/cmsRun_3.log.tar.gz',
+            '/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/miniaodfake_3.root': 'davs://eoscms.cern.ch:443/eos/cms/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/miniaodfake_3.root',
+            '/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/output_3.root': 'davs://eoscms.cern.ch:443/eos/cms/store/temp/user/tseethon.d6830fc3715ee01030105e83b81ff3068df7c8e0/tseethon/test-rucio/ruciotransfers-1697125324/GenericTTbar/ruciotransfers-1697125324/231012_154207/0000/output_3.root',
+        }
+    }
+
+    t.LFN2PFNMap = LFN2PFNMap
+    t.LFN2transferItemMap = LFN2transferItemMap
+    proxyPath = '/path/to/proxy'
+    t.restProxyFile = proxyPath
+    logPath = '/path/to/gfal.log'
+    config.args = Namespace(gfal_log_path=logPath)
+    expectedPFNs = LFN2PFNMap['T2_CH_CERN_Temp'].values()
+    with patch('ASO.Rucio.Actions.Cleanup.callGfalRm', autospec=True) as mo_callGfalRm:
+        m = Cleanup(t)
+        m.deleteFileInTempArea(bookkeepingOKLock)
+        mo_callGfalRm.assert_called_once()
+        calledPFNs, calledProxy, calledLogPath = mo_callGfalRm.call_args.args
+        assert calledProxy == proxyPath
+        assert calledLogPath == logPath
+        for pfn in expectedPFNs:
+            assert pfn in calledPFNs

--- a/test/python/ASO/Rucio/Actions/test_MonitorLockStatus.py
+++ b/test/python/ASO/Rucio/Actions/test_MonitorLockStatus.py
@@ -336,7 +336,8 @@ def test_registerToMultiPubContainers(mock_addReplicasToContainer):
     t.multiPubContainers = multiPubContainers
     mock_addReplicasToContainer.side_effect = side_effect
     m = MonitorLockStatus(t, Mock(), Mock())
-    ret = m.registerToMultiPubContainers(outputAllOK)
+    ret = m.registerToMutiPubContainers(outputAllOK)
+
 
     # check args pass to addReplicasToContainer()
     allcall = []
@@ -350,3 +351,11 @@ def test_registerToMultiPubContainers(mock_addReplicasToContainer):
 
 def test_checkBlockCompleteStatus():
     assert 1 == 0
+
+@pytest.mark.skip(reason="Laziness.")
+def test_CleanUpTempArea_allFailed():
+    assert 0 == 1
+
+@pytest.mark.skip(reason="Laziness.")
+def test_CleanUpTempArea_mixed():
+    assert 0 == 1

--- a/test/python/ASO/Rucio/test_Transfer.py
+++ b/test/python/ASO/Rucio/test_Transfer.py
@@ -30,7 +30,6 @@ def bookkeepingRulesJSONContent():
     with open(path, 'r', encoding='utf-8') as r:
         return json.load(r)
 
-
 @pytest.fixture
 def listContentDatasets():
     path = 'test/assets/rucio_list_content_datasets.json'
@@ -55,6 +54,19 @@ def containerRuleIDJSONContent():
     with open(path, 'r', encoding='utf-8') as r:
         return r.read()
 
+# https://stackoverflow.com/a/57015304
+@pytest.fixture(name='LFN2PFNMapJSON')
+def fixture_LFN2PFNMapJSON():
+    path = 'test/assets/LFN2PFNMap.json'
+    with open(path, 'r', encoding='utf-8') as r:
+        return json.load(r)
+
+@pytest.fixture(name='cleanedFiles')
+def fixture_cleanedFiles():
+    path = 'test/assets/transferDicts.json'
+    with open(path, 'r', encoding='utf-8') as r:
+        transfersItem = json.load(r)
+    return [xdict['destination_lfn'] for xdict in transfersItem]
 
 #old relic
 #def test_Transfer_readInfo():
@@ -272,7 +284,6 @@ def test_getContainerInfo(mock_rucioClient, listContentDatasets, listContentFile
 def test_buildReplica2IDMap():
     assert 0 == 1
 
-
 def test_buildMultiPubContainerNames(transferDicts):
     t = Transfer()
     t.transferItems = transferDicts
@@ -307,7 +318,7 @@ def test_updateContainerRuleID(containerRuleIDJSONContent, fs):
         y = json.loads(containerRuleIDJSONContent)
         assert x == y
 
-def test_readContainerRuleID(containerRuleIDJSONContent, fs):
+def test_readContainerRuleID(containerRuleIDJSONContent):
     path = '/path/to/container_ruleid.json'
     config.args = Namespace(container_ruleid_path=path, force_publishname=False)
     with patch('ASO.Rucio.Transfer.open', new_callable=mock_open, read_data=containerRuleIDJSONContent):
@@ -320,3 +331,53 @@ def test_readContainerRuleID(containerRuleIDJSONContent, fs):
             '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d_output.root/USER': 'e609d75e4a7a4fa3a880ea0bb6681371',
             '/GenericTTbar/tseethon-ruciotransfers-1697125324-94ba0e06145abd65ccb1d21786dc7e1d_miniaodfake.root/USER': '6b159d7e5dc940daa2188658a68c4b23',
         }
+
+def test_readLFN2PFNMap(LFN2PFNMapJSON):
+    path = '/path/to/lfn2pfn.json'
+    config.args = Namespace(lfn2pfn_map_path=path, ignore_lfn2pfn_map=False)
+    with patch('ASO.Rucio.Transfer.open', new_callable=mock_open, read_data=json.dumps(LFN2PFNMapJSON)) as mo:
+        t = Transfer()
+        t.readLFN2PFNMap()
+        # check if open correct file
+        mo.assert_called_once_with(path, 'r', encoding='utf-8')
+        assert t.LFN2PFNMap == LFN2PFNMapJSON
+
+def test_updateLFN2PFNMap(LFN2PFNMapJSON, fs):
+    path = '/path/to/lfn2pfn.json'
+    config.args = Namespace(lfn2pfn_map_path=path)
+    fs.create_file(path)
+    with open(path, 'w', encoding='utf-8') as mock_file:
+        with patch('ASO.Rucio.Transfer.writePath') as mock_writePath:
+            mock_writePath.return_value.__enter__.return_value = mock_file
+            t = Transfer()
+            t.LFN2PFNMap = LFN2PFNMapJSON
+            t.updateLFN2PFNMap()
+            mock_writePath.assert_called_once_with(path)
+    with open(path, 'r', encoding='utf-8') as mock_file:
+        fileContent = json.loads(mock_file.read())
+        assert fileContent == LFN2PFNMapJSON
+
+def test_readCleanedFiles(cleanedFiles):
+    path = '/path/to/files.txt'
+    config.args = Namespace(cleaned_files_path=path, ignore_cleaned_files=False)
+    with patch('ASO.Rucio.Transfer.open', new_callable=mock_open, read_data=json.dumps(cleanedFiles)) as mo:
+        t = Transfer()
+        t.readCleanedFiles()
+        # check if open correct file
+        mo.assert_called_once_with(path, 'r', encoding='utf-8')
+        assert t.cleanedFiles == cleanedFiles
+
+def test_updateCleanedFiles(cleanedFiles, fs):
+    path = '/path/to/files.txt'
+    config.args = Namespace(cleaned_files_path=path, ignore_cleaned_files=False)
+    fs.create_file(path)
+    with open(path, 'w', encoding='utf-8') as mock_file:
+        with patch('ASO.Rucio.Transfer.writePath') as mock_writePath:
+            mock_writePath.return_value.__enter__.return_value = mock_file
+            t = Transfer()
+            t.cleanedFiles = cleanedFiles
+            t.updateCleanedFiles()
+            mock_writePath.assert_called_once_with(path)
+    with open(path, 'r', encoding='utf-8') as mock_file:
+        fileContent = json.loads(mock_file.read())
+        assert fileContent == cleanedFiles


### PR DESCRIPTION
Partial fix https://github.com/dmwm/CRABServer/issues/7423

New `Cleanup` action for cleaning up temp area (and remove temp replica from Rucio DB in the future).
Need to bookkeeping PFNs in case process terminate before run `Cleanup` action in previous run.