### PR TITLE
CMSRunAnalysis.py takes JSON file as arg Fix #8196

### DIFF
--- a/scripts/CMSRunAnalysis.sh
+++ b/scripts/CMSRunAnalysis.sh
@@ -67,7 +67,7 @@ echo "==== Local directory contents dump FINISHING ===="
 echo "======== CMSRunAnalysis.py STARTING at $(TZ=GMT date) ========"
 echo "Now running the CMSRunAnalysis.py job in `pwd`..."
 set -x
-$pythonCommand CMSRunAnalysis.py -r "`pwd`" "$@"
+$pythonCommand CMSRunAnalysis.py "$@"
 jobrc=$?
 set +x
 echo "== The job had an exit code of $jobrc "

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -707,7 +707,7 @@ class DagmanCreator(TaskAction):
             argDict['scriptExe'] = kw['task']['tm_scriptexe'] #
             argDict['eventsPerLumi'] = kw['task']['tm_events_per_lumi'] #
             argDict['maxRuntime'] = kw['task']['max_runtime'] #-1
-            argDict['scriptArgs'] = json.dumps(kw['task']['tm_scriptargs']).replace('"', r'\"\"') #'[]'
+            argDict['scriptArgs'] = kw['task']['tm_scriptargs']
             argDict['CRAB_AdditionalOutputFiles'] = info['addoutputfiles_flatten']
             #The following two are for fixing up job.submit files
             argDict['CRAB_localOutputFiles'] = dagspec['localOutputFiles']


### PR DESCRIPTION
also small changes to CMSRunAnalysis.sh for compatibility and remove double conversion to JSON of `ScriptArgs` in DagmanCreator