### PR TITLE
raise exception if ARCH does not map to OS. For #8098

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -520,10 +520,12 @@ class DagmanCreator(TaskAction):
         else:
             info['accelerator_jdl'] = ''
         info['extra_jdl'] = '\n'.join(literal_eval(task['tm_extrajdl']))
-        # info['jobarch_flatten'].split("_")[0]: extracts "slc7" from "slc7_amd64_gcc10"
-        required_os_list = ARCH_TO_OS.get(info['jobarch_flatten'].split("_")[0])
+        arch = info['jobarch_flatten'].split("_")[0]  # extracts "slc7" from "slc7_amd64_gcc10"
+        required_os_list = ARCH_TO_OS.get(arch)
+        if not required_os_list:
+            raise TaskWorkerException(f"Unsupported architecture {arch}")
         # ARCH_TO_OS.get("slc7") gives a list with one item only: ['rhel7']
-        info['opsys_req'] = '+REQUIRED_OS="{}"'.format(required_os_list[0] if required_os_list else "any")
+        info['opsys_req'] = f'+REQUIRED_OS="{required_os_list[0]}"'
 
         info.setdefault("additional_environment_options", '')
         info.setdefault("additional_input_file", "")


### PR DESCRIPTION
with this PR in crab-dev-tw01:
```
belforte@lxplus936/EL9> crab status -d ./crab_20231214_180639 
CRAB project directory:		/afs/cern.ch/work/b/belforte/CRAB3/TC3/EL9/crab_20231214_180639
Task name:			231214_170642:belforte_crab_20231214_180639
Grid scheduler - Task Worker:	N/A yet - crab-dev-tw01
Status on the CRAB server:	SUBMITFAILED
Task URL to use for HELP:	https://cmsweb-test2.cern.ch/crabserver/ui/task/231214_170642%3Abelforte_crab_20231214_180639
Dashboard monitoring URL:	https://monit-grafana.cern.ch/d/cmsTMDetail/cms-task-monitoring-task-view?orgId=11&var-user=belforte&var-task=231214_170642%3Abelforte_crab_20231214_180639&from=1702570002000&to=now
Failure message from server:	Unsupported architecture el9
Log file is /afs/cern.ch/work/b/belforte/CRAB3/TC3/EL9/crab_20231214_180639/crab.log
belforte@lxplus936/EL9> 
```
instead of the run time failure reported in https://cms-talk.web.cern.ch/t/jobs-failing-with-exit-code-10040/32699