### PR TITLE
use crab-sched-901 for Jenkins tests

### DIFF
--- a/test/clientValidationTasks/crabConfiguration.py
+++ b/test/clientValidationTasks/crabConfiguration.py
@@ -29,4 +29,4 @@ config.section_("Site")
 config.Site.storageSite = 'T2_CH_CERN'
 
 config.section_("Debug")
-config.Debug.scheddName = 'crab3@vocms059.cern.ch'
+config.Debug.scheddName = 'crab3@crab-sched-901.cern.ch'

--- a/test/statusTrackingTasks/HC-1kj.py
+++ b/test/statusTrackingTasks/HC-1kj.py
@@ -36,6 +36,6 @@ config.Site.blacklist = ['T2_ES_IFCA']
 config.Site.storageSite = 'T2_CH_CERN'
  
 config.section_("Debug")
-config.Debug.scheddName = 'crab3@vocms059.cern.ch'
+config.Debug.scheddName = 'crab3@crab-sched-901.cern.ch'
 
 

--- a/test/statusTrackingTasks/HC-automaticSplit.py
+++ b/test/statusTrackingTasks/HC-automaticSplit.py
@@ -35,6 +35,6 @@ config.Site.blacklist = ['T2_ES_IFCA']
 config.Site.storageSite = 'T2_CH_CERN'
  
 config.section_("Debug")
-config.Debug.scheddName = 'crab3@vocms059.cern.ch'
+config.Debug.scheddName = 'crab3@crab-sched-901.cern.ch'
 
 

--- a/test/statusTrackingTasks/HC-splitByEventAwareLumi.py
+++ b/test/statusTrackingTasks/HC-splitByEventAwareLumi.py
@@ -36,6 +36,6 @@ config.Site.blacklist = ['T2_ES_IFCA']
 config.Site.storageSite = 'T2_CH_CERN'
  
 config.section_("Debug")
-config.Debug.scheddName = 'crab3@vocms059.cern.ch'
+config.Debug.scheddName = 'crab3@crab-sched-901.cern.ch'
 
 

--- a/test/statusTrackingTasks/HC-splitByFile.py
+++ b/test/statusTrackingTasks/HC-splitByFile.py
@@ -36,6 +36,6 @@ config.Site.blacklist = ['T2_ES_IFCA']
 config.Site.storageSite = 'T2_CH_CERN'
  
 config.section_("Debug")
-config.Debug.scheddName = 'crab3@vocms059.cern.ch'
+config.Debug.scheddName = 'crab3@crab-sched-901.cern.ch'
 
 

--- a/test/statusTrackingTasks/HC-splitByLumi.py
+++ b/test/statusTrackingTasks/HC-splitByLumi.py
@@ -36,6 +36,6 @@ config.Site.blacklist = ['T2_ES_IFCA']
 config.Site.storageSite = 'T2_CH_CERN'
  
 config.section_("Debug")
-config.Debug.scheddName = 'crab3@vocms059.cern.ch'
+config.Debug.scheddName = 'crab3@crab-sched-901.cern.ch'
 
 

--- a/test/statusTrackingTasks/Pythia.py
+++ b/test/statusTrackingTasks/Pythia.py
@@ -38,6 +38,6 @@ config.Site.blacklist = ['T2_ES_IFCA']
 config.Site.storageSite = 'T2_CH_CERN'
  
 config.section_("Debug")
-config.Debug.scheddName = 'crab3@vocms059.cern.ch'
+config.Debug.scheddName = 'crab3@crab-sched-901.cern.ch'
 
 

--- a/test/statusTrackingTasks/rucio_transfers.py
+++ b/test/statusTrackingTasks/rucio_transfers.py
@@ -45,4 +45,4 @@ config.Site.whitelist = ['T1_*','T2_US_*','T2_IT_*','T2_DE_*','T2_ES_*','T2_FR_*
 config.Site.storageSite = 'T2_CH_CERN'
 
 config.section_("Debug")
-config.Debug.scheddName = 'crab3@vocms059.cern.ch'
+config.Debug.scheddName = 'crab3@crab-sched-901.cern.ch'

--- a/test/statusTrackingTasks/rucio_transfers_group.py
+++ b/test/statusTrackingTasks/rucio_transfers_group.py
@@ -45,4 +45,4 @@ config.Site.whitelist = ['T1_*','T2_US_*','T2_IT_*','T2_DE_*','T2_ES_*','T2_FR_*
 config.Site.storageSite = 'T2_IT_Legnaro'
 
 config.section_("Debug")
-config.Debug.scheddName = 'crab3@vocms059.cern.ch'
+config.Debug.scheddName = 'crab3@crab-sched-901.cern.ch'

--- a/test/statusTrackingTasks/rucio_transfers_manyedm_nopublication.py
+++ b/test/statusTrackingTasks/rucio_transfers_manyedm_nopublication.py
@@ -45,4 +45,4 @@ config.Site.whitelist = ['T1_*','T2_US_*','T2_IT_*','T2_DE_*','T2_ES_*','T2_FR_*
 config.Site.storageSite = 'T2_CH_CERN'
 
 config.section_("Debug")
-config.Debug.scheddName = 'crab3@vocms059.cern.ch'
+config.Debug.scheddName = 'crab3@crab-sched-901.cern.ch'

--- a/test/statusTrackingTasks/rucio_transfers_nopublication.py
+++ b/test/statusTrackingTasks/rucio_transfers_nopublication.py
@@ -45,4 +45,4 @@ config.Site.whitelist = ['T1_*','T2_US_*','T2_IT_*','T2_DE_*','T2_ES_*','T2_FR_*
 config.Site.storageSite = 'T2_CH_CERN'
 
 config.section_("Debug")
-config.Debug.scheddName = 'crab3@vocms059.cern.ch'
+config.Debug.scheddName = 'crab3@crab-sched-901.cern.ch'

--- a/test/statusTrackingTasks/rucio_transfers_withnoneedm.py
+++ b/test/statusTrackingTasks/rucio_transfers_withnoneedm.py
@@ -47,4 +47,4 @@ config.Site.whitelist = ['T1_*','T2_US_*','T2_IT_*','T2_DE_*','T2_ES_*','T2_FR_*
 config.Site.storageSite = 'T2_CH_CERN'
 
 config.section_("Debug")
-config.Debug.scheddName = 'crab3@vocms059.cern.ch'
+config.Debug.scheddName = 'crab3@crab-sched-901.cern.ch'

--- a/test/statusTrackingTasks/rucio_transfers_withnoneedm_nopublication.py
+++ b/test/statusTrackingTasks/rucio_transfers_withnoneedm_nopublication.py
@@ -47,4 +47,4 @@ config.Site.whitelist = ['T1_*','T2_US_*','T2_IT_*','T2_DE_*','T2_ES_*','T2_FR_*
 config.Site.storageSite = 'T2_CH_CERN'
 
 config.section_("Debug")
-config.Debug.scheddName = 'crab3@vocms059.cern.ch'
+config.Debug.scheddName = 'crab3@crab-sched-901.cern.ch'

--- a/test/testUtils.py
+++ b/test/testUtils.py
@@ -113,6 +113,7 @@ config.section_('Site')
 config.Site.storageSite = 'T2_CH_CERN'
 
 config.section_('Debug')
+config.Debug.scheddName = 'crab3@crab-sched-901.cern.ch'
 """
 
 psetFileContent = """


### PR DESCRIPTION
temporary change to test new alma9 schedulers

To be reverted after enough Jenkins tests have run