### PR TITLE
Clean up cmsbot's Rucio storage space

### DIFF
--- a/cicd/rucio/cleanup.py
+++ b/cicd/rucio/cleanup.py
@@ -7,7 +7,7 @@ import os
 from rucio.client import Client
 from rucio.rse.rsemanager import find_matching_scheme
 
-DRY_RUN = os.getenv("DRY_RUN", 'False').lower() in ('True', 'true', '1', 't')
+DRY_RUN = os.getenv("DRY_RUN", 'True').lower() in ('True', 'true', '1', 't')
 
 def deleteRules(client=None, filters=None):
     """

--- a/cicd/rucio/cleanup.py
+++ b/cicd/rucio/cleanup.py
@@ -5,14 +5,13 @@ import datetime
 import os
 
 from rucio.client import Client
-from rucio.rse.rsemanager import find_matching_scheme
 
-DRY_RUN = os.getenv("DRY_RUN", 'True').lower() in ('True', 'true', '1', 't')
+DRY_RUN = os.getenv("DRY_RUN", 'True').lower() in ('true', '1', 't')
 
 def deleteRules(client=None, filters=None):
     """
-    Delete rucio rules that older than 30 day. Make sure to delete only rules
-    match name create by CRAB Rucio ASO.
+    Delete Rucio rules that older than 30 day. Make sure to delete only rules
+    that match name created by CRAB Rucio ASO.
 
     :param client: rucio client object
     :type client: rucio.client.client.Client

--- a/cicd/rucio/cleanup.py
+++ b/cicd/rucio/cleanup.py
@@ -1,41 +1,62 @@
-#!/usr/bin/env python
-
+"""
+Cleanup rucio rules from cmsbot account created by task in testsuite.
+"""
 import datetime
-import pprint
+import os
 
 from rucio.client import Client
 from rucio.rse.rsemanager import find_matching_scheme
 
+DRY_RUN = os.getenv("DRY_RUN", 'False').lower() in ('True', 'true', '1', 't')
+
 def deleteRules(client=None, filters=None):
+    """
+    Delete rucio rules that older than 30 day. Make sure to delete only rules
+    match name create by CRAB Rucio ASO.
+
+    :param client: rucio client object
+    :type client: rucio.client.client.Client
+    :param filters: dict filter used by list_replication_rules()
+    :type filters: dict
+
+    """
+    # get rules, apply filters
     allRules = client.list_replication_rules(filters=filters)
     formattedRules = [(x['created_at'], x['id'], x['name']) for x in allRules]
 
     #pprint.pprint(formattedRules)
+    now = datetime.datetime.now()
+    today = datetime.datetime(year=now.year, month=now.month, day=now.day)
 
     matchRules = []
     for x in formattedRules:
-        if x[0] > (datetime.datetime.now() - datetime.timedelta(days=4)):
+        # skip if rule is newer than 30 day
+        if x[0] > (today - datetime.timedelta(days=30)):
             continue
+        # failsafe to delete only task created by crab.
         if not ('ruciotransfers' in x[2] or 'FakePublish' in x[2]):
             continue
         matchRules.append(x)
 
-    #pprint.pprint(matchRules)
+    print(f'Found {len(formattedRules)} rules, match {len(matchRules)} rules')
 
-    print(f'Found {len(formattedRules)}, match {len(matchRules)}')
-
+    # deleting the rules
     for x in matchRules:
         try:
-            print(f'deleting rules {x[1]}')
+            print(f'Deleting rules {x[1]}')
+            if DRY_RUN:
+                raise Exception('Dry run.')
             client.delete_replication_rule(x[1], purge_replicas=True)
         except Exception as e:
             print(f'Error: {e}')
             print('Skipping...')
 
 
+# Cleanup cmsbot account
 rucio=Client()
 rucio.whoami()
 deleteRules(client=rucio, filters={'account': 'cmsbot', 'scope': 'user.cmsbot'})
+# Cleanup crab_test_group account
 rucioGroup=Client(account='crab_test_group')
 rucioGroup.whoami()
 deleteRules(client=rucioGroup, filters={'account': 'crab_test_group', 'scope': 'group.crab_test'})

--- a/cicd/rucio/cleanup.py
+++ b/cicd/rucio/cleanup.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+import datetime
+import pprint
+
+from rucio.client import Client
+from rucio.rse.rsemanager import find_matching_scheme
+
+def deleteRules(client=None, filters=None):
+    allRules = client.list_replication_rules(filters=filters)
+    formattedRules = [(x['created_at'], x['id'], x['name']) for x in allRules]
+
+    #pprint.pprint(formattedRules)
+
+    matchRules = []
+    for x in formattedRules:
+        if x[0] > (datetime.datetime.now() - datetime.timedelta(days=4)):
+            continue
+        if not ('ruciotransfers' in x[2] or 'FakePublish' in x[2]):
+            continue
+        matchRules.append(x)
+
+    #pprint.pprint(matchRules)
+
+    print(f'Found {len(formattedRules)}, match {len(matchRules)}')
+
+    for x in matchRules:
+        try:
+            print(f'deleting rules {x[1]}')
+            client.delete_replication_rule(x[1], purge_replicas=True)
+        except Exception as e:
+            print(f'Error: {e}')
+            print('Skipping...')
+
+
+rucio=Client()
+rucio.whoami()
+deleteRules(client=rucio, filters={'account': 'cmsbot', 'scope': 'user.cmsbot'})
+rucioGroup=Client(account='crab_test_group')
+rucioGroup.whoami()
+deleteRules(client=rucioGroup, filters={'account': 'crab_test_group', 'scope': 'group.crab_test'})

--- a/cicd/rucio/cleanup.sh
+++ b/cicd/rucio/cleanup.sh
@@ -7,4 +7,5 @@ voms-proxy-info
 source /cvmfs/cms.cern.ch/rucio/setup-py3.sh
 rucio whoami
 
+export DRY_RUN=${DRY_RUN:-false}
 python3 "${SCRIPT_DIR}"/cleanup.py

--- a/cicd/rucio/cleanup.sh
+++ b/cicd/rucio/cleanup.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+voms-proxy-init --rfc --voms cms -valid 192:00
+voms-proxy-info
+
+source /cvmfs/cms.cern.ch/rucio/setup-py3.sh
+rucio whoami
+
+python3 "${SCRIPT_DIR}"/cleanup.py


### PR DESCRIPTION
Hardcode username and filter for now, will fix when we migrate to Gitlab-CI later.

Jenkins job config: https://cmssdt.cern.ch/dmwm-jenkins/job/tseethon_Run/configure
Succesfully run: https://cmssdt.cern.ch/dmwm-jenkins/job/tseethon_Run/11/console
