### PR TITLE
crab shutdown - ansible playbooks for dagman hold and release

### DIFF
--- a/scripts/Utils/crab-shutdown/000-hold.yml
+++ b/scripts/Utils/crab-shutdown/000-hold.yml
@@ -1,0 +1,17 @@
+- hosts: schedd
+  become: yes
+  become_user: root
+  become_method: sudo
+  vars:
+    ansible_remote_tmp: /tmp
+  tasks:
+  - name: qedit
+    ansible.builtin.shell:
+      cmd: condor_qedit -con 'jobuniverse==7&&jobstatus==2' HoldKillSig \"SIGKILL\"
+    register: shelloutput
+  - ansible.builtin.debug: var=shelloutput.stdout_lines
+  - name: hold
+    ansible.builtin.shell:
+      cmd: condor_hold -con 'jobuniverse==7&&jobstatus==2' -reason ORACLEOFF -subcode 20231212
+    register: shelloutput
+  - ansible.builtin.debug: var=shelloutput.stdout_lines

--- a/scripts/Utils/crab-shutdown/001-release.yml
+++ b/scripts/Utils/crab-shutdown/001-release.yml
@@ -1,0 +1,17 @@
+- hosts: schedd
+  become: yes
+  become_user: root
+  become_method: sudo
+  vars:
+    ansible_remote_tmp: /tmp
+  tasks:
+  - name: qedit
+    ansible.builtin.shell:
+      cmd: condor_qedit -con 'jobuniverse==7&&jobstatus==5&&HoldReason=="ORACLEOFF (by user condor)"&&HoldReasonSubCode==20231212' HoldKillSig \"SIGUSR1\"
+    register: shelloutput
+  - ansible.builtin.debug: var=shelloutput.stdout_lines
+  - name: release
+    ansible.builtin.shell:
+      cmd: condor_release -con 'jobuniverse==7&&jobstatus==5&&HoldReason=="ORACLEOFF (by user condor)"&&HoldReasonSubCode==20231212'
+    register: shelloutput
+  - ansible.builtin.debug: var=shelloutput.stdout_lines

--- a/scripts/Utils/crab-shutdown/README.md
+++ b/scripts/Utils/crab-shutdown/README.md
@@ -1,0 +1,64 @@
+# CRAB Shutdown - useful tools
+
+## Hold and release the dagmans on all the schedds
+
+This directory contains two ansible playbooks to help with hold and release
+the dagmans in all the productions schedds.
+
+Further details on these operation are available on the CRAB 
+[docs](https://cmscrab.docs.cern.ch/technical/crab-shutdown.html)
+
+Install ansible on your laptop, then cd into this directory and hold the
+dagmans in all the schedds with
+
+```bash
+ansible-playbook --diff -i inventory.ini 000-hold.yml
+```
+
+
+Then use this command to release all the dagmans
+
+```bash
+ansible-playbook --diff -i inventory.ini 001-release.yml
+```
+
+An example of a successful release is:
+
+```plaintext
+> ansible-playbook --diff -i inventory.txt 000-restart.yml
+
+PLAY [schedd] **********************************************************************************************************************************************************************************************************************************************
+
+TASK [Gathering Facts] *************************************************************************************************************************************************************************************************************************************
+ok: [vocms0106.cern.ch]
+[...]
+
+TASK [qedit] ***********************************************************************************************************************************************************************************************************************************************
+changed: [vocms0107.cern.ch]
+[...]
+
+TASK [ansible.builtin.debug] *******************************************************************************************************************************************************************************************************************************
+ok: [vocms0106.cern.ch] => {
+    "shelloutput.stdout_lines": [
+        "Set attribute \"HoldKillSig\" for 39 matching jobs."
+    ]
+}
+[...]
+
+TASK [release] *********************************************************************************************************************************************************************************************************************************************
+changed: [vocms0106.cern.ch]
+[...]
+
+TASK [ansible.builtin.debug] *******************************************************************************************************************************************************************************************************************************
+ok: [vocms0106.cern.ch] => {
+    "shelloutput.stdout_lines": [
+        "All jobs matching constraint (jobuniverse==7&&jobstatus==5&&HoldReason==\"ORACLEOFF (by user condor)\"&&HoldReasonSubCode==20231212) have been released"
+    ]
+}
+[...]
+
+PLAY RECAP *************************************************************************************************************************************************************************************************************************************************
+vocms0106.cern.ch          : ok=5    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+[...]
+```
+ 

--- a/scripts/Utils/crab-shutdown/README.md
+++ b/scripts/Utils/crab-shutdown/README.md
@@ -8,7 +8,11 @@ the dagmans in all the productions schedds.
 Further details on these operation are available on the CRAB 
 [docs](https://cmscrab.docs.cern.ch/technical/crab-shutdown.html)
 
-Install ansible on your laptop, then cd into this directory and hold the
+Install ansible on your laptop, make sure you can ssh into the schedds 
+from your laptop with `ssh vocms0106.cern.ch`. Adjust your ssh client config
+if you can not.
+
+Then cd into this directory and hold the
 dagmans in all the schedds with
 
 ```bash
@@ -21,6 +25,33 @@ Then use this command to release all the dagmans
 ```bash
 ansible-playbook --diff -i inventory.ini 001-release.yml
 ```
+
+### troubleshoot
+
+If you have never connected to a schedd before from your laptop, ssh will ask
+you to accept the schedd VM ssh fingerprint and ansible will hang at the
+gathering facts step.
+
+You can avoid this check and let the playbook do its job with
+
+```bash
+# every time
+export ANSIBLE_HOST_KEY_CHECKING=False
+ansible-playbook ...
+```
+
+Or, you can connect to every machine, accept the fingerprint, then run the
+ansible playbook
+
+```bash
+# once, until you clean your ~/.ssh/known_hosts
+for i in $(cat inventory.ini | grep cern.ch); do ssh $i 'cat /etc/hostname'; done
+# every time
+ansible-playbook
+```
+
+
+### Example
 
 An example of a successful release is:
 

--- a/scripts/Utils/crab-shutdown/inventory.ini
+++ b/scripts/Utils/crab-shutdown/inventory.ini
@@ -1,0 +1,16 @@
+[schedd]
+vocms0106.cern.ch
+vocms0107.cern.ch
+vocms0119.cern.ch
+vocms0120.cern.ch
+vocms0121.cern.ch
+vocms0122.cern.ch
+vocms0137.cern.ch
+vocms0144.cern.ch
+vocms0155.cern.ch
+vocms0194.cern.ch
+vocms0195.cern.ch
+vocms0196.cern.ch
+vocms0197.cern.ch
+vocms0198.cern.ch
+vocms0199.cern.ch


### PR DESCRIPTION
I would like to add to dmwm/CRABServer the ansible scripts that I ended up using for holding and releasing the dagmans. 

I had some problems with escaping the single and double quotes to use condor commands with `wassh`, so I quickly drafted and used a couple of ansible playbooks this I would like to share.

@belforte and @novicecpp : every suggestion is always welcome, especially deciding which directory we should use to place such files :)