### PR TITLE
monit - run monit scripts inside docker containers

### DIFF
--- a/cicd/build/monit-python/Dockerfile
+++ b/cicd/build/monit-python/Dockerfile
@@ -25,11 +25,11 @@ WORKDIR ${WDIR}
 
 RUN git clone https://github.com/dmwm/WMCore /data/srv/monit/WMCore
 RUN mkdir -p /data/srv/monit/
-COPY CheckTapeRecall.py /data/srv/monit
-COPY ServerUtilities.py /data/srv/monit
-COPY RESTInteractions.py /data/srv/monit
-COPY aso_metrics_ora.py /data/srv/monit
-COPY ReportRecallQuota.py /data/srv/monit
+COPY ./scripts/Utils/CheckTapeRecall.py      /data/srv/monit
+COPY ./src/python/ServerUtilities.py         /data/srv/monit
+COPY ./src/python/RESTInteractions.py        /data/srv/monit
+COPY ./src/script/Monitor/aso_metrics_ora.py /data/srv/monit
+COPY ./src/script/Monitor/ReportRecallQuota.py /data/srv/monit
 
 ENV PYTHONPATH=$PYTHONPATH:/data/srv/monit/WMCore/src/python
 ENV RUCIO_HOME=/cvmfs/cms.cern.ch/rucio/current/
@@ -39,7 +39,7 @@ ENV RUCIO_ACCOUNT="crab_server"
 # ENV PYTHONPATH=$PYTHONPATH:/cvmfs/cms.cern.ch/rucio/x86_64/el9/py3/current/lib/python3.9/site-packages/
 # ENV PYTHONPATH=$PYTHONPATH:/cvmfs/cms.cern.ch/rucio/x86_64/el8/py3/current/lib/python3.6/site-packages/
 
-COPY entrypoint.sh /entrypoint.sh
+COPY ./cicd/build/monit-python/entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/bin/bash", "/entrypoint.sh" ]
 
 CMD python3.8 /data/srv/monit/CheckTapeRecall.py

--- a/cicd/build/monit-python/Dockerfile
+++ b/cicd/build/monit-python/Dockerfile
@@ -1,0 +1,47 @@
+FROM python:3.8-bullseye
+
+RUN apt update && apt install -y \
+  vim nano \
+  && \
+  apt clean && rm -rf /var/lib/apt/lists/*
+# the following packages are necessary, but already provided inside the docker image
+#  libcurl-openssl-dev, libssl-dev \
+
+ENV WDIR=/data
+ENV USER=crab3
+
+# add new user and switch to user
+RUN useradd ${USER} &&\
+ install -o ${USER} -d ${WDIR} &&\
+ install -o ${USER} -d /home/${USER}
+USER ${USER}
+
+# pip is already available in the python:3.8 docker image
+# RUN python3.8 -m ensurepip
+RUN python3.8 -m pip install --user rucio-clients pandas pycurl jwt future
+
+RUN mkdir -p /data/srv/tmp
+WORKDIR ${WDIR}
+
+RUN git clone https://github.com/dmwm/WMCore /data/srv/monit/WMCore
+RUN mkdir -p /data/srv/monit/
+COPY CheckTapeRecall.py /data/srv/monit
+COPY ServerUtilities.py /data/srv/monit
+COPY RESTInteractions.py /data/srv/monit
+COPY aso_metrics_ora.py /data/srv/monit
+COPY ReportRecallQuota.py /data/srv/monit
+
+ENV PYTHONPATH=$PYTHONPATH:/data/srv/monit/WMCore/src/python
+ENV RUCIO_HOME=/cvmfs/cms.cern.ch/rucio/current/
+ENV RUCIO_ACCOUNT="crab_server"
+# no need to source a rucio environment from cvmfs. rucio client is already installed
+# via pip, do not pollute the python env with things you do not need!
+# ENV PYTHONPATH=$PYTHONPATH:/cvmfs/cms.cern.ch/rucio/x86_64/el9/py3/current/lib/python3.9/site-packages/
+# ENV PYTHONPATH=$PYTHONPATH:/cvmfs/cms.cern.ch/rucio/x86_64/el8/py3/current/lib/python3.6/site-packages/
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT [ "/bin/bash", "/entrypoint.sh" ]
+
+CMD python3.8 /data/srv/monit/CheckTapeRecall.py
+  # cp -v RecallRules.html /data/eos/RecallRules-docker.html
+  ## we decided to send data to opensearch instead of saving it to eos. no need to copy the file.

--- a/cicd/build/monit-python/entrypoint.sh
+++ b/cicd/build/monit-python/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# ensure container has needed mounts
+check_link(){
+# function checks if symbolic links required to start service exists and if they are not broken
+
+  if [ -L $1 ] ; then
+    if [ -e $1 ] ; then
+       return 0
+    else
+       unlink $1
+       return 1
+    fi
+  else
+    return 1
+  fi
+}
+
+declare -A links=( ["/data/srv/monit/logs"]="/data/hostdisk/${SERVICE}/logs")
+
+for name in "${!links[@]}";
+do
+  check_link "${name}" || ln -s "${links[$name]}" "$name"
+done
+
+exec "$@"

--- a/cicd/build/monit-python/monit_build.sh
+++ b/cicd/build/monit-python/monit_build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+## bash ./cicd/build/monit-python/monit_build.sh
+
+cp ./scripts/Utils/CheckTapeRecall.py      ./cicd/build/monit-python/
+cp ./src/python/ServerUtilities.py         ./cicd/build/monit-python/
+cp ./src/python/RESTInteractions.py        ./cicd/build/monit-python/
+cp ./src/script/Monitor/aso_metrics_ora.py ./cicd/build/monit-python/
+cp ./src/script/Monitor/ReportRecallQuota.py ./cicd/build/monit-python/
+
+docker build \
+  --network=host \
+  -t registry.cern.ch/cmscrab/crabtaskworker:20240328-monitpython \
+  ./cicd/build/monit-python

--- a/cicd/build/monit-python/monit_build.sh
+++ b/cicd/build/monit-python/monit_build.sh
@@ -2,13 +2,8 @@
 
 ## bash ./cicd/build/monit-python/monit_build.sh
 
-cp ./scripts/Utils/CheckTapeRecall.py      ./cicd/build/monit-python/
-cp ./src/python/ServerUtilities.py         ./cicd/build/monit-python/
-cp ./src/python/RESTInteractions.py        ./cicd/build/monit-python/
-cp ./src/script/Monitor/aso_metrics_ora.py ./cicd/build/monit-python/
-cp ./src/script/Monitor/ReportRecallQuota.py ./cicd/build/monit-python/
-
 docker build \
   --network=host \
-  -t registry.cern.ch/cmscrab/crabtaskworker:20240328-monitpython \
-  ./cicd/build/monit-python
+  -t registry.cern.ch/cmscrab/crabtaskworker:20240422-monitpython \
+  ./ \
+  -f ./cicd/build/monit-python/Dockerfile

--- a/cicd/build/monit-taskworker/Dockerfile
+++ b/cicd/build/monit-taskworker/Dockerfile
@@ -5,9 +5,10 @@ RUN source /data/srv/TaskManager/env.sh && \
   python3 -m ensurepip && \
   python3 -m pip install pyjwt
 
-COPY GenerateMONIT.py /data/srv/TaskManager/
 
-COPY entrypoint.sh /entrypoint.sh
+COPY ./src/script/Monitor/GenerateMONIT.py /data/srv/TaskManager/
+
+COPY ./cicd/build/monit-taskworker/entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT [ "/bin/bash", "/entrypoint.sh" ]
 

--- a/cicd/build/monit-taskworker/Dockerfile
+++ b/cicd/build/monit-taskworker/Dockerfile
@@ -1,0 +1,14 @@
+ARG TAG=latest
+FROM registry.cern.ch/cmscrab/crabtaskworker:${TAG}
+
+RUN source /data/srv/TaskManager/env.sh && \
+  python3 -m ensurepip && \
+  python3 -m pip install pyjwt
+
+COPY GenerateMONIT.py /data/srv/TaskManager/
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT [ "/bin/bash", "/entrypoint.sh" ]
+
+CMD python3 /data/srv/TaskManager/GenerateMONIT.py

--- a/cicd/build/monit-taskworker/entrypoint.sh
+++ b/cicd/build/monit-taskworker/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+source /data/srv/TaskManager/env.sh
+
+# ensure container has needed mounts
+check_link(){
+# function checks if symbolic links required to start service exists and if they are not broken
+
+  if [ -L $1 ] ; then
+    if [ -e $1 ] ; then
+       return 0
+    else
+       unlink $1
+       return 1
+    fi
+  else
+    return 1
+  fi
+}
+
+declare -A links=( ["/data/srv/TaskManager/logs"]="/data/hostdisk/${SERVICE}/logs")
+
+for name in "${!links[@]}";
+do
+  check_link "${name}" || ln -s "${links[$name]}" "$name"
+done
+
+exec "$@"

--- a/cicd/build/monit-taskworker/monit_build.sh
+++ b/cicd/build/monit-taskworker/monit_build.sh
@@ -4,10 +4,10 @@
 
 TAG=v3.240325
 
-cp ./src/script/Monitor/GenerateMONIT.py ./cicd/build/monit-taskworker/
-
 docker build \
   --build-arg "TAG=$TAG" \
   --network=host \
   -t registry.cern.ch/cmscrab/crabtaskworker:$TAG.monittw \
-  ./cicd/build/monit-taskworker
+  ./ \
+  -f ./cicd/build/monit-taskworker/Dockerfile
+

--- a/cicd/build/monit-taskworker/monit_build.sh
+++ b/cicd/build/monit-taskworker/monit_build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+## bash ./cicd/build/monit-taskworker/monit_build.sh v3.240111
+
+TAG=v3.240325
+
+cp ./src/script/Monitor/GenerateMONIT.py ./cicd/build/monit-taskworker/
+
+docker build \
+  --build-arg "TAG=$TAG" \
+  --network=host \
+  -t registry.cern.ch/cmscrab/crabtaskworker:$TAG.monittw \
+  ./cicd/build/monit-taskworker

--- a/src/script/Container/runContainer.sh
+++ b/src/script/Container/runContainer.sh
@@ -7,16 +7,19 @@ helpFunction(){
   echo -e "\t-v TW/Publisher version"
   echo -e "\t-s which service should be started: Publisher, Publisher_schedd, Publisher_asoless, Publisher_rucio or TaskWorker"
   echo -e "\t-r docker hub repo, if not provided, default points to 'cmssw'"
+  echo -e "\t-c command that overrides CMD specified in the dockerfile"
   exit 1
   }
 
-while getopts ":v:s:r:h" opt
+while getopts ":v:s:r:h:c:u:" opt
 do
     case "$opt" in
       h) helpFunction ;;
       v) TW_VERSION="$OPTARG" ;;
       s) SERVICE="$OPTARG" ;;
       r) TW_REPO="$OPTARG" ;;
+      c) COMMAND="$OPTARG" ;;
+      u) LOGUUID="$OPTARG" ;;
       :) echo "$0: -$OPTARG needs a value"; helpFunction ;;
       * ) echo "Unimplemented option: -$OPTARG"; helpFunction ;;
     esac
@@ -30,6 +33,9 @@ fi
 dir=("/data/container/${SERVICE}/cfg" "/data/container/${SERVICE}/logs")
 
 case $SERVICE in
+  TaskWorker_monit_*)
+    DIRECTORY='monit'
+    ;;
   TaskWorker*)
     DIRECTORY='TaskManager'
     ;;
@@ -47,9 +53,55 @@ for d in "${dir[@]}"; do
   fi
 done
 
-DOCKER_VOL="-v /data/container/:/data/hostdisk/ -v /data/srv/tmp/:/data/srv/tmp/ -v /cvmfs/cms.cern.ch/SITECONF:/cvmfs/cms.cern.ch/SITECONF -v /etc/grid-security/:/etc/grid-security/ -v /data/certs/:/data/certs/ -v /var/run/nscd/socket:/var/run/nscd/socket -v /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+uuid=$(uuidgen)
+if [ -n "${LOGUUID}+1" ]; then
+    # if LOGUUID is set, then use it
+    uuid=${LOGUUID}
+fi
+tmpfile=/tmp/monit-${uuid}.txt
+
+if [[ "${SERVICE}" == TaskWorker_monit_*  ]]; then
+  countrunning=$(docker ps | grep ${SERVICE} | wc -l)
+  if [[ ! $countrunning -eq "0" ]]; then
+    msg="There already is a running container for $SERVICE. It is likely stuck. Stopping, removing and then starting again."
+    echo $msg
+    # writing now that the previous execution of the script is hanging.
+    # if this execution is ok, then we forget about the previous failure,
+    # otherwise we keep track in /tmp/monit-*.txt that we are having problems
+    echo $msg > $tmpfile
+    docker container stop $SERVICE
+  fi
+  docker container rm $SERVICE
+fi
+
+DOCKER_VOL="-v /data/container/:/data/hostdisk/ -v /data/srv/tmp/:/data/srv/tmp/"
+DOCKER_VOL="${DOCKER_VOL} -v /cvmfs/cms.cern.ch:/cvmfs/cms.cern.ch"
+DOCKER_VOL="${DOCKER_VOL} -v /etc/grid-security/:/etc/grid-security/"
+DOCKER_VOL="${DOCKER_VOL} -v /data/certs/:/data/certs/"
+DOCKER_VOL="${DOCKER_VOL} -v /var/run/nscd/socket:/var/run/nscd/socket"
+DOCKER_VOL="${DOCKER_VOL} -v /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+DOCKER_VOL="${DOCKER_VOL} -v /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/pki/tls/certs/ca-bundle.crt"
 DOCKER_OPT="-e SERVICE=${SERVICE} -w /data/srv/${DIRECTORY} "
-docker run --name ${SERVICE} -d -ti --net host --privileged $DOCKER_OPT $DOCKER_VOL ${TW_REPO:-registry.cern.ch/cmscrab}/crabtaskworker:${TW_VERSION}
+
+if [[ "${SERVICE}" == TaskWorker_monit_*  ]]; then
+  echo "TaskWorker_monit_* detected"
+  # # the following two bind mounts are necessary to write to eos. it has been superseded by sending data to opensearch
+  # DOCKER_OPT="${DOCKER_OPT} -v /eos/project-c/cmsweb/www/CRAB/:/data/eos "
+  # DOCKER_OPT="${DOCKER_OPT} -v /tmp/krb5cc_1000:/tmp/krb5cc_1000 "
+
+  # - monit script does not work with `-di` option inside crontab. 
+  # - in order to get the exit code of the command run inside docker container, 
+  #   remove the `-d` option for monit crontabs
+else
+  # start docker container in background when you run TW and Published, not monitoring scripts.
+  DOCKER_OPT="${DOCKER_OPT} -d"
+fi
+
+docker run --name ${SERVICE} -t --net host --privileged $DOCKER_OPT $DOCKER_VOL ${TW_REPO:-registry.cern.ch/cmscrab}/crabtaskworker:${TW_VERSION} $COMMAND > $tmpfile
+if [ $? -eq 0 ]; then
+  # if the crontab does not fail, remove the log file
+  rm $tmpfile
+fi
 
 echo -e "Sleeping for 3 seconds.\nRunning containers:"
 sleep 3 && docker ps

--- a/src/script/Monitor/GenerateMONIT.py
+++ b/src/script/Monitor/GenerateMONIT.py
@@ -19,11 +19,15 @@ from requests.auth import HTTPBasicAuth
 
 from RESTInteractions import CRABRest
 
-hostname = os.uname()[1]
-hostsAllowRun = ['crab-prod-tw02.cern.ch', 'crab-preprod-tw02.cern.ch',]
-if not hostname in hostsAllowRun:
-    print(f"running on {hostname}, but script allowed to run on {hostsAllowRun}")
-    sys.exit(0)
+## no need to check the hostname, we control where this scripts run on
+## via puppet
+# hostname = os.uname()[1]
+# hostsAllowRun = ['crab-prod-tw02.cern.ch', 
+#                  'crab-preprod-tw02.cern.ch',
+#                  ]
+# if not hostname in hostsAllowRun:
+#     print(f"running on {hostname}, but script allowed to run on {hostsAllowRun}")
+#     sys.exit(0)
 
 FMT = "%Y-%m-%dT%H:%M:%S%z"
 WORKDIR = '/data/srv/TaskManager/'

--- a/src/script/Monitor/ReportRecallQuota.py
+++ b/src/script/Monitor/ReportRecallQuota.py
@@ -1,0 +1,113 @@
+"""
+report used Rucio quota to ElasticSearch via MONIT
+"""
+import sys
+import json
+import logging
+from socket import gethostname
+
+import datetime
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+FMT = "%Y-%m-%dT%H:%M:%S%z"
+WORKDIR = '/data/srv/monit/'
+LOGDIR = '/data/srv/monit/logs/'
+LOGFILE = f'GenMonit-{datetime.datetime.now().strftime("%Y%m%d_%H%M%S")}.log'
+
+
+def readpwd():
+    """
+    Reads password from disk
+    """
+    with open(f"/data/certs/monit.d/MONIT-CRAB.json", encoding='utf-8') as f:
+        credentials = json.load(f)
+    return credentials["url"], credentials["username"], credentials["password"]
+MONITURL, MONITUSER, MONITPWD = readpwd()
+
+def createQuotaReport(rucioClient=None, account=None):
+    """
+    create a dictionary with the quota report to be sent to MONIT
+    even if we do not report usage at single RSE's now, let's collect that info as well
+    returns {'rse1':bytes, 'rse':bytes,..., 'totalTB':TBypte}
+    """
+
+    usageGenerator = rucioClient.get_local_account_usage(account=account)
+    totalBytes = 0
+    report = {}
+    for usage in usageGenerator:
+        rse = usage['rse']
+        used = usage['bytes']
+        report[rse] = used // 1e12
+        totalBytes += used
+    totalTB = totalBytes // 1e12
+    report['totalTB'] = totalTB
+    return report
+
+def send(document):
+    """
+    sends this document to Elastic Search via MONIT
+    the document may contain InfluxDB data, but those will be ignored unless the end point
+    in MONIT is changed. See main code body for more
+    Currently there is no need for using InfluxDB, see discussion in
+    https://its.cern.ch/jira/browse/CMSMONIT-72?focusedCommentId=2920389&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2920389
+    :param document:
+    :return:
+    """
+    return requests.post(f"{MONITURL}", 
+                        auth=HTTPBasicAuth(MONITUSER, MONITPWD),
+                         data=json.dumps(document),
+                         headers={"Content-Type": "application/json; charset=UTF-8"},
+                         verify=False
+                         )
+
+def send_and_check(document, should_fail=False):
+    """
+    commend the `##PROD` section when developing, not to duplicate the data inside elasticsearch
+    """
+    ## DEV
+    # print(type(document), document)
+    # PROD
+    response = send(document)
+    msg = 'With document: {0}. Status code: {1}. Message: {2}'.format(document, response.status_code, response.text)
+    assert ((response.status_code in [200]) != should_fail), \
+        msg
+
+def main(logger):
+    from rucio.client import Client
+    rucioClient = Client(
+        creds={"client_cert": "/data/certs/robotcert.pem", "client_key": "/data/certs/robotkey.pem"},
+        auth_type='x509',
+    )
+    logger.info("rucio client initialized: %s %s", rucioClient.ping(), rucioClient.whoami() )
+
+    # prepare a JSON to be sent to MONIT
+    jsonDoc = {'producer': 'crab', 'type': 'reportrecallquota', 'hostname': gethostname()}
+    # get info for the used account, each will be sent with ad-hoc tag in the JSON
+    accounts = [{'name': 'crab_tape_recall', 'tag': 'tape_recall_total_TB'},
+                {'name': 'crab_input',       'tag': 'crab_input_total_TB'}]
+    for account in accounts:
+        report = createQuotaReport(rucioClient=rucioClient, account=account['name'])
+        jsonDoc[account['tag']] = report['totalTB']
+    send_and_check(jsonDoc)
+
+
+if __name__ == '__main__':
+    # Simple main to execute the action standalone. You just need to set the task worker environment.
+    #  The main is set up to work with the production task worker. If you want to use it on your own
+    #  instance you need to change resthost, resturi, and TWCONFIG.
+
+    # TWCONFIG = '/data/srv/TaskManager/current/TaskWorkerConfig.py'
+
+    logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG)
+    handler1 = logging.StreamHandler(sys.stdout)
+    logger.addHandler(handler1)
+    handler2 = logging.FileHandler(LOGDIR + LOGFILE)
+    formatter = logging.Formatter("%(asctime)s:%(levelname)s:%(module)s %(message)s", datefmt="%a, %d %b %Y %H:%M:%S %Z(%z)")
+    handler2.setFormatter(formatter)
+    logger.addHandler(handler2)
+    logger.setLevel(logging.DEBUG)
+
+    main(logger)

--- a/src/script/Monitor/aso_metrics_ora.py
+++ b/src/script/Monitor/aso_metrics_ora.py
@@ -6,26 +6,50 @@ from __future__ import print_function
 from __future__ import division
 
 import json
+import datetime
+import logging
+import sys
 
 from socket import gethostname
 import requests
+from requests.auth import HTTPBasicAuth
 
 from RESTInteractions import CRABRest
 from ServerUtilities import encodeRequest, oracleOutputMapping
 from ServerUtilities import TRANSFERDB_STATES, PUBLICATIONDB_STATES
 
-MONIT = 'http://monit-metrics:10012/'
+# MONIT = 'http://monit-metrics:10012/'
+# CMSWEB = 'cmsweb.cern.ch'
+# DBINSTANCE = 'prod'
+# CERTIFICATE = '/data/certs/servicecert.pem'
+# KEY = '/data/certs/servicekey.pem'
+
+workdir = '/data/srv/monit/'
+logdir = '/data/srv/monit/logs/'
+logfile = f'GenMonit-{datetime.datetime.now().strftime("%Y%m%d_%H%M%S")}.log'
+
 CMSWEB = 'cmsweb.cern.ch'
 DBINSTANCE = 'prod'
-CERTIFICATE = '/data/certs/servicecert.pem'
-KEY = '/data/certs/servicekey.pem'
+CMSWEB_CERTIFICATE = '/data/certs/servicecert.pem'
+CMSWEB_KEY = '/data/certs/servicekey.pem'
+
+def readpwd():
+    """
+    Reads password from disk
+    """
+    with open(f"/data/certs/monit.d/MONIT-CRAB.json", encoding='utf-8') as f:
+        credentials = json.load(f)
+    return credentials["url"], credentials["username"], credentials["password"]
+MONITURL, MONITUSER, MONITPWD = readpwd()
 
 #======================================================================================================================================
 def getData(subresource):
     """This function will fetch data from Oracle table"""
 
-    crabserver = CRABRest(hostname=CMSWEB, localcert=CERTIFICATE,
-                          localkey=KEY, retry=3, userAgent='CRABTaskWorker')
+    crabserver = CRABRest(hostname=CMSWEB, 
+                          localcert=CMSWEB_CERTIFICATE,
+                          localkey=CMSWEB_KEY, 
+                          retry=3, userAgent='CRABTaskWorker')
     crabserver.setDbInstance(dbInstance=DBINSTANCE)
     result = crabserver.get(api='filetransfers', data=encodeRequest({'subresource': subresource, 'grouping': 0}))
 
@@ -33,18 +57,18 @@ def getData(subresource):
 
 #======================================================================================================================================
 
-def printData(data, header):
+def printData(data, header, logger=None):
     """This function will print table on screen for debuging purpose"""
 
     i = 1
-    print("="*70)
-    print("%-4s%-15s%-10s%-10s" % header)
-    print("-"*70)
+    logger.info("="*70)
+    logger.info("%-4s%-15s%-10s%-10s" % header)
+    logger.info("-"*70)
     for row in data:
-        print("%-4d%-15s%-10d%-10d" % (i, row[header[1]], row[header[2]], row[header[3]]))
+        logger.info("%-4d%-15s%-10d%-10d" % (i, row[header[1]], row[header[2]], row[header[3]]))
         i = i+1
 
-    print("="*70)
+    logger.info("="*70)
 #======================================================================================================================================
 
 def fillData(data, dict_key, aso_worker, state, inputdoc):
@@ -61,52 +85,73 @@ def fillData(data, dict_key, aso_worker, state, inputdoc):
 
 #======================================================================================================================================
 
-def sendDocument(document):
+def sendDocument(document, logger=None):
     """This function upload JSON to MONIT"""
 
-    response = requests.post(MONIT, data=json.dumps(document), headers={"Content-Type": "application/json; charset=UTF-8"})
+    response = requests.post(f"{MONITURL}", 
+                             auth=HTTPBasicAuth(MONITUSER, MONITPWD),
+                             data=json.dumps(document), 
+                             headers={"Content-Type": "application/json; charset=UTF-8"},
+                             verify=False)
+    msg = 'With document: {0}. Status code: {1}. Message: {2}'.format(document, response.status_code, response.text)
+    if not response.status_code in [200]:
+        logger.info(msg)
     return response.status_code
 #======================================================================================================================================
 
-inputDoc = {
-    'producer': 'crab',
-    'type': 'asoless',
-    'hostname': gethostname(),
-    'transfers':{
-        'NEW':{'count':0, 'size':0},
-        'ACQUIRED':{'count':0, 'size':0},
-        'FAILED':{'count':0, 'size':0},
-        'DONE':{'count':0, 'size':0},
-        'RETRY':{'count':0, 'size':0},
-        'SUBMITTED':{'count':0, 'size':0},
-        'KILL':{'count':0, 'size':0},
-        'KILLED':{'count':0, 'size':0}
-        },
-    'publications':{
-        'NEW':{'count':0},
-        'ACQUIRED':{'count':0},
-        'FAILED':{'count':0},
-        'DONE':{'count':0},
-        'RETRY':{'count':0},
-        'NOT_REQUIRED':{'count':0}
-        }
-}
-results = getData('groupedTransferStatistics')
-printData(results, ('Row', 'aso_worker', 'nt', 'transfer_state'))
-print("TRANSFERDB_STATES = {0: 'NEW', 1: 'ACQUIRED', 2: 'FAILED', 3: 'DONE', 4: 'RETRY', 5: 'SUBMITTED', 6: 'KILL', 7: 'KILLED'}")
-fillData(results, 'transfers', 'schedd', 'transfer_state', inputDoc)
+def main():
+    logger = logging.getLogger()
+    handler1 = logging.StreamHandler(sys.stdout)
+    logger.addHandler(handler1)
+    handler2 = logging.FileHandler(logdir + logfile)
+    formatter = logging.Formatter("%(asctime)s:%(levelname)s:%(module)s %(message)s",
+                                  datefmt="%a, %d %b %Y %H:%M:%S %Z(%z)")
+    handler2.setFormatter(formatter)
+    logger.addHandler(handler2)
+    logger.setLevel(logging.INFO)
 
-results = getData('groupedPublishStatistics')
-printData(results, ('Row', 'aso_worker', 'nt', 'publication_state'))
-print("PUBLICATIONDB_STATES={0: 'NEW', 1: 'ACQUIRED', 2: 'FAILED', 3: 'DONE', 4: 'RETRY', 5: 'NOT_REQUIRED'}")
-fillData(results, 'publications', 'schedd', 'publication_state', inputDoc)
+    inputDoc = {
+        'producer': MONITUSER,
+        'type': 'asoless',
+        'hostname': gethostname(),
+        'transfers':{
+            'NEW':{'count':0, 'size':0},
+            'ACQUIRED':{'count':0, 'size':0},
+            'FAILED':{'count':0, 'size':0},
+            'DONE':{'count':0, 'size':0},
+            'RETRY':{'count':0, 'size':0},
+            'SUBMITTED':{'count':0, 'size':0},
+            'KILL':{'count':0, 'size':0},
+            'KILLED':{'count':0, 'size':0}
+            },
+        'publications':{
+            'NEW':{'count':0},
+            'ACQUIRED':{'count':0},
+            'FAILED':{'count':0},
+            'DONE':{'count':0},
+            'RETRY':{'count':0},
+            'NOT_REQUIRED':{'count':0}
+            }
+    }
+    results = getData('groupedTransferStatistics')
+    printData(results, ('Row', 'aso_worker', 'nt', 'transfer_state'), logger)
+    logger.info("TRANSFERDB_STATES = {0: 'NEW', 1: 'ACQUIRED', 2: 'FAILED', 3: 'DONE', 4: 'RETRY', 5: 'SUBMITTED', 6: 'KILL', 7: 'KILLED'}")
+    fillData(results, 'transfers', 'schedd', 'transfer_state', inputDoc)
 
-print("Filled json doc with   where aso_worker=asoless")
-print("-"*70)
-print(json.dumps([inputDoc]))
+    results = getData('groupedPublishStatistics')
+    printData(results, ('Row', 'aso_worker', 'nt', 'publication_state'), logger)
+    logger.info("PUBLICATIONDB_STATES={0: 'NEW', 1: 'ACQUIRED', 2: 'FAILED', 3: 'DONE', 4: 'RETRY', 5: 'NOT_REQUIRED'}")
+    fillData(results, 'publications', 'schedd', 'publication_state', inputDoc)
 
-print("="*70)
-if sendDocument([inputDoc]) == 200:
-    print('successfully uploaded')
-else:
-    print('errors in  uploaded')
+    logger.info("Filled json doc with   where aso_worker=asoless")
+    logger.info("-"*70)
+    logger.info(json.dumps([inputDoc]))
+
+    logger.info("="*70)
+    if sendDocument([inputDoc], logger) == 200:
+        logger.info('successfully uploaded')
+    else:
+        logger.info('errors in  uploaded')
+
+if __name__ == "__main__":
+    main()

--- a/src/script/Monitor/aso_metrics_ora.py
+++ b/src/script/Monitor/aso_metrics_ora.py
@@ -24,9 +24,9 @@ from ServerUtilities import TRANSFERDB_STATES, PUBLICATIONDB_STATES
 # CERTIFICATE = '/data/certs/servicecert.pem'
 # KEY = '/data/certs/servicekey.pem'
 
-workdir = '/data/srv/monit/'
-logdir = '/data/srv/monit/logs/'
-logfile = f'GenMonit-{datetime.datetime.now().strftime("%Y%m%d_%H%M%S")}.log'
+WORKDIR = '/data/srv/monit/'
+LOGDIR = '/data/srv/monit/logs/'
+LOGFILE = f'GenMonit-{datetime.datetime.now().strftime("%Y%m%d_%H%M%S")}.log'
 
 CMSWEB = 'cmsweb.cern.ch'
 DBINSTANCE = 'prod'
@@ -37,7 +37,7 @@ def readpwd():
     """
     Reads password from disk
     """
-    with open(f"/data/certs/monit.d/MONIT-CRAB.json", encoding='utf-8') as f:
+    with open("/data/certs/monit.d/MONIT-CRAB.json", encoding='utf-8') as f:
         credentials = json.load(f)
     return credentials["url"], credentials["username"], credentials["password"]
 MONITURL, MONITUSER, MONITPWD = readpwd()
@@ -46,9 +46,9 @@ MONITURL, MONITUSER, MONITPWD = readpwd()
 def getData(subresource):
     """This function will fetch data from Oracle table"""
 
-    crabserver = CRABRest(hostname=CMSWEB, 
+    crabserver = CRABRest(hostname=CMSWEB,
                           localcert=CMSWEB_CERTIFICATE,
-                          localkey=CMSWEB_KEY, 
+                          localkey=CMSWEB_KEY,
                           retry=3, userAgent='CRABTaskWorker')
     crabserver.setDbInstance(dbInstance=DBINSTANCE)
     result = crabserver.get(api='filetransfers', data=encodeRequest({'subresource': subresource, 'grouping': 0}))
@@ -62,16 +62,16 @@ def printData(data, header, logger=None):
 
     i = 1
     logger.info("="*70)
-    logger.info("%-4s%-15s%-10s%-10s" % header)
+    logger.info("%-4s%-15s%-10s%-10s", header)
     logger.info("-"*70)
     for row in data:
-        logger.info("%-4d%-15s%-10d%-10d" % (i, row[header[1]], row[header[2]], row[header[3]]))
+        logger.info("%-4d%-15s%-10d%-10d", (i, row[header[1]], row[header[2]], row[header[3]]))
         i = i+1
 
     logger.info("="*70)
 #======================================================================================================================================
 
-def fillData(data, dict_key, aso_worker, state, inputdoc):
+def fillData(data, dictKey, asoWorker, state, inputdoc):
     "This function will fill fetched data from Oracle table in JSON dict."""
 
     if state == 'transfer_state':
@@ -80,17 +80,17 @@ def fillData(data, dict_key, aso_worker, state, inputdoc):
         STATES = PUBLICATIONDB_STATES
 
     for row in data:
-        if row['aso_worker'] == aso_worker:
-            inputdoc[dict_key][STATES[row[state]]]['count'] = row['nt']
+        if row['aso_worker'] == asoWorker:
+            inputdoc[dictKey][STATES[row[state]]]['count'] = row['nt']
 
 #======================================================================================================================================
 
 def sendDocument(document, logger=None):
     """This function upload JSON to MONIT"""
 
-    response = requests.post(f"{MONITURL}", 
+    response = requests.post(f"{MONITURL}",
                              auth=HTTPBasicAuth(MONITUSER, MONITPWD),
-                             data=json.dumps(document), 
+                             data=json.dumps(document),
                              headers={"Content-Type": "application/json; charset=UTF-8"},
                              verify=False)
     msg = 'With document: {0}. Status code: {1}. Message: {2}'.format(document, response.status_code, response.text)
@@ -103,7 +103,7 @@ def main():
     logger = logging.getLogger()
     handler1 = logging.StreamHandler(sys.stdout)
     logger.addHandler(handler1)
-    handler2 = logging.FileHandler(logdir + logfile)
+    handler2 = logging.FileHandler(LOGDIR + LOGFILE)
     formatter = logging.Formatter("%(asctime)s:%(levelname)s:%(module)s %(message)s",
                                   datefmt="%a, %d %b %Y %H:%M:%S %Z(%z)")
     handler2.setFormatter(formatter)


### PR DESCRIPTION
Related to #6493 

### status

Tested, ready to be reviewed

### Description

The purpose of this PR is to run the scripts GenerateMonit, CheckTapeRecall, aso_metrics_ora and ReportRecallQuota inside docker containers.

- GenerateMonit.py runs inside a crabtaskworker container.
- CheckTapeRecall.py, aso_metrics_ora and ReportRecallQuota runs inside a python:3.8 

design choices:

- run script inside a docker container. The script runs once per `docker run`
- script output:
    - every script has it's own application log, same as before
    - every script prints to stdout. if the script fails, then the stdout is saved in a file in `/tmp/monit-*.txt`
    - [ ] ? shall we get rid of the application log and send everything to stdout? 

next steps

- [ ] merge this PR
- [ ] change puppet qa and master so that runcontainer.sh is taken from master branch (not from the branch of this PR)
- [ ] disable scripts on crab-preprod-tw02, enable script on crab-prod-tw02
- [ ] disable recurring action [report recall quota](https://github.com/dmwm/CRABServer/blob/master/src/python/TaskWorker/Actions/Recurring/ReportRecallQuota.py)

All further information is available in our docs, at:

- https://cmscrab.docs.cern.ch/technical/crab-monitoring/crab-opensearch.html
- https://cmscrab.docs.cern.ch/technical/crab-monitoring/crab-crontabs.html
