### PR TITLE
Fix bug from PR#8254

### DIFF
--- a/cicd/crabserver_pypi/Dockerfile
+++ b/cicd/crabserver_pypi/Dockerfile
@@ -53,6 +53,9 @@ RUN ls /data/srv/current/ \
     && install -d -o ${USER} -g ${USER} /data/srv/current/auth/crabserver \
     && install -d -o ${USER} -g ${USER} /data/srv/current/config/crabserver
 
+# remove unuse /data/manage come from baseimage to prevent confusion
+RUN rm /data/manage
+
 # copy running script files
 COPY cicd/crabserver_pypi/run.sh cicd/crabserver_pypi/manage.sh cicd/crabserver_pypi/entrypoint.sh cicd/crabserver_pypi/start.sh cicd/crabserver_pypi/stop.sh /data/
 

--- a/cicd/crabserver_pypi/run.sh
+++ b/cicd/crabserver_pypi/run.sh
@@ -1,6 +1,8 @@
 #! /bin/bash
 # Container main process.
 
+set -euo pipefail
+
 # run monitoring script
 if [ -f /data/monitor.sh ]; then
     /data/monitor.sh &
@@ -14,7 +16,7 @@ cat /data/srv/state/crabserver/crabserver-fifo &
 
 #start the service
 #export CRYPTOGRAPHY_ALLOW_OPENSSL_102=true
-/data/manage start
+/data/start.sh -c
 
 # cat fifo forever to read logs
 while true;

--- a/cicd/crabserver_pypi/start.sh
+++ b/cicd/crabserver_pypi/start.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -euo pipefail
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 helpFunction() {
@@ -10,6 +12,8 @@ helpFunction() {
     exit 1
 }
 
+DEBUG=''
+MODE=''
 while getopts ":dDcCgGhH" o; do
     case "${o}" in
         h|H) helpFunction ;;
@@ -28,16 +32,16 @@ fi
 case $MODE in
     current)
         # current mode: run current instance
-        APP_PATH=/data/srv/current/lib/python/site-packages
+        PYTHONPATH=/data/srv/current/lib/python/site-packages:${PYTHONPATH:-}
         ;;
     fromGH)
         # private mode: run private instance from GH
-        APP_PATH=/data/repos/WMCore/src/python:/data/repos/CRABServer/src/python
+        PYTHONPATH=/data/repos/WMCore/src/python:/data/repos/CRABServer/src/python:${PYTHONPATH:-}
         ;;
     *) echo "Unimplemented mode: $MODE\n"; helpFunction ;;
 esac
 
 # passing DEBUG/APP_PATH to ./manage.sh scripts
 export DEBUG
-export APP_PATH
+export PYTHONPATH
 "${SCRIPT_DIR}/manage.sh" start

--- a/cicd/crabserver_pypi/stop.sh
+++ b/cicd/crabserver_pypi/stop.sh
@@ -1,4 +1,6 @@
 #! /bin/bash
 
+set -euo pipefail
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 "${SCRIPT_DIR}"/manage.sh stop

--- a/cicd/crabtaskworker_pypi/manage.sh
+++ b/cicd/crabtaskworker_pypi/manage.sh
@@ -2,8 +2,10 @@
 
 # Same style as crabserver_pypi/manage.sh script, but for crabtaskworker.
 # This script needs following environment variables:
-#   - DEBUG:   if `true`, setup debug mode environment .
-#   - APP_DIR: PYTHONPATH of the app.
+#   - DEBUG:   if `true`, setup debug mode environment.
+#   - PYTHONPATH: inherit from ./start.sh
+
+set -euo pipefail
 
 ##H Usage: manage.sh ACTION [ATTRIBUTE] [SECURITY-STRING]
 ##H
@@ -17,14 +19,15 @@
 
 ## some variable use in start_srv
 TASKWORKER_HOME=/data/srv/TaskManager
-COMMAND_DIR=${APP_PATH}/TaskWorker
 CONFIG=$TASKWORKER_HOME/cfg/TaskWorkerConfig.py
 
 # CRABTASKWORKER_ROOT is a mandatory variable for getting data directory in `DagmanCreator.getLocation()`
 # Hardcoded the path and use new_updateTMRuntime.sh to build it from source and copy to this path.
 export CRABTASKWORKER_ROOT=/data/srv/current/lib/python/site-packages/
-## app
-export PYTHONPATH=$APP_PATH:$PYTHONPATH
+
+# app path. Inherit PYTHONPATH from ./start.sh
+PYTHONPATH=${PYTHONPATH:-/data/srv/current/lib/python/site-packages}
+export PYTHONPATH
 
 usage()
 {
@@ -33,9 +36,11 @@ usage()
 
 start_srv() {
     if [[ "$DEBUG" == true ]]; then
-        python3 -m pdb ${COMMAND_DIR}/SequentialWorker.py ${CONFIG} --logDebug
+        APP_DIR=${APP_DIR:-/data/repos/CRABServer/src/python}
+        python3 -m pdb ${APP_DIR}/TaskWorker/SequentialWorker.py ${CONFIG} --logDebug
     else
-        nohup python3 ${COMMAND_DIR}/MasterWorker.py --config ${CONFIG} --logDebug &
+        APP_DIR=/data/srv/current/lib/python/site-packages
+        nohup python3 ${APP_DIR}/TaskWorker/MasterWorker.py --config ${CONFIG} --logDebug &
     fi
 }
 
@@ -43,16 +48,21 @@ stop_srv() {
     # This part is copy from https://github.com/dmwm/CRABServer/blob/3af9d658271a101db02194f48c5cecaf5fab7725/src/script/Deployment/TaskWorker/stop.sh
     # TW is given checkTimes*timeout seconds to stop, if it is still running after
     # this period, TW and all its slaves are killed by sending SIGKILL signal.
+    echo 'Stopping TaskWorker...'
     checkTimes=12
     timeout=15 #that will give 12*15=180 seconds (3min) for the TW to finish work
 
-    TaskMasterPid=$(ps exfww | grep MasterWorker | grep -v grep | head -1 | awk '{print $1}')
-    kill $TaskMasterPid || return
+    TaskMasterPid=$(ps exfww | grep MasterWorker | grep -v grep | head -1 | awk '{print $1}') || true
+    if [[ -z $TaskMasterPid ]]; then
+        echo "No master process running."
+        return;
+    fi
+    kill $TaskMasterPid
     echo "SIGTERM sent to MasterWorker pid $TaskMasterPid"
 
     for (( i=0; i<$checkTimes; ++i)); do
       # get only alive slaves, i.e. exclude defunct processes
-      aliveSlaves=`ps --ppid $TaskMasterPid  -o pid,s | grep -v "Z" | awk '{print $1}' | tail -n +2 | tr '\n' ' '`
+      aliveSlaves=$(ps --ppid $TaskMasterPid  -o pid,s | grep -v "Z" | awk '{print $1}' | tail -n +2 | tr '\n' ' ') || true
 
       if [ -n "$aliveSlaves" ]; then
         echo "slave(s) PID [ ($aliveSlaves) ] are still running, sleeping for $timeout seconds. ($((i+1)) of $checkTimes try)"
@@ -64,7 +74,7 @@ stop_srv() {
       fi
     done
 
-    runningProcesses=`pgrep -f TaskWorker | tr '\n' ' '`
+    runningProcesses=$(pgrep -f TaskWorker | tr '\n' ' ') || true
     if [ -n "$runningProcesses" ]; then
       echo -e "After max allowed time ($((checkTimes * timeout)) seconds) following TW processes are still running: $runningProcesses \nSending SIGKILL to stop it."
       pkill -9 -f TaskWorker

--- a/cicd/crabtaskworker_pypi/run.sh
+++ b/cicd/crabtaskworker_pypi/run.sh
@@ -1,8 +1,10 @@
 #! /bin/bash
 # Main process of container.
 
+set -euo pipefail
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-cd ${SCRIPT_DIR}
+cd "${SCRIPT_DIR}"
 
 ./start.sh -c
 

--- a/cicd/crabtaskworker_pypi/start.sh
+++ b/cicd/crabtaskworker_pypi/start.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 helpFunction() {
@@ -10,6 +12,8 @@ helpFunction() {
     exit 1
 }
 
+DEBUG=''
+MODE=''
 while getopts ":dDcCgGhH" o; do
     case "${o}" in
         h|H) helpFunction ;;
@@ -34,19 +38,19 @@ case $MODE in
             echo "Refuse to start with -c option."
             exit 1
         fi
-        APP_PATH=/data/srv/current/lib/python/site-packages
+        PYTHONPATH=/data/srv/current/lib/python/site-packages:${PYTHONPATH:-}
         ;;
     fromGH)
         # private mode: run private instance from GH
-        APP_PATH=/data/repos/CRABServer/src/python:/data/repos/WMCore/src/python
+        PYTHONPATH=/data/repos/CRABServer/src/python:/data/repos/WMCore/src/python:${PYTHONPATH:-}
         # update runtime (create TaskManagerRun.tar.gz from source)
         touch ${markmodify_path}
-        ./new_updateTMRuntime.sh
+        ./updateDatafiles.sh
         ;;
     *) echo "Unimplemented mode: $MODE\n"; helpFunction ;;
 esac
 
 # export APP_PATH and DEBUG to ./manage.sh
-export APP_PATH
+export PYTHONPATH
 export DEBUG
 "${SCRIPT_DIR}/manage.sh" start

--- a/cicd/crabtaskworker_pypi/stop.sh
+++ b/cicd/crabtaskworker_pypi/stop.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -euo pipefail
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 "${SCRIPT_DIR}"/manage.sh stop


### PR DESCRIPTION
1. Fix typo bug from file name changes.
2. Use PYTHONPATH directly instead of APP_PATH because it will break path when assign as prefix of COMMAND_DIR in [manage.sh#L20](https://github.com/dmwm/CRABServer/blob/22cb74aaf1f15d4d6eafd7701d06d9e71b9c8430/cicd/crabtaskworker_pypi/manage.sh#L20) in `./start.sh -g` mode.
3. Apply `set -euo pipefail` to all process control scripts to make it more robust.

