### PR TITLE
Deal with failed migrations 8244

### DIFF
--- a/src/python/Publisher/PublisherDbsUtils.py
+++ b/src/python/Publisher/PublisherDbsUtils.py
@@ -101,6 +101,147 @@ def setupDbsAPIs(sourceURL=None, publishURL=None, DBSHost=None, logger=None):
     return DBSApis
 
 
+def findParentBlocks(listOfFileDicts=None, DBSApis=None, logger=None, verbose=None):
+    """ find parent blocks for a list of files"""
+
+    # Set of all the parent files from all the files requested to be published.
+    parentFiles = set()
+    # Set of parent files for which the migration to the destination DBS instance
+    # should be skipped (because they were not found in DBS).
+    parentsToSkip = set()
+    # Set of parent files to migrate from the source DBS instance
+    # to the destination DBS instance.
+    localParentBlocks = set()
+    # Set of parent files to migrate from the global DBS instance
+    # to the destination DBS instance.
+    globalParentBlocks = set()
+
+    for file in listOfFileDicts:  # pylint: disable=too-many-nested-blocks
+        if verbose:
+            logger.info(file)
+        # Get the parent files and for each parent file do the following:
+        # 1) Add it to the list of parent files.
+        # 2) Find the block to which it belongs and insert that block name in
+        #    (one of) the set of blocks to be migrated to the destination DBS.
+        for parentFile in list(file['parents']):
+            if parentFile not in parentFiles:
+                parentFiles.add(parentFile)
+                # Is this parent file already in the destination DBS instance?
+                # (If yes, then we don't have to migrate this block.)
+                # some parent files are illegal DBS names (GH issue #6771), skip them
+                try:
+                    blocksDict = DBSApis['destRead'].listBlocks(logical_file_name=parentFile)
+                except Exception:
+                    file['parents'].remove(parentFile)
+                    continue
+                if not blocksDict:
+                    # No, this parent file is not in the destination DBS instance.
+                    # Maybe it is in the same DBS instance as the input dataset?
+                    blocksDict = DBSApis['source'].listBlocks(logical_file_name=parentFile)
+                    if blocksDict:
+                        # Yes, this parent file is in the same DBS instance as the input dataset.
+                        # Add the corresponding block to the set of blocks from the source DBS
+                        # instance that have to be migrated to the destination DBS.
+                        localParentBlocks.add(blocksDict[0]['block_name'])
+                    else:
+                        # No, this parent file is not in the same DBS instance as input dataset.
+                        # Maybe it is in global DBS instance?
+                        blocksDict = DBSApis['global'].listBlocks(logical_file_name=parentFile)
+                        if blocksDict:
+                            # Yes, this parent file is in global DBS instance.
+                            # Add the corresponding block to the set of blocks from global DBS
+                            # instance that have to be migrated to the destination DBS.
+                            globalParentBlocks.add(blocksDict[0]['block_name'])
+                # If this parent file is not in the destination DBS instance, is not
+                # the source DBS instance, and is not in global DBS instance, then it
+                # means it is not known to DBS and therefore we can not migrate it.
+                # Put it in the set of parent files for which migration should be skipped.
+                if not blocksDict:
+                    parentsToSkip.add(parentFile)
+            # If this parent file should not be migrated because it is not known to DBS,
+            # we remove it from the list of parents in the file-to-publish info dictionary
+            # (so that when publishing, this "parent" file will not appear as a parent).
+            if parentFile in parentsToSkip:
+                msg = f"Skipping parent file {parentFile}, as it doesn't seem to be known to DBS."
+                logger.info(msg)
+                if parentFile in file['parents']:
+                    file['parents'].remove(parentFile)
+    return (localParentBlocks, globalParentBlocks)
+
+def prepareDbsPublishingConfigs(blockDict=None, aFile=None, inputDataset=None, outputDataset=None,
+                                DBSApis=None, logger=None):
+    """
+    Fills the DBSConfigs dictionary with the various configs needed to publish one block
+    Needs a few parameters from the a sample block to be published
+    DBSConfigs = {'primds_config', 'dataset_config', 'output_config',
+              'processing_era_config', 'acquisition_era_config'}
+    """
+    # to unify with TaskPublish (no Rucio) need as arguments, in place of blockDict
+    # a sample file dictionary (aFile)
+
+    if blockDict:
+        aFile = blockDict['files'][0]
+    psetHash = aFile['publishname'].split("-")[-1]
+    releaseVersion = aFile['swversion']
+
+    noInput = len(inputDataset.split("/")) <= 3
+    if not noInput:
+        existing_datasets = DBSApis['source'].listDatasets(dataset=inputDataset, detail=True, dataset_access_type='*')
+        primary_ds_type = existing_datasets[0]['primary_ds_type']
+        acquisitionEra = existing_datasets[0]['acquisition_era_name']
+        existing_output = DBSApis['destRead'].listOutputConfigs(dataset=inputDataset)
+        if not existing_output:
+            msg = f"Unable to list output config for input dataset {inputDataset}"
+            logger.error(msg)
+            globalTag = 'crab3_tag'
+        else:
+            globalTag = existing_output[0]['global_tag']
+    else:
+        msg = "This publication appears to be for private MC."
+        logger.info(msg)
+        primary_ds_type = 'mc'
+        acquisitionEra = 'CRAB'
+        globalTag = 'crab3_tag'
+
+    appName = 'cmsRun'
+    if not globalTag or globalTag == 'null' or globalTag == 'None':
+        globalTag = 'crab3_tag'
+    if not acquisitionEra or acquisitionEra == 'null' or acquisitionEra == 'None':
+        acquisitionEra = 'CRAB'
+
+    _, primName, procName, tier = outputDataset.split('/')
+    primds_config = {'primary_ds_name': primName, 'primary_ds_type': primary_ds_type}
+
+    acquisition_era_config = {'acquisition_era_name': acquisitionEra, 'start_date': 0}
+
+    processing_era_config = {'processing_version': 1, 'description': 'CRAB3_processing_era'}
+
+    output_config = {'release_version': releaseVersion,
+                     'pset_hash': psetHash,
+                     'app_name': appName,
+                     'output_module_label': 'o',
+                     'global_tag': globalTag,
+                     }
+
+    dataset_config = {'dataset': outputDataset,
+                      'processed_ds_name': procName,
+                      'data_tier_name': tier,
+                      'dataset_access_type': 'VALID',
+                      'physics_group_name': 'CRAB3',
+                      'last_modification_date': int(time.time()),
+                      }
+
+    logger.info("Output dataset config: %s", str(dataset_config))
+
+    DBSConfigs = {}
+    DBSConfigs['primds_config'] = primds_config
+    DBSConfigs['dataset_config'] = dataset_config
+    DBSConfigs['output_config'] = output_config
+    DBSConfigs['processing_era_config'] = processing_era_config
+    DBSConfigs['acquisition_era_config'] = acquisition_era_config
+
+    return DBSConfigs
+
 def createBulkBlock(output_config, processing_era_config, primds_config,
                     dataset_config, acquisition_era_config, block_config, files):
     """

--- a/src/python/Publisher/PublisherDbsUtils.py
+++ b/src/python/Publisher/PublisherDbsUtils.py
@@ -168,6 +168,7 @@ def findParentBlocks(listOfFileDicts=None, DBSApis=None, logger=None, verbose=No
                     file['parents'].remove(parentFile)
     return (localParentBlocks, globalParentBlocks)
 
+
 def prepareDbsPublishingConfigs(blockDict=None, aFile=None, inputDataset=None, outputDataset=None,
                                 DBSApis=None, logger=None):
     """
@@ -241,6 +242,7 @@ def prepareDbsPublishingConfigs(blockDict=None, aFile=None, inputDataset=None, o
     DBSConfigs['acquisition_era_config'] = acquisition_era_config
 
     return DBSConfigs
+
 
 def createBulkBlock(output_config, processing_era_config, primds_config,
                     dataset_config, acquisition_era_config, block_config, files):

--- a/src/python/Publisher/PublisherMasterRucio.py
+++ b/src/python/Publisher/PublisherMasterRucio.py
@@ -487,13 +487,12 @@ class Master():  # pylint: disable=too-many-instance-attributes
                         if fileInTDB['destination_lfn'] == fmd['lfn']:
                             metadataFound = True
                             toPublish.append(fmd['lfn'])
-                            for key in ['inevents', 'filetype', 'publishname', 'lfn', 'jobid',
+                            for key in ['inevents', 'filetype', 'publishname', 'lfn', 'jobid', 'swversion',
                                         'runlumi', 'adler32', 'cksum', 'filesize', 'parents', 'state', 'created']:
                                 fileDict[key] = fmd[key]
                             # following three vars. only need to be saved once, they are the same for all FMD
                             # but let's stay simple even if a bit redundant
                             acquisitionEra = fmd['acquisitionera']
-                            releaseVersion = fmd['swversion']
                             globalTag = fmd['globaltag']
                             break
                     if not metadataFound:
@@ -502,7 +501,6 @@ class Master():  # pylint: disable=too-many-instance-attributes
                     filesInfo.append(fileDict)
                 blockDict['files'] = filesInfo
                 blockDict['acquisition_era_name'] = acquisitionEra
-                blockDict['release_version'] = releaseVersion
                 blockDict['global_tag'] = globalTag
                 blockDictsToPublish.append(blockDict)
 

--- a/src/python/Publisher/PublisherMasterRucio.py
+++ b/src/python/Publisher/PublisherMasterRucio.py
@@ -528,7 +528,7 @@ class Master():  # pylint: disable=too-many-instance-attributes
 
     def markAsFailed(self, lfns=None, reason=None):
         """
-        could this be replaced by PublisherUtils/mark_failed ?
+        could this be replaced by PublisherUtils/markFailed ?
         """
         nMarked = 0
         for lfn in lfns:

--- a/src/python/Publisher/PublisherUtils.py
+++ b/src/python/Publisher/PublisherUtils.py
@@ -28,9 +28,10 @@ def createLogdir(dirname):
 
 
 def setupLogging(config, taskname, verbose, console):
-    # prepare log and work directories for TaskPublish
-    # an initialize a logger
-    # returs a dictionary log={logger, logdir, migrationlLogDir, taskFilesDir}
+    """
+    prepare log and work directories for TaskPublish and initializes a logger
+    returs a dictionary log={logger, logdir, migrationlLogDir, taskFilesDir}
+    """
     log = {}
     taskFilesDir = config.General.taskFilesDir
     username = taskname.split(':')[1].split('_')[0]
@@ -58,7 +59,7 @@ def setupLogging(config, taskname, verbose, console):
 
 
 def prepareDummySummary(taskname):
-    # prepare a dummy summary JSON file in case there's nothing to do
+    """ prepare a dummy summary JSON file in case there's nothing to do """
     nothingToDo = {}
     nothingToDo['taskname'] = taskname
     nothingToDo['result'] = 'OK'
@@ -90,7 +91,7 @@ def saveSummaryJson(summary=None, logdir=None):
     return summaryFileName
 
 
-def mark_good(files=None, crabServer=None, asoworker=None, logger=None):
+def markGood(files=None, crabServer=None, asoworker=None, logger=None):
     """
     Mark the list of files as published
     files must be a list of SOURCE_LFN's i.e. /store/temp/user/...
@@ -101,8 +102,8 @@ def mark_good(files=None, crabServer=None, asoworker=None, logger=None):
 
     nMarked = 0
     for lfn in files:
-        source_lfn = lfn
-        docId = getHashLfn(source_lfn)
+        sourceLfn = lfn
+        docId = getHashLfn(sourceLfn)
         data = {}
         data['asoworker'] = asoworker
         data['subresource'] = 'updatePublication'
@@ -113,18 +114,19 @@ def mark_good(files=None, crabServer=None, asoworker=None, logger=None):
 
         try:
             result = crabServer.post(api='filetransfers', data=encodeRequest(data))
-            logger.debug("updated DocumentId: %s lfn: %s Result %s", docId, source_lfn, result)
-        except Exception as ex:
-            logger.error("Error updating status for DocumentId: %s lfn: %s", docId, source_lfn)
+            logger.debug("updated DocumentId: %s lfn: %s Result %s", docId, sourceLfn, result)
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.error("Error updating status for DocumentId: %s lfn: %s", docId, sourceLfn)
             logger.error("Error reason: %s", ex)
             logger.error("Error reason: %s", ex)
 
         nMarked += 1
         if nMarked % 10 == 0:
             logger.info('marked %d files', nMarked)
+        logger.info('total of %s files, marked as Good', nMarked)
 
 
-def mark_failed(files=None, crabServer=None, failure_reason="", asoworker=None, logger=None):
+def markFailed(files=None, crabServer=None, failureReason="", asoworker=None, logger=None):
     """
     Something failed for these files.
     files must be a list of SOURCE_LFN's i.e. /store/temp/user/...
@@ -134,36 +136,40 @@ def mark_failed(files=None, crabServer=None, failure_reason="", asoworker=None, 
 
     nMarked = 0
     for lfn in files:
-        source_lfn = lfn
-        docId = getHashLfn(source_lfn)
+        sourceLfn = lfn
+        docId = getHashLfn(sourceLfn)
         data = {}
         data['asoworker'] = asoworker
         data['subresource'] = 'updatePublication'
         data['list_of_ids'] = [docId]
         data['list_of_publication_state'] = ['FAILED']
         data['list_of_retry_value'] = [1]
-        data['list_of_failure_reason'] = [failure_reason]
+        data['list_of_failure_reason'] = [failureReason]
 
         logger.debug("data: %s ", data)
         try:
             result = crabServer.post(api='filetransfers', data=encodeRequest(data))
-            logger.debug("updated DocumentId: %s lfn: %s Result %s", docId, source_lfn, result)
-        except Exception as ex:
-            logger.error("Error updating status for DocumentId: %s lfn: %s", docId, source_lfn)
+            logger.debug("updated DocumentId: %s lfn: %s Result %s", docId, sourceLfn, result)
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.error("Error updating status for DocumentId: %s lfn: %s", docId, sourceLfn)
             logger.error("Error reason: %s", ex)
 
         nMarked += 1
         if nMarked % 10 == 0:
             logger.info('marked %d files', nMarked)
+        logger.info('total of %s files, marked as Failed', nMarked)
 
 
 def getDBSInputInformation(taskname=None, crabServer=None):
-    # LOOK UP Input dataset info in CRAB DB task table
-    # for this task to know which DBS istance it was in
+    """
+    LOOK UP Input dataset info in CRAB DB task table
+    for this task to know which DBS istance it was in
+    """
+
     data = {'subresource': 'search',
             'workflow': taskname}
     results = crabServer.get(api='task', data=encodeRequest(data))
-    # TODO THERE are better ways to parse rest output into a dict !!
+    # NOTICE: There are better ways to parse rest output into a dict !!
     inputDatasetIndex = results[0]['desc']['columns'].index("tm_input_dataset")
     inputDataset = results[0]['result'][inputDatasetIndex]
     # in case input was a Rucio container, remove the scope if any

--- a/src/python/Publisher/PublisherUtils.py
+++ b/src/python/Publisher/PublisherUtils.py
@@ -72,7 +72,7 @@ def prepareDummySummary(taskname):
     return nothingToDo
 
 
-def saveSummaryJson(summary, logdir):
+def saveSummaryJson(summary=None, logdir=None):
     """
     Save a publication summary as JSON. Make a new file every time this script runs
     :param summary: a summary disctionary. Must at least have key 'taskname'

--- a/src/python/Publisher/TaskPublish.py
+++ b/src/python/Publisher/TaskPublish.py
@@ -195,7 +195,7 @@ def publishInDBS3(config, taskname, verbose, console):
         else:
             try:
                 statusCode, failureMsg = migrateByBlockDBS3(taskname, migrateApi, destReadApi, sourceApi,
-                                                            inputDataset, localParentBlocks, migrationLogDir,
+                                                            localParentBlocks, migrationLogDir,
                                                             logger=logger, verbose=verbose)
             except CannotMigrateException as ex:
                 # there is nothing we can do in this case
@@ -229,8 +229,8 @@ def publishInDBS3(config, taskname, verbose, console):
         else:
             try:
                 statusCode, failureMsg = migrateByBlockDBS3(taskname, migrateApi, destReadApi, globalApi,
-                                                            inputDataset, globalParentBlocks, migrationLogDir,
-                                                            verbose)
+                                                            globalParentBlocks, migrationLogDir,
+                                                            logger=logger, verbose=verbose)
             except Exception as ex:
                 logger.exception('Exception raised inside migrateByBlockDBS3\n%s', ex)
                 statusCode = 1

--- a/src/python/Publisher/TaskPublish.py
+++ b/src/python/Publisher/TaskPublish.py
@@ -8,467 +8,48 @@ from __future__ import print_function
 import os
 import uuid
 import time
-from datetime import datetime
-import logging
-import sys
 import json
 import traceback
 import argparse
 import pprint
 
-from dbs.apis.dbsClient import DbsApi
-from dbs.exceptions.dbsClientException import dbsClientException
-from RestClient.ErrorHandling.RestClientExceptions import HTTPError
-from ServerUtilities import getHashLfn, encodeRequest
-from ServerUtilities import SERVICE_INSTANCES
-from TaskWorker.WorkerExceptions import ConfigException, CannotMigrateException
-from RESTInteractions import CRABRest
 from WMCore.Configuration import loadConfigurationFile
 
+from TaskWorker.WorkerExceptions import CannotMigrateException
+from TaskWorker.WorkerUtilities import getCrabserver
 
-def format_file_3(file_):
-    """
-    format file for DBS
-    """
-    nf = {'logical_file_name': file_['lfn'],
-          'file_type': 'EDM',
-          'check_sum': str(file_['cksum']),  # historically CRAB FILEMTETADATADB has the wrong type (int)
-          'event_count': file_['inevents'],
-          'file_size': file_['filesize'],
-          'adler32': file_['adler32'],
-          'file_parent_list': [{'file_parent_lfn': i} for i in set(file_['parents'])],
-         }
-    file_lumi_list = []
-    for run, lumis in file_['runlumi'].items():
-        for lumi in lumis:
-            file_lumi_list.append({'lumi_section_num': int(lumi), 'run_num': int(run)})
-    nf['file_lumi_list'] = file_lumi_list
-    if file_.get("md5") != "asda" and file_.get("md5") != "NOTSET": # asda is the silly value that MD5 defaults to
-        nf['md5'] = file_['md5']
-    return nf
+from PublisherUtils import setupLogging, prepareDummySummary, saveSummaryJson, \
+    mark_good, mark_failed, getDBSInputInformation
 
+from PublisherDbsUtils import format_file_3, setupDbsAPIs, findParentBlocks, \
+    createBulkBlock, migrateByBlockDBS3, prepareDbsPublishingConfigs
 
-def createBulkBlock(output_config, processing_era_config, primds_config, \
-                    dataset_config, acquisition_era_config, block_config, files):
-    """
-    manage blocks
-    """
-    file_conf_list = []
-    file_parent_list = []
-    for file_ in files:
-        file_conf = output_config.copy()
-        file_conf_list.append(file_conf)
-        file_conf['lfn'] = file_['logical_file_name']
-        for parent_lfn in file_.get('file_parent_list', []):
-            file_parent_list.append({'logical_file_name': file_['logical_file_name'],
-                                     'parent_logical_file_name': parent_lfn['file_parent_lfn']})
-        del file_['file_parent_list']
-    blockDump = {
-        'dataset_conf_list': [output_config],
-        'file_conf_list': file_conf_list,
-        'files': files,
-        'processing_era': processing_era_config,
-        'primds': primds_config,
-        'dataset': dataset_config,
-        'acquisition_era': acquisition_era_config,
-        'block': block_config,
-        'file_parent_list': file_parent_list
-    }
-    blockDump['block']['file_count'] = len(files)
-    blockDump['block']['block_size'] = sum([int(file_['file_size']) for file_ in files])
-    return blockDump
-
-
-def migrateByBlockDBS3(taskname, migrateApi, destReadApi, sourceApi, dataset, blocks, migLogDir, verbose=False):
-    """
-    Submit one migration request for each block that needs to be migrated.
-    If blocks argument is not specified, migrate the whole dataset.
-    Returns a 2-element ntuple : (exitcode, message)
-    exit codes:  0 OK, 1 taking too long, 2 failure
-    """
-    #wfnamemsg = "%s: " % taskname
-    logger = logging.getLogger(taskname)
-    logging.basicConfig(filename=taskname+'.log', level=logging.INFO)
-
-    if blocks:
-        blocksToMigrate = set(blocks)
-    else:
-        # migration of a full dataset is better accomplished with a separate method
-        raise NotImplementedError
-
-    numBlocksToMigrate = len(blocksToMigrate)
-    if numBlocksToMigrate == 0:
-        msg = "No migration needed."
-        logger.info(msg)
-        return 0, ""
-    msg = "Have to migrate %d blocks from %s to %s." % (numBlocksToMigrate, sourceApi.url, destReadApi.url)
-    logger.info(msg)
-    if verbose:
-        msg = "List of blocks to migrate:\n%s." % (", ".join(blocksToMigrate))
-        logger.debug(msg)
-    msg = "Submitting %d block migration requests to DBS3 ..." % (numBlocksToMigrate)
-    logger.info(msg)
-    numFailedSubmissions = 0
-    migrationsInProgress = []
-    for block in list(blocksToMigrate):
-        # Submit migration request for this block.
-        ok = requestBlockMigration(taskname, migrateApi, sourceApi, block, migLogDir)
-        if ok:
-            migrationsInProgress.append(block)
-        else:
-            numFailedSubmissions += 1
-
-    numMigrationsInProgress = len(migrationsInProgress)
-    msg = "%d block migration requests successfully submitted." % numMigrationsInProgress
-    if numFailedSubmissions:
-        msg = "%d block migration requests failed to be submitted." % numFailedSubmissions
-    logger.info(msg)
-    if not migrationsInProgress:
-        return 2, "Migration of %s failed." % (dataset)
-
-    # Wait for up to 300 seconds, then return to the main loop. Note that we
-    # don't fail or cancel any migration request, but just retry it next time.
-    # In the case of failure, we expect the publisher daemon to try again in
-    # the future.
-    numFailedMigrations = 0
-    numSuccessfulMigrations = 0
-    waitTime = 30
-    numTimes = 10
-    msg = "Will monitor their status for up to %d seconds." % (waitTime * numTimes)
-    logger.info(msg)
-    for _ in range(numTimes):
-        msg = "%d block migrations in progress." % numMigrationsInProgress
-        msg += " Will check migrations status in %d seconds." % waitTime
-        logger.info(msg)
-        time.sleep(waitTime)
-        # Check the migration status of each block migration request.
-        # If a block migration has succeeded or terminally failes, remove the
-        # migration request id from the list of migration requests in progress.
-        for block in migrationsInProgress.copy():  # make a copy to allow manipulating original list
-            try:
-                inProgress, atDestination, failed = checkBlockMigration(taskname, migrateApi, block, migLogDir)
-            except Exception as ex:
-                msg = "Could not get migration status for %s:\n%s" % (block, ex)
-                logger.error(msg)
-                continue  # will check status next time
-            if atDestination:
-                logger.info('Migration completed for %s', block)
-                migrationsInProgress.remove(block)
-                numSuccessfulMigrations += 1
-            if failed:
-                logger.error('Migration failed for %s', block)
-                migrationsInProgress.remove(block)
-                numFailedMigrations += 1
-            if inProgress:
-                pass  # will check again later
-        numMigrationsInProgress = len(migrationsInProgress)  # update counter at the end of loop
-        # Stop waiting if there are no more migrations in progress.
-        if numMigrationsInProgress == 0:
-            break
-    # If after the 300 seconds there are still some migrations in progress, return
-    # with status 1.
-    if numMigrationsInProgress > 0:
-        msg = "Migration of %s is taking too long - will delay the publication." % dataset
-        logger.info(msg)
-        return 1, "Migration of %s is taking too long." % (dataset)
-    msg = "Migration of %s has finished." % dataset
-    logger.info(msg)
-    msg = "Migration status summary (from %d input blocks to migrate):" % numBlocksToMigrate
-    msg += " succeeded = %d," % numSuccessfulMigrations
-    msg += " failed = %d," % numFailedMigrations
-    msg += " submission failed = %d," % numFailedSubmissions
-    logger.info(msg)
-    # If there were failed migrations, return with status 2.
-    if numFailedMigrations > 0 or numFailedSubmissions > 0:
-        msg = "Some blocks failed to be migrated."
-        logger.info(msg)
-        return 2, "Migration of %s failed." % (dataset)
-    msg = "Migration completed. Wait 5sec before verifying that migrated datesed is OK in destination DBS"
-    logger.info(msg)
-    time.sleep(5.0)
-    migratedDataset = None
-    try:
-        migratedDataset = destReadApi.listDatasets(dataset=dataset, detail=True, dataset_access_type='*')
-        if not migratedDataset or migratedDataset[0].get('dataset', None) != dataset:
-            return 4, "Migration of %s in some inconsistent status." % dataset
-    except Exception as ex:
-        logger.exception("Migration check failed.")
-        if migratedDataset:
-            logger.error("listDatasets returned %s", migratedDataset)
-        return 4, "Migration check failed. %s" % ex
-    return 0, ""
-
-
-def requestBlockMigration(taskname, migrateApi, sourceApi, block, migLogDir):
-    """
-    Submit migration request for one block, checking the request output.
-    returns False if request could not be submitted, True otherwise
-    migration status will have to be checked later using block name as key.
-    If something went wrong, migration will have to be retried later
-    """
-
-    logger = logging.getLogger(taskname)
-    #    logging.basicConfig(filename=taskname+'.log', level=logging.INFO, format=config.General.logMsgFormat)
-
-    msg = "Submiting migration request for block %s ..." % block
-    logger.info(msg)
-    sourceURL = sourceApi.url
-    data = {'migration_url': sourceURL, 'migration_input': block}
-    result = None
-    try:
-        result = migrateApi.submitMigration(data)
-        # N.B. a migration request is supposed never to fail. Only failure to contact server should
-        # result in HTTP or curl error/exceptions. Otherwise server will always return a list of dicionaries.
-        # But there are cases where server replies with HTTP code other than 200 (e.g. 400 if migration
-        # request is invalid), in those caes client raises exception which should be handled with proper care
-    except dbsClientException as dbsEx:
-        logger.error("HTTP call to server %s failed: %s", migrateApi.url, dbsEx)
-        return False
-    except HTTPError as httpErr:
-        # this is a structured message from migrate server as per
-        #  https://github.com/dmwm/dbs2go/blob/master/docs/DBSServer.md#dbs-errors
-        # http call went through, simply server returned an HTTP code other than 200
-        code = httpErr.code
-        body = json.loads(httpErr.body)
-        reason = body[0]['error']['reason']
-        if code >= 500:
-            # something bad happened inside server
-            logger.error("HTTP error %d with msg %s", code, reason)
-            return False
-        if code == 400:
-            # beware "not allowed for migration" error which is persistent
-            msg = "Migration request refused by server."
-            logger.error(msg)
-            # if we simply report flase, Publisher will try and fail again, forever
-            # some reasons for this are known
-            if 'has status PRODUCTION' in reason:
-                msg = 'Input dataset has status PRODUCTION'
-            raise CannotMigrateException(msg) from httpErr
-
-        if code > 400:
-            # in this cases it is better to treat the migration request submission as successful
-            # and go on with status checking via checkBlockMigration where various status codes
-            # are properly handled
-            logger.error("HTTP error %d", code)
-            logger.error("A new migration request could not be submitted. Reason: %s", reason)
-            return True
-        else:
-            logger.error("Unexpected HTTP error %d", code)
-            return False
-    except CannotMigrateException :
-        raise
-    except Exception as ex:
-        msg = "Request to migrate %s failed." % block
-        msg += "\nRequest detail: %s" % data
-        msg += "\nDBS3 exception: %s" % ex
-        logger.error(msg)
-        return False
-    # if HTTP call succeeded a migration request was sent for this block and all its ancestors
-    logger.info('Migration request submitted. %d blocks will be migrated', len(result))
-    return True
-
-def checkBlockMigration(taskname, migrateApi, block, migLogDir):
-    """
-    returns a 3plet of booleans: (inProgress, atDestination, failed)
-    WHen something goes wrong, reports all false
-    """
-    logger = logging.getLogger(taskname)
-    # check status using block name
-
-    atDestination = False
-    failed = True
-    inProgress = False
-    try:
-        result = migrateApi.statusMigration(block_name=block)
-    except Exception as ex:
-        msg = "Migration status query for block %s failed" % block
-        msg += "\nDBS3 exception: %s" % ex
-        logger.error(msg)
-        failed = True
-        return inProgress, atDestination, failed
-
-    if result:
-        status = result[0].get('migration_status')
-        reqid = result[0].get('migration_request_id')
-    else:
-        # result can be [] if there's no migration for this block in the DB
-        failed = True  # handle like failed, will be retried in next Publisher iteration
-        return inProgress, atDestination, failed
-    if status is None or reqid is None:
-        msg = "Migration request failed to submit."
-        msg += "\nMigration request results: %s" % str(result)
-        logger.error(msg)
-    # reference https://github.com/dmwm/dbs2go/blob/master/docs/MigrationServer.md
-    # Migration states:
-    #   0 = PENDING
-    #   1 = IN PROGRESS
-    #   2 = SUCCESS
-    #   3 = FAILED (failed migrations are retried up to 3 times automatically)
-    #   4 = NOT ACCEPTED (block is already at destination)
-    #   5 = QUEUED (migration server needs to compute list of ancestors to migrate)
-    #   9 = Terminally FAILED
-    inProgress = status in (0, 1, 5)
-    atDestination = status in (2, 4)
-    beingRetried = (status == 3)
-    failed = (status == 9)
-    if beingRetried:  # sanity check
-        nRetries = result[0]['retry_count']
-        if nRetries > 10:
-            logger.error("too many (%d) retries. Treat as terminally failed", nRetries)
-            failed = True
-            return inProgress, atDestination, failed
-    if failed:
-        logger.error("migration terminally failed for %s\n", block)
-        logger.error("migration status details:\n%s", result)
-        failedMigrationsLog = os.path.join(migLogDir, 'TerminallyFailedLog.txt')
-        logger.debug("Migration terminally failed, log to %s", failedMigrationsLog)
-        creationDate = result[0]['creation_date']
-        # convert to human format
-        migCreation = datetime.fromtimestamp(creationDate).strftime('%Y-%m-%d,%H:%M:%S')
-        # FiledMigFile format is CSV: reqid,creationDate, block, taskname
-        with open(failedMigrationsLog, 'a', encoding='utf8') as fp:
-            line = "%d,%s,%s,%s\n" % (reqid, migCreation, block, taskname)
-            fp.write(line)
-        return inProgress, atDestination, failed
-    # all OK, we got a usable status information
-    return inProgress, atDestination, failed
-
-
-def publishInDBS3(config, taskname, verbose):
+def publishInDBS3(config, taskname, verbose, console):
     """
     Publish output from one task in DBS
     """
+    # a few dictionaries to pass global information around all these functions
+    # initialized here to None simply as documentation
+    log = {'logger': None, 'logdir': None, 'logTaskDir': None, 'taskFilesDir': None}
+    DBSApis = {'source': None, 'destRead': None, 'destWrite': None, 'global': None, 'migrate': None}
+    nothingToDo = {}  # a pre-filled SummaryFile in case of no useful input or errors
 
-    def mark_good(files, crabServer, logger):
-        """
-        Mark the list of files as published
-        files must be a list of SOURCE_LFN's i.e. /store/temp/user/...
-        """
+    log = setupLogging(config, taskname, verbose, console)
+    logger = log['logger']
+    logdir = log['logdir']
+    migrationLogDir = log['migrationLogDir']
+    taskFilesDir = log['taskFilesDir']
 
-        msg = "Marking %s file(s) as published." % len(files)
-        logger.info(msg)
-        if dryRun:
-            logger.info("DryRun: skip marking good file")
-            return
-
-        nMarked = 0
-        for lfn in files:
-            data = {}
-            source_lfn = lfn
-            docId = getHashLfn(source_lfn)
-            data['asoworker'] = config.General.asoworker
-            data['subresource'] = 'updatePublication'
-            data['list_of_ids'] = [docId]
-            data['list_of_publication_state'] = ['DONE']
-            data['list_of_retry_value'] = [1]
-            data['list_of_failure_reason'] = ['']
-
-            try:
-                result = crabServer.post(api='filetransfers', data=encodeRequest(data))
-                logger.debug("updated DocumentId: %s lfn: %s Result %s", docId, source_lfn, result)
-            except Exception as ex:
-                logger.error("Error updating status for DocumentId: %s lfn: %s", docId, source_lfn)
-                logger.error("Error reason: %s", ex)
-                logger.error("Error reason: %s", ex)
-
-            nMarked += 1
-            if nMarked % 10 == 0:
-                logger.info('marked %d files', nMarked)
-
-
-    def mark_failed(files, crabServer, logger, failure_reason=""):
-        """
-        Something failed for these files.
-        files must be a list of SOURCE_LFN's i.e. /store/temp/user/...
-        """
-
-        msg = "Marking %s file(s) as failed" % len(files)
-        logger.info(msg)
-        if dryRun:
-            logger.debug("DryRun: skip marking failed files")
-            return
-
-        nMarked = 0
-        for lfn in files:
-            source_lfn = lfn
-            docId = getHashLfn(source_lfn)
-            data = {}
-            data['asoworker'] = config.General.asoworker
-            data['subresource'] = 'updatePublication'
-            data['list_of_ids'] = [docId]
-            data['list_of_publication_state'] = ['FAILED']
-            data['list_of_retry_value'] = [1]
-            data['list_of_failure_reason'] = [failure_reason]
-
-            logger.debug("data: %s ", data)
-            try:
-                result = crabServer.post(api='filetransfers', data=encodeRequest(data))
-                logger.debug("updated DocumentId: %s lfn: %s Result %s", docId, source_lfn, result)
-            except Exception as ex:
-                logger.error("Error updating status for DocumentId: %s lfn: %s", docId, source_lfn)
-                logger.error("Error reason: %s", ex)
-
-            nMarked += 1
-            if nMarked % 10 == 0:
-                logger.info('marked %d files', nMarked)
-
-
-    def createLogdir(dirname):
-        """
-        Create the directory dirname ignoring errors in case it exists. Exit if
-        the directory cannot be created.
-        """
-        try:
-            os.mkdir(dirname)
-        except OSError as ose:
-            if ose.errno != 17: #ignore the "Directory already exists error"
-                print(str(ose))
-                print("The task worker need to access the '%s' directory" % dirname)
-                sys.exit(1)
-
-    def saveSummaryJson(logdir, summary):
-        """
-        Save a publication summary as JSON. Make a new file every time this script runs
-        :param summary: a summary disctionary. Must at least have key 'taskname'
-        :param logdir: the directory where to write the summary
-        :return: the full path name of the written file
-        """
-        taskname = summary['taskname']
-        counter = 1
-        summaryFileName = os.path.join(logdir, taskname + '-1.json')
-        while os.path.exists(summaryFileName):
-            counter += 1
-            summaryFileName = os.path.join(logdir, taskname + '-%d.json' % counter)
-        with open(summaryFileName, 'w', encoding='utf8') as fd:
-            json.dump(summary, fd)
-        return summaryFileName
-
-    taskFilesDir = config.General.taskFilesDir
     dryRun = config.TaskPublisher.dryRun
-    username = taskname.split(':')[1].split('_')[0]
-    logdir = os.path.join(config.General.logsDir, 'tasks', username)
-    logfile = os.path.join(logdir, taskname + '.log')
-    createLogdir(logdir)
-    migrationLogDir = os.path.join(config.General.logsDir, 'migrations')
-    createLogdir(migrationLogDir)
-    logger = logging.getLogger(taskname)
-    logging.basicConfig(filename=logfile, level=logging.INFO, format=config.TaskPublisher.logMsgFormat)
-    if verbose:
-        logger.setLevel(logging.DEBUG)
-
     logger.info("Start new iteration on taskname:  %s\nGet files to publish", taskname)
 
-    # prepare a dummy summary JSON file in case there's nothing to do
-    nothingToDo = {}
-    nothingToDo['taskname'] = taskname
-    nothingToDo['result'] = 'OK'
-    nothingToDo['reason'] = 'NOTHING TO DO'
-    nothingToDo['publishedBlocks'] = 0
-    nothingToDo['failedBlocks'] = 0
-    nothingToDo['failedBlockDumps'] = []
-    nothingToDo['publishedFiles'] = 0
-    nothingToDo['failedFiles'] = 0
-    nothingToDo['nextIterFiles'] = 0
+
+    # DBS client relies on X509 env. vars
+    os.environ['X509_USER_CERT'] = config.TaskPublisher.cert
+    os.environ['X509_USER_KEY'] = config.TaskPublisher.key
+
+    # preapre an empy summary to be used in case of errors
+    nothingToDo = prepareDummySummary(taskname)
 
     toPublish = []
     # TODO move from new to done when processed
@@ -478,7 +59,7 @@ def publishInDBS3(config, taskname, verbose):
 
     if not toPublish:
         logger.info("Empty data file %s", fname)
-        summaryFileName = saveSummaryJson(logdir, nothingToDo)
+        summaryFileName = saveSummaryJson(nothingToDo, logdir)
         return summaryFileName
 
     pnn = toPublish[0]["Destination"]
@@ -486,183 +67,39 @@ def publishInDBS3(config, taskname, verbose):
     logger.info("Will publish user files in %s", dataset)
 
     # CRABServer REST API's (see CRABInterface)
+    # initialize CRABServer REST
+    crabServer = getCrabserver(restConfig=config.REST, agentName='CRABPublisher', logger=logger)
+
+    # retrieve info on DBS from TaskDB table
     try:
-        instance = config.General.instance
+        (inputDataset, sourceURL, publishURL) = getDBSInputInformation(taskname, crabServer)
     except Exception as ex:
-        msg = "No instance provided: need to specify config.General.instance in the configuration"
-        raise ConfigException(msg) from ex
-
-    if instance in SERVICE_INSTANCES:
-        logger.info('Will connect to CRAB service: %s', instance)
-        restHost = SERVICE_INSTANCES[instance]['restHost']
-        dbInstance = SERVICE_INSTANCES[instance]['dbInstance']
-    else:
-        msg = "Invalid instance value '%s'" % instance
-        raise ConfigException(msg)
-    if instance == 'other':
-        logger.info('Will use restHost and dbInstance from config file')
-        try:
-            restHost = config.General.restHost
-            dbInstance = config.General.dbInstance
-        except Exception as ex:
-            msg = "Need to specify config.General.restHost and dbInstance in the configuration"
-            raise ConfigException(msg) from ex
-
-    restURInoAPI = '/crabserver/' + dbInstance
-    logger.info('Will connect to CRAB Data Base via URL: https://%s%s', restHost, restURInoAPI)
-
-    # CRAB REST API's
-    crabServer = CRABRest(hostname=restHost, localcert=config.General.serviceCert,
-                          localkey=config.General.serviceKey, retry=3,
-                          userAgent='CRABPublisher')
-    crabServer.setDbInstance(dbInstance=dbInstance)
-
-    data = {}
-    data['subresource'] = 'search'
-    data['workflow'] = taskname
-
-    try:
-        results = crabServer.get(api='task', data=encodeRequest(data))
-    except Exception as ex:
-        logger.error("Failed to get acquired publications from oracleDB: %s", ex)
+        logger.error("Failed to get task info oracleDB: %s", ex)
         nothingToDo['result'] = 'FAIL'
         nothingToDo['reason'] = 'Error contacting CRAB REST'
-        summaryFileName = saveSummaryJson(logdir, nothingToDo)
+        summaryFileName = saveSummaryJson(nothingToDo, log['logdir'])
         return summaryFileName
+    logger.info("inputDataset: %s", inputDataset)
 
-    if verbose:
-        logger.info(results[0]['desc']['columns'])
 
+    # prepare DBS API's
     try:
-        inputDatasetIndex = results[0]['desc']['columns'].index("tm_input_dataset")
-        inputDataset = results[0]['result'][inputDatasetIndex]
-        # in case input was a Rucio container, remove the scope if any
-        inputDataset = inputDataset.split(':')[-1]
-        sourceURLIndex = results[0]['desc']['columns'].index("tm_dbs_url")
-        sourceURL = results[0]['result'][sourceURLIndex]
-        publish_dbs_urlIndex = results[0]['desc']['columns'].index("tm_publish_dbs_url")
-        publish_dbs_url = results[0]['result'][publish_dbs_urlIndex]
-
-
-
-        if not sourceURL.endswith("/DBSReader") and not sourceURL.endswith("/DBSReader/"):
-            sourceURL += "/DBSReader"
+        DBSApis = setupDbsAPIs(sourceURL=sourceURL, publishURL=publishURL,
+                               DBSHost=config.TaskPublisher.DBShost, logger=logger)
     except Exception as ex:
-        logger.exception("ERROR: %s", ex)
-
-    # When looking up parents may need to look in global DBS as well.
-    globalURL = sourceURL
-    globalURL = globalURL.replace('phys01', 'global')
-    globalURL = globalURL.replace('phys02', 'global')
-    globalURL = globalURL.replace('phys03', 'global')
-    globalURL = globalURL.replace('caf', 'global')
-
-    # allow to use a DBS REST host different from cmsweb.cern.ch (which is the
-    # default inserted by CRAB Client)
-    sourceURL = sourceURL.replace('cmsweb.cern.ch', config.TaskPublisher.DBShost)
-    globalURL = globalURL.replace('cmsweb.cern.ch', config.TaskPublisher.DBShost)
-    publish_dbs_url = publish_dbs_url.replace('cmsweb.cern.ch', config.TaskPublisher.DBShost)
-
-    # DBS client relies on X509 env. vars
-    os.environ['X509_USER_CERT'] = config.General.serviceCert
-    os.environ['X509_USER_KEY'] = config.General.serviceKey
-
-    # create DBS API objects
-    logger.info("DBS Source API URL: %s", sourceURL)
-    sourceApi = DbsApi(url=sourceURL, debug=False)
-    logger.info("DBS Global API URL: %s", globalURL)
-    globalApi = DbsApi(url=globalURL, debug=False)
-
-    if publish_dbs_url.endswith('/DBSWriter'):
-        publish_read_url = publish_dbs_url[:-len('/DBSWriter')] + '/DBSReader'
-        publish_migrate_url = publish_dbs_url[:-len('/DBSWriter')] + '/DBSMigrate'
-    else:
-        publish_migrate_url = publish_dbs_url + '/DBSMigrate'
-        publish_read_url = publish_dbs_url + '/DBSReader'
-        publish_dbs_url += '/DBSWriter'
-    try:
-        logger.info("DBS Destination API URL: %s", publish_dbs_url)
-        destApi = DbsApi(url=publish_dbs_url, debug=False)
-        logger.info("DBS Destination read API URL: %s", publish_read_url)
-        destReadApi = DbsApi(url=publish_read_url, debug=False)
-        logger.info("DBS Migration API URL: %s", publish_migrate_url)
-        migrateApi = DbsApi(url=publish_migrate_url, debug=False)
-    except Exception as ex:
-        logger.exception('Error creating DBS APIs, likely wrong DBS URL %s\n%s', publish_dbs_url, ex)
+        logger.exception('Error creating DBS APIs, likely wrong DBS URL %s\n%s', publishURL, ex)
         nothingToDo['result'] = 'FAIL'
         nothingToDo['reason'] = 'Error contacting DBS'
-        summaryFileName = saveSummaryJson(logdir, nothingToDo)
+        summaryFileName = saveSummaryJson(nothingToDo, log['logdir'])
         return summaryFileName
 
+    sourceApi = DBSApis['source']
+    globalApi = DBSApis['global']
+    destApi = DBSApis['destWrite']
+    destReadApi = DBSApis['destRead']
+    migrateApi = DBSApis['migrate']
+
     logger.info("inputDataset: %s", inputDataset)
-    noInput = len(inputDataset.split("/")) <= 3
-
-    if not noInput:
-        try:
-            existing_datasets = sourceApi.listDatasets(dataset=inputDataset, detail=True, dataset_access_type='*')
-            primary_ds_type = existing_datasets[0]['primary_ds_type']
-        except Exception as ex:
-            logger.exception('Error looking up input dataset in %s\n%s', sourceApi.url, ex)
-            nothingToDo['result'] = 'FAIL'
-            nothingToDo['reason'] = 'Error looking up input dataset in DBS'
-            summaryFileName = saveSummaryJson(logdir, nothingToDo)
-            return summaryFileName
-
-        try:
-            existing_output = destReadApi.listOutputConfigs(dataset=inputDataset)
-        except Exception as ex:
-            logger.exception('Error from listOutputConfigs in %s\n%s', destReadApi.url, ex)
-            nothingToDo['result'] = 'FAIL'
-            nothingToDo['reason'] = 'Error looking up input dataset in DBS'
-            summaryFileName = saveSummaryJson(logdir, nothingToDo)
-            return summaryFileName
-        if not existing_output:
-            msg = "Unable to list output config for input dataset %s." % (inputDataset)
-            logger.error(msg)
-            global_tag = 'crab3_tag'
-        else:
-            global_tag = existing_output[0]['global_tag']
-    else:
-        msg = "This publication appears to be for private MC."
-        logger.info(msg)
-        primary_ds_type = 'mc'
-        global_tag = 'crab3_tag'
-
-    acquisition_era_name = "CRAB"
-    processing_era_config = {'processing_version': 1, 'description': 'CRAB3_processing_era'}
-
-    appName = 'cmsRun'
-    appVer = toPublish[0]["swversion"]
-    pset_hash = toPublish[0]['publishname'].split("-")[-1]
-    gtag = str(toPublish[0]['globaltag'])
-    if gtag == "None":
-        gtag = global_tag
-    try:
-        if toPublish[0]['acquisitionera'] and not toPublish[0]['acquisitionera'] in ["null"]:
-            acquisitionera = str(toPublish[0]['acquisitionera'])
-        else:
-            acquisitionera = acquisition_era_name
-    except Exception as ex:
-        acquisitionera = acquisition_era_name
-
-    _, primName, procName, tier = toPublish[0]['outdataset'].split('/')
-
-    primds_config = {'primary_ds_name': primName, 'primary_ds_type': primary_ds_type}
-    msg = "About to insert primary dataset"
-    logger.debug(msg)
-    if dryRun:
-        logger.info("DryRun: skip insertPrimaryDataset")
-    else:
-        try:
-            destApi.insertPrimaryDataset(primds_config)
-        except Exception:
-            logger.exception('Error inserting PrimaryDataset in %s', destApi.url)
-            nothingToDo['result'] = 'FAIL'
-            nothingToDo['reason'] = 'Error looking up input dataset in DBS'
-            summaryFileName = saveSummaryJson(logdir, nothingToDo)
-            return summaryFileName
-        msg = "Successfully inserted primary dataset %s." % (primName)
-        logger.info(msg)
 
     final = {}
     failed = []
@@ -684,7 +121,7 @@ def publishInDBS3(config, taskname, verbose):
         logger.error(msg)
         nothingToDo['result'] = 'FAIL'
         nothingToDo['reason'] = 'Error listing existing files in DBS'
-        summaryFileName = saveSummaryJson(logdir, nothingToDo)
+        summaryFileName = saveSummaryJson(nothingToDo, logdir)
         return summaryFileName
 
     # check if actions are needed
@@ -702,43 +139,21 @@ def publishInDBS3(config, taskname, verbose):
         logger.info('Make sure those files are marked as Done')
         # docId is the has of the source LFN i.e. the file in the tmp area at the running site
         files = [f['SourceLFN'] for f in toPublish]
-        mark_good(files, crabServer, logger)
-        summaryFileName = saveSummaryJson(logdir, nothingToDo)
+        if not dryRun:
+            mark_good(files=files, crabServer=crabServer, asoworker=config.General.asoworker, logger=logger)
+        summaryFileName = saveSummaryJson(nothingToDo, logdir)
         return summaryFileName
 
-    acquisition_era_config = {'acquisition_era_name': acquisitionera, 'start_date': 0}
-
-    output_config = {'release_version': appVer,
-                     'pset_hash': pset_hash,
-                     'app_name': appName,
-                     'output_module_label': 'o',
-                     'global_tag': global_tag,
-                    }
-
-    dataset_config = {'dataset': dataset,
-                      'processed_ds_name': procName,
-                      'data_tier_name': tier,
-                      'dataset_access_type': 'VALID',
-                      'physics_group_name': 'CRAB3',
-                      'last_modification_date': int(time.time()),
-                     }
-
-    logger.info("Output dataset config: %s", str(dataset_config))
+    # OK got something to do
+    DBSConfigs = prepareDbsPublishingConfigs(aFile=toPublish[0], inputDataset=inputDataset,
+                                              outputDataset=dataset, DBSApis=DBSApis, logger=logger)
 
     # List of all files that must (and can) be published.
     dbsFiles = []
     dbsFiles_f = []
-    # Set of all the parent files from all the files requested to be published.
-    parentFiles = set()
-    # Set of parent files for which the migration to the destination DBS instance
-    # should be skipped (because they were not found in DBS).
-    parentsToSkip = set()
-    # Set of parent files to migrate from the source DBS instance
-    # to the destination DBS instance.
-    localParentBlocks = set()
-    # Set of parent files to migrate from the global DBS instance
-    # to the destination DBS instance.
-    globalParentBlocks = set()
+
+    (localParentBlocks, globalParentBlocks) = findParentBlocks(
+        toPublish, DBSApis=DBSApis, logger=logger, verbose=verbose)
 
     # Loop over all files to publish.
     for file_ in toPublish:
@@ -747,53 +162,6 @@ def publishInDBS3(config, taskname, verbose):
         # Check if this file was already published and if it is valid.
         if file_['lfn'] not in existingFilesValid:
             # We have a file to publish.
-            # Get the parent files and for each parent file do the following:
-            # 1) Add it to the list of parent files.
-            # 2) Find the block to which it belongs and insert that block name in
-            #    (one of) the set of blocks to be migrated to the destination DBS.
-            for parentFile in list(file_['parents']):
-                if parentFile not in parentFiles:
-                    parentFiles.add(parentFile)
-                    # Is this parent file already in the destination DBS instance?
-                    # (If yes, then we don't have to migrate this block.)
-                    # some parent files are illegal DBS names (GH issue #6771), skip them
-                    try:
-                        blocksDict = destReadApi.listBlocks(logical_file_name=parentFile)
-                    except Exception:
-                        file_['parents'].remove(parentFile)
-                        continue
-                    if not blocksDict:
-                        # No, this parent file is not in the destination DBS instance.
-                        # Maybe it is in the same DBS instance as the input dataset?
-                        blocksDict = sourceApi.listBlocks(logical_file_name=parentFile)
-                        if blocksDict:
-                            # Yes, this parent file is in the same DBS instance as the input dataset.
-                            # Add the corresponding block to the set of blocks from the source DBS
-                            # instance that have to be migrated to the destination DBS.
-                            localParentBlocks.add(blocksDict[0]['block_name'])
-                        else:
-                            # No, this parent file is not in the same DBS instance as input dataset.
-                            # Maybe it is in global DBS instance?
-                            blocksDict = globalApi.listBlocks(logical_file_name=parentFile)
-                            if blocksDict:
-                                # Yes, this parent file is in global DBS instance.
-                                # Add the corresponding block to the set of blocks from global DBS
-                                # instance that have to be migrated to the destination DBS.
-                                globalParentBlocks.add(blocksDict[0]['block_name'])
-                    # If this parent file is not in the destination DBS instance, is not
-                    # the source DBS instance, and is not in global DBS instance, then it
-                    # means it is not known to DBS and therefore we can not migrate it.
-                    # Put it in the set of parent files for which migration should be skipped.
-                    if not blocksDict:
-                        parentsToSkip.add(parentFile)
-                # If this parent file should not be migrated because it is not known to DBS,
-                # we remove it from the list of parents in the file-to-publish info dictionary
-                # (so that when publishing, this "parent" file will not appear as a parent).
-                if parentFile in parentsToSkip:
-                    msg = "Skipping parent file %s, as it doesn't seem to be known to DBS." % (parentFile)
-                    logger.info(msg)
-                    if parentFile in file_['parents']:
-                        file_['parents'].remove(parentFile)
             # Add this file to the list of files to be published.
             dbsFiles.append(format_file_3(file_))
             dbsFiles_f.append(file_)
@@ -819,7 +187,7 @@ def publishInDBS3(config, taskname, verbose):
     if not dbsFiles_f:
         msg = "No file to publish to do for this dataset."
         logger.info(msg)
-        summaryFileName = saveSummaryJson(logdir, nothingToDo)
+        summaryFileName = saveSummaryJson(nothingToDo, logdir)
         return summaryFileName
 
     # Migrate parent blocks before publishing.
@@ -834,16 +202,19 @@ def publishInDBS3(config, taskname, verbose):
             try:
                 statusCode, failureMsg = migrateByBlockDBS3(taskname, migrateApi, destReadApi, sourceApi,
                                                             inputDataset, localParentBlocks, migrationLogDir,
-                                                            verbose)
+                                                            logger=logger, verbose=verbose)
             except CannotMigrateException as ex:
                 # there is nothing we can do in this case
                 failureMsg = 'Cannot migrate. ' + str(ex)
                 logger.info('%s. Mark all files as failed', failureMsg)
-                mark_failed([file['SourceLFN'] for file in toPublish], crabServer, logger, failureMsg)
+                if not dryRun:
+                    mark_failed([file['SourceLFN'] for file in toPublish],
+                                crabServer=crabServer, asoworker=config.General.asoworker,
+                                failure_reason=failureMsg, logger=logger)
                 nothingToDo['result'] = 'FAIL'
                 nothingToDo['reason'] = failureMsg
                 nothingToDo['failedFiles'] = len(dbsFiles)
-                summaryFileName = saveSummaryJson(logdir, nothingToDo)
+                summaryFileName = saveSummaryJson(nothingToDo, logdir)
                 return summaryFileName
             except Exception as ex:
                 logger.exception('Exception raised inside migrateByBlockDBS3\n%s', ex)
@@ -852,7 +223,7 @@ def publishInDBS3(config, taskname, verbose):
             if statusCode:
                 failureMsg += " Not publishing any files."
                 logger.info(failureMsg)
-                summaryFileName = saveSummaryJson(logdir, nothingToDo)
+                summaryFileName = saveSummaryJson(nothingToDo, logdir)
                 return summaryFileName
     # Then migrate the parent blocks that are in the global DBS instance.
     if globalParentBlocks:
@@ -872,7 +243,7 @@ def publishInDBS3(config, taskname, verbose):
             if statusCode:
                 failureMsg += " Not publishing any files."
                 logger.info(failureMsg)
-                summaryFileName = saveSummaryJson(logdir, nothingToDo)
+                summaryFileName = saveSummaryJson(nothingToDo, logdir)
                 return summaryFileName
     # Publish the files in blocks. The blocks must have exactly max_files_per_block
     # files, unless there are less than max_files_per_block files to publish to
@@ -911,16 +282,17 @@ def publishInDBS3(config, taskname, verbose):
         t1 = 0
         blockSize = '0'
         didPublish = 'OK'
-        failure_reason = ''
         try:
             block_config = {'block_name': block_name, 'origin_site_name': pnn, 'open_for_writing': 0}
             if verbose:
                 msg = "Inserting files %s into block %s." % ([f['logical_file_name']
                                                               for f in files_to_publish], block_name)
                 logger.info(msg)
-            blockDump = createBulkBlock(output_config, processing_era_config,
-                                        primds_config, dataset_config,
-                                        acquisition_era_config, block_config, files_to_publish)
+
+            blockDump = createBulkBlock(DBSConfigs['output_config'], DBSConfigs['processing_era_config'],
+                                        DBSConfigs['primds_config'], DBSConfigs['dataset_config'],
+                                        DBSConfigs['acquisition_era_config'],
+                                        block_config, files_to_publish)
             #logger.debug("Block to insert: %s\n %s" % (blockDump, destApi.__dict__ ))
             blockSizeKBytes = len(json.dumps(blockDump)) // 1024
             if blockSizeKBytes > 1024:
@@ -946,7 +318,6 @@ def publishInDBS3(config, taskname, verbose):
             msg += str(ex)
             msg += str(traceback.format_exc())
             logger.error(msg)
-            failure_reason = str(ex)
             taskFilesDir = config.General.taskFilesDir
             fname = os.path.join(taskFilesDir, 'FailedBlocks', 'failed-block-at-%s.txt' % time.time())
             with open(fname, 'w', encoding='utf8') as fd:
@@ -990,13 +361,12 @@ def publishInDBS3(config, taskname, verbose):
 
     try:
         if published:
-            mark_good(published, crabServer, logger)
-            data['workflow'] = taskname
-            data['subresource'] = 'updatepublicationtime'
-            crabServer.post(api='task', data=encodeRequest(data))
+            if not dryRun:
+                mark_good(files=published, crabServer=crabServer, asoworker=config.General.asoworker, logger=logger)
         if failed:
             logger.debug("Failed files: %s ", failed)
-            mark_failed(failed, crabServer, logger, failure_reason)
+            if not dryRun:
+                mark_failed(failed, crabServer=crabServer, asoworker=config.General.asoworker, logger=logger)
     except Exception as ex:
         logger.exception("Status update failed: %s", ex)
 
@@ -1011,7 +381,7 @@ def publishInDBS3(config, taskname, verbose):
     summary['failedFiles'] = len(failed)
     summary['nextIterFiles'] = len(publish_in_next_iteration)
 
-    summaryFileName = saveSummaryJson(logdir, summary)
+    summaryFileName = saveSummaryJson(summary, logdir)
 
     return summaryFileName
 
@@ -1038,11 +408,13 @@ def main():
     parser.add_argument('--taskname', help='taskname', required=True)
     parser.add_argument('--verbose', help='Verbose mode, print dictionaries', action='store_true')
     parser.add_argument('--dry', help='Dry run mode, no changes done in DBS', action='store_true')
+    parser.add_argument('--console', help='Console mode, send logging to stdout', action='store_true')
     args = parser.parse_args()
     configFile = os.path.abspath(args.configFile)
     taskname = args.taskname
     verbose = args.verbose
     dryRun = args.dry
+    console = args.console
     modeMsg = " in DRY RUN mode" if dryRun else ""
     config = loadConfigurationFile(configFile)
     if dryRun:
@@ -1051,7 +423,7 @@ def main():
     if verbose:
         print("Will run%s with:\nconfigFile: %s\ntaskname  : %s\n" % (modeMsg, configFile, taskname))
 
-    result = publishInDBS3(config, taskname, verbose)
+    result = publishInDBS3(config, taskname, verbose, console)
     print("Completed with result in %s" % result)
 
 if __name__ == '__main__':

--- a/src/python/Publisher/TaskPublishRucio.py
+++ b/src/python/Publisher/TaskPublishRucio.py
@@ -16,7 +16,7 @@ from TaskWorker.WorkerExceptions import CannotMigrateException
 from TaskWorker.WorkerUtilities import getCrabserver
 
 from PublisherUtils import setupLogging, prepareDummySummary, saveSummaryJson, \
-    mark_good, mark_failed, getDBSInputInformation
+    markGood, markFailed, getDBSInputInformation
 
 from PublisherDbsUtils import format_file_3, setupDbsAPIs, findParentBlocks, \
     prepareDbsPublishingConfigs, createBulkBlock, migrateByBlockDBS3
@@ -169,8 +169,6 @@ def publishInDBS3(config, taskname, verbose, console):  # pylint: disable=too-ma
                 failureReason = 'failedToInsertInDBS'
             finally:
                 elapsed = int(time.time() - t1)
-                # msg = 'PUBSTAT: Nfiles=%4d, lumis=%7d, blockSize=%6s, time=%3ds, status=%s, task=%s' % \
-                #       (len(dbsFiles), nLumis, blockSize, elapsed, didPublish, taskname)
                 msg = f"PUBSTAT: Nfiles={len(dbsFiles):{4}}, lumis={nLumis:{7}}"
                 msg += f", blockSize={blockSize:{6}}, time={elapsed:{3}}"
                 msg += f", status={didPublish}, task={taskname}"
@@ -271,7 +269,7 @@ def publishInDBS3(config, taskname, verbose, console):  # pylint: disable=too-ma
         # docId is the hash of the source LFN i.e. the file in the tmp area at the running site
         files = [f['source_lfn'] for f in block['files'] for block in blocksToPublish]
         if not dryRun:
-            mark_good(files=files, crabServer=crabServer, asoworker=config.General.asoworker, logger=logger)
+            markGood(files=files, crabServer=crabServer, asoworker=config.General.asoworker, logger=logger)
         summaryFileName = saveSummaryJson(nothingToDo, log['logdir'])
         return summaryFileName
 
@@ -310,7 +308,7 @@ def publishInDBS3(config, taskname, verbose, console):  # pylint: disable=too-ma
             publishedBlocks += 1
             publishedFiles += len(blockDict['files'])
             if not dryRun:
-                mark_good(files=lfnsInBlock, crabServer=crabServer, asoworker=config.General.asoworker, logger=logger)
+                markGood(files=lfnsInBlock, crabServer=crabServer, asoworker=config.General.asoworker, logger=logger)
             listOfPublishedLFNs.extend(lfnsInBlock)
         elif result['status'] == 'FAIL':
             failedBlocks += 1
@@ -318,7 +316,7 @@ def publishInDBS3(config, taskname, verbose, console):  # pylint: disable=too-ma
             failedBlocks += 1
             failedFiles += len(blockDict['files'])
             if not dryRun:
-                mark_failed(files=lfnsInBlock, crabServer=crabServer, asoworker=config.General.asoworker, logger=logger)
+                markFailed(files=lfnsInBlock, crabServer=crabServer, asoworker=config.General.asoworker, logger=logger)
             listOfFailedLFNs.extend(lfnsInBlock)
             if result['reason'] == 'failedToInsertInDBS':
                 logger.error("Failed to insert block in DBS. Block Dump saved")

--- a/src/python/Publisher/TaskPublishRucio.py
+++ b/src/python/Publisher/TaskPublishRucio.py
@@ -18,7 +18,8 @@ from TaskWorker.WorkerUtilities import getCrabserver
 from PublisherUtils import setupLogging, prepareDummySummary, saveSummaryJson, \
     mark_good, mark_failed, getDBSInputInformation
 
-from PublisherDbsUtils import format_file_3, setupDbsAPIs, createBulkBlock, migrateByBlockDBS3
+from PublisherDbsUtils import format_file_3, setupDbsAPIs, findParentBlocks, \
+    prepareDbsPublishingConfigs, createBulkBlock, migrateByBlockDBS3
 
 
 def publishInDBS3(config, taskname, verbose, console):  # pylint: disable=too-many-statements, too-many-locals
@@ -32,144 +33,6 @@ def publishInDBS3(config, taskname, verbose, console):  # pylint: disable=too-ma
     log = {'logger': None, 'logdir': None, 'logTaskDir': None, 'taskFilesDir': None}
     DBSApis = {'source': None, 'destRead': None, 'destWrite': None, 'global': None, 'migrate': None}
     nothingToDo = {}  # a pre-filled SummaryFile in case of no useful input or errors
-
-    def findParentBlocks(listOfFileDicts=None, logger=None):
-        # sourceApi, globalApi, destApi, destReadApi, migrateApi = DBSApis
-
-        # Set of all the parent files from all the files requested to be published.
-        parentFiles = set()
-        # Set of parent files for which the migration to the destination DBS instance
-        # should be skipped (because they were not found in DBS).
-        parentsToSkip = set()
-        # Set of parent files to migrate from the source DBS instance
-        # to the destination DBS instance.
-        localParentBlocks = set()
-        # Set of parent files to migrate from the global DBS instance
-        # to the destination DBS instance.
-        globalParentBlocks = set()
-
-        for file in listOfFileDicts:  # pylint: disable=too-many-nested-blocks
-            if verbose:
-                logger.info(file)
-            # Get the parent files and for each parent file do the following:
-            # 1) Add it to the list of parent files.
-            # 2) Find the block to which it belongs and insert that block name in
-            #    (one of) the set of blocks to be migrated to the destination DBS.
-            for parentFile in list(file['parents']):
-                if parentFile not in parentFiles:
-                    parentFiles.add(parentFile)
-                    # Is this parent file already in the destination DBS instance?
-                    # (If yes, then we don't have to migrate this block.)
-                    # some parent files are illegal DBS names (GH issue #6771), skip them
-                    try:
-                        blocksDict = DBSApis['destRead'].listBlocks(logical_file_name=parentFile)
-                    except Exception:
-                        file['parents'].remove(parentFile)
-                        continue
-                    if not blocksDict:
-                        # No, this parent file is not in the destination DBS instance.
-                        # Maybe it is in the same DBS instance as the input dataset?
-                        blocksDict = DBSApis['source'].listBlocks(logical_file_name=parentFile)
-                        if blocksDict:
-                            # Yes, this parent file is in the same DBS instance as the input dataset.
-                            # Add the corresponding block to the set of blocks from the source DBS
-                            # instance that have to be migrated to the destination DBS.
-                            localParentBlocks.add(blocksDict[0]['block_name'])
-                        else:
-                            # No, this parent file is not in the same DBS instance as input dataset.
-                            # Maybe it is in global DBS instance?
-                            blocksDict = DBSApis['global'].listBlocks(logical_file_name=parentFile)
-                            if blocksDict:
-                                # Yes, this parent file is in global DBS instance.
-                                # Add the corresponding block to the set of blocks from global DBS
-                                # instance that have to be migrated to the destination DBS.
-                                globalParentBlocks.add(blocksDict[0]['block_name'])
-                    # If this parent file is not in the destination DBS instance, is not
-                    # the source DBS instance, and is not in global DBS instance, then it
-                    # means it is not known to DBS and therefore we can not migrate it.
-                    # Put it in the set of parent files for which migration should be skipped.
-                    if not blocksDict:
-                        parentsToSkip.add(parentFile)
-                # If this parent file should not be migrated because it is not known to DBS,
-                # we remove it from the list of parents in the file-to-publish info dictionary
-                # (so that when publishing, this "parent" file will not appear as a parent).
-                if parentFile in parentsToSkip:
-                    msg = f"Skipping parent file {parentFile}, as it doesn't seem to be known to DBS."
-                    logger.info(msg)
-                    if parentFile in file['parents']:
-                        file['parents'].remove(parentFile)
-        return (localParentBlocks, globalParentBlocks)
-
-    def prepareDbsPublishingConfigs(blockDict=None, inputDataset=None, logger=None):
-        """
-        Fills the DBSConfigs dictionary with the various configs needed to publish one block
-        Needs a few parameters from the a sample block to be published
-        DBSConfigs = {'primds_config', 'dataset_config', 'output_config',
-                  'processing_era_config', 'acquisition_era_config'}
-        """
-
-        releaseVersion = blockDict['release_version']
-        globalTag = blockDict['global_tag']
-        acquisitionEra = blockDict['acquisition_era_name']
-        aFile = blockDict['files'][0]
-        psetHash = aFile['publishname'].split("-")[-1]
-
-        noInput = len(inputDataset.split("/")) <= 3
-        if not noInput:
-            existing_datasets = DBSApis['source'].listDatasets(dataset=inputDataset, detail=True, dataset_access_type='*')
-            primary_ds_type = existing_datasets[0]['primary_ds_type']
-            existing_output = DBSApis['destRead'].listOutputConfigs(dataset=inputDataset)
-            if not existing_output:
-                msg = f"Unable to list output config for input dataset {inputDataset}"
-                logger.error(msg)
-                globalTag = 'crab3_tag'
-            else:
-                globalTag = existing_output[0]['global_tag']
-        else:
-            msg = "This publication appears to be for private MC."
-            logger.info(msg)
-            primary_ds_type = 'mc'
-            globalTag = 'crab3_tag'
-
-        appName = 'cmsRun'
-        if not globalTag or globalTag == 'null' or globalTag == 'None':
-            globalTag = 'crab3_tag'
-        if not acquisitionEra or acquisitionEra == 'null' or acquisitionEra == 'None':
-            acquisitionEra = 'CRAB'
-
-        outputDataset = aBlock['block_name'].split('#')[0]
-        _, primName, procName, tier = outputDataset.split('/')
-        primds_config = {'primary_ds_name': primName, 'primary_ds_type': primary_ds_type}
-
-        acquisition_era_config = {'acquisition_era_name': acquisitionEra, 'start_date': 0}
-
-        processing_era_config = {'processing_version': 1, 'description': 'CRAB3_processing_era'}
-
-        output_config = {'release_version': releaseVersion,
-                         'pset_hash': psetHash,
-                         'app_name': appName,
-                         'output_module_label': 'o',
-                         'global_tag': globalTag,
-                         }
-
-        dataset_config = {'dataset': outputDataset,
-                          'processed_ds_name': procName,
-                          'data_tier_name': tier,
-                          'dataset_access_type': 'VALID',
-                          'physics_group_name': 'CRAB3',
-                          'last_modification_date': int(time.time()),
-                          }
-
-        logger.info("Output dataset config: %s", str(dataset_config))
-
-        DBSConfigs = {}
-        DBSConfigs['primds_config'] = primds_config
-        DBSConfigs['dataset_config'] = dataset_config
-        DBSConfigs['output_config'] = output_config
-        DBSConfigs['processing_era_config'] = processing_era_config
-        DBSConfigs['acquisition_era_config'] = acquisition_era_config
-
-        return DBSConfigs
 
     def publishOneBlockInDBS(blockDict=None, DBSConfigs=None, logger=None):
         """
@@ -205,7 +68,8 @@ def publishInDBS3(config, taskname, verbose, console):  # pylint: disable=too-ma
             logger.info(msg)
             return {'status': 'FAIL', 'reason': msg, 'dumpFile': None}
 
-        (localParentBlocks, globalParentBlocks) = findParentBlocks(dictsOfFilesToBePublished, logger=logger)
+        (localParentBlocks, globalParentBlocks) = findParentBlocks(
+            dictsOfFilesToBePublished, DBSApis=DBSApis, logger=logger, verbose=verbose)
 
         # Print a message with the number of files to publish.
         msg = f"Found {len(dbsFiles)} files not already present in DBS which will be published."
@@ -413,7 +277,8 @@ def publishInDBS3(config, taskname, verbose, console):  # pylint: disable=too-ma
 
     # OK got something to do !
     try:
-        DBSConfigs = prepareDbsPublishingConfigs(blockDict=blocksToPublish[0], inputDataset=inputDataset, logger=logger)
+        DBSConfigs = prepareDbsPublishingConfigs(blockDict=blocksToPublish[0], inputDataset=inputDataset,
+                                                 outputDataset=outputDataset, DBSApis=DBSApis, logger=logger)
     except Exception as ex:
         logger.exception('Error looking up input dataset info:\n%s', ex)
         nothingToDo['result'] = 'FAIL'


### PR DESCRIPTION
this combines
1. refactoring so that almost all code common to TaskPublish and TaskPublishRucio is in common Publish(Dbs)Utils
2. catch "migration already exists" and make sure that it is retried