### PR TITLE
attempt to streamline parent file discovery

### DIFF
--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -107,13 +107,12 @@ class DBSDataDiscovery(DataDiscovery):
         common_runs = d1.keys() & d2.keys()
         if len(common_runs)	== 0: return False
 
-        for	run in common_runs:
-            print(run)
+        for run in common_runs:
             common_lumis = set(d1[run]).intersection(set(d2[run]))
             if len(common_lumis)>0 : return	True
 
         return False
-    
+
     def execute(self, *args, **kwargs):
         """
         This is a convenience wrapper around the executeInternal function

--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -95,6 +95,25 @@ class DBSDataDiscovery(DataDiscovery):
                 msg += "\nhttps://twiki.cern.ch/twiki/bin/view/CMSPublic/CRAB3FAQ"
                 raise TaskWorkerException(msg)
 
+    @staticmethod
+    def lumi_overlap(d1,d2):
+        """
+        This finds if there are common run and lumis in two lists in the form of
+        {
+        '1': [1,2,3,4,6,7,8,9,10],
+        '2': [1,4,5,20]
+        }
+        """
+        common_runs = d1.keys() & d2.keys()
+        if len(common_runs)	== 0: return False
+
+        for	run in common_runs:
+            print(run)
+            common_lumis = set(d1[run]).intersection(set(d2[run]))
+            if len(common_lumis)>0 : return	True
+
+        return False
+    
     def execute(self, *args, **kwargs):
         """
         This is a convenience wrapper around the executeInternal function
@@ -353,17 +372,15 @@ class DBSDataDiscovery(DataDiscovery):
                         del filedetails[key]
             if secondaryDataset:
                 moredetails = self.dbs.listDatasetFileDetails(secondaryDataset, getParents=False, getLumis=needLumiInfo, validFileOnly=0)
-
-                for secfilename, secinfos in moredetails.items():
-                    secinfos['lumiobj'] = LumiList(runsAndLumis=secinfos['Lumis'])
-
                 self.logger.info("Beginning to match files from secondary dataset")
+
                 for dummyFilename, infos in filedetails.items():
+                    primary_lumis = infos['Lumis']
                     infos['Parents'] = []
-                    lumis = LumiList(runsAndLumis=infos['Lumis'])
                     for secfilename, secinfos in moredetails.items():
-                        if lumis & secinfos['lumiobj']:
+                        if self.lumi_overlap(primary_lumis,secinfos['Lumis']):
                             infos['Parents'].append(secfilename)
+                
                 self.logger.info("Done matching files from secondary dataset")
                 kwargs['task']['tm_use_parent'] = 1
         except Exception as ex:

--- a/src/python/TaskWorker/Actions/DBSDataDiscovery.py
+++ b/src/python/TaskWorker/Actions/DBSDataDiscovery.py
@@ -105,7 +105,7 @@ class DBSDataDiscovery(DataDiscovery):
         }
         """
         common_runs = d1.keys() & d2.keys()
-        if len(common_runs)	== 0: return False
+        if len(common_runs) == 0: return False
 
         for run in common_runs:
             common_lumis = set(d1[run]).intersection(set(d2[run]))


### PR DESCRIPTION
After a bit of discussion with @belforte , this is some untested code that shoudl considerably reduce the time spent in checking for overlapping lumis when looking for secondary files.