### PR TITLE
Bump cmsweb TW to 20230901-stable and WMCore to 2.3.2rc3

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/cmsweb:20230427-stable
+FROM registry.cern.ch/cmsweb/cmsweb:20230901-stable
 MAINTAINER Daina Dirmaite daina.dirmaite@gmail.com
 
 #keep only voms-proxy basded on c++

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@
 # Format:
 # Dependency==version
 
-wmcver==2.1.8
+wmcver==2.3.2rc3


### PR DESCRIPTION
Same version as [CRAB REST](https://github.com/dmwm/CMSKubernetes/blob/0e9277d98a1feba8f9e6b0bc20c5fb6e1f0ef4c9/docker/crabserver/Dockerfile#L1).