### PR TITLE
Fix typos in output strings

### DIFF
--- a/scripts/CMSRunAnalysis.py
+++ b/scripts/CMSRunAnalysis.py
@@ -220,7 +220,7 @@ def logCMSSW():
             for aLine in fh:
                 printCMSSWLine(f"{prefix + aLine}", maxLineLen)
 
-    print("======== CMSSW OUTPUT FINSHING ========")
+    print("======== CMSSW OUTPUT FINISHING ========")
     logCMSSWSaved = True
     # inform CMSRunAnalysis.sh by "touching a file"
     with open('logCMSSWSaved.txt', 'a', encoding='utf-8'):

--- a/scripts/Utils/AutoRemoveFailedMigration.py
+++ b/scripts/Utils/AutoRemoveFailedMigration.py
@@ -40,7 +40,7 @@ def main():
         if state == 2:
             print("Migration with ID: %d is DONE" % migrationId)
             return
-        stateName = {0:'created', 1:'in progress', 2:'done', 3:'failed but beign retried', 9:'terminally failed'}
+        stateName = {0:'created', 1:'in progress', 2:'done', 3:'failed but being retried', 9:'terminally failed'}
         print("%d is in state %d (%s), not 9" % (migrationId, state, stateName[state]))
         print("This migrationId is not terminally failed. Will not remove it")
         return

--- a/scripts/Utils/CheckDiskAvailability.py
+++ b/scripts/Utils/CheckDiskAvailability.py
@@ -51,7 +51,7 @@ def main():
          return
     blackListedSites = get_crab_blacklist()
     nBlocks = len(blocks)
-    print("Checking blocks availabiliyt on disk ...")
+    print("Checking blocks availability on disk ...")
     locationsMap = create_locations_map(blocks, rucio)
     (nbFORnr, nbFORrse) = createBlockMaps(locationsMap=locationsMap, blackList=[])
     print_blocks_per_replica_map(nbFORnr)

--- a/scripts/Utils/RemoveFailedMigration.py
+++ b/scripts/Utils/RemoveFailedMigration.py
@@ -35,7 +35,7 @@ def main():
     state = status[0].get("migration_status")
 
     if not state == 9:
-        stateName = {0:'created', 1:'in progress', 2:'done', 3:'failed but beign retried', 9:'terminally failed'}
+        stateName = {0:'created', 1:'in progress', 2:'done', 3:'failed but being retried', 9:'terminally failed'}
         print("%id is in state %d (%s), not 9" % (migrationId, state, stateName[state]))
         print("This migrationId is not terminally failed. Will not remove it")
         return

--- a/src/python/CRABInterface/RESTCache.py
+++ b/src/python/CRABInterface/RESTCache.py
@@ -120,7 +120,7 @@ class RESTCache(RESTEntity):
                 objectPath = ownerName + '/sandboxes/' + tarballname
             else:
                 if not taskname:
-                    raise MissingParameter("takskname is missing")
+                    raise MissingParameter("taskname is missing")
                 ownerName = getUsernameFromTaskname(taskname)
                 # task related files go in bucket/username/taskname/
                 objectPath = ownerName + '/' + taskname + '/' + objecttype

--- a/src/python/CRABInterface/Utilities.py
+++ b/src/python/CRABInterface/Utilities.py
@@ -47,7 +47,7 @@ def globalinit(credpath):
 def execute_command(command, logger, timeout):
     """
     _execute_command_
-    Funtion to manage commands.
+    Function to manage commands.
     """
 
     stdout, stderr, rc = None, None, 99999
@@ -96,7 +96,7 @@ cfgFallback = {}
 
 def getCentralConfig(extconfigurl, mode):
     """Utility to retrieve the central configuration to be used for dynamic variables
-    arg str extconfigurl: the url pointing to the exteranl configuration parameter
+    arg str extconfigurl: the url pointing to the external configuration parameter
     arg str mode: also known as the variant of the rest (prod, preprod, dev, private)
     return: the dictionary containing the external configuration for the selected mode."""
 

--- a/src/python/HTCondorLocator.py
+++ b/src/python/HTCondorLocator.py
@@ -84,7 +84,7 @@ def memoryBasedChoices(schedds, logger=None):
             weight = 24*1024
         weights[schedd['Name']] = weight
         if logger:
-            logger.debug(f"Scheduler: {schedd}: mwmory wight: {weight}")
+            logger.debug(f"Scheduler: {schedd}: memory weight: {weight}")
     choices = [(schedd['Name'], weights[schedd['Name']]) for schedd in schedds]
     return choices
 
@@ -130,7 +130,7 @@ class HTCondorLocator():
                                  ['Name', 'DetectedMemory', 'TotalFreeMemoryMB', 'TransferQueueNumUploading',
                                   'TransferQueueMaxUploading','TotalRunningJobs', 'JobsRunning', 'MaxJobsRunning', 'IsOK'])
             if not schedds:
-                raise Exception(f"No CRAB schedds returned by collecor query. {collParam} parameter is {htcondor.param['COLLECTOR_HOST']}. Try later")
+                raise Exception(f"No CRAB schedds returned by collector query. {collParam} parameter is {htcondor.param['COLLECTOR_HOST']}. Try later")
 
             # Get only those schedds that are listed in our external REST configuration
             if self.config and "htcondorSchedds" in self.config:

--- a/src/python/Publisher/PublisherDbsUtils.py
+++ b/src/python/Publisher/PublisherDbsUtils.py
@@ -378,7 +378,7 @@ def migrateByBlockDBS3(taskname, migrateApi, destReadApi, sourceApi, blocks,  # 
         msg = "Some blocks failed to be migrated."
         logger.info(msg)
         return 2, f"Migration of {datasetToMigrate} failed."
-    msg = "Migration completed. Wait 5sec before verifying that migrated datesed is OK in destination DBS"
+    msg = "Migration completed. Wait 5sec before verifying that migrated dataset is OK in destination DBS"
     logger.info(msg)
     time.sleep(5.0)
     migratedDataset = None
@@ -405,7 +405,7 @@ def requestBlockMigration(taskname, migrateApi, sourceApi, block):
     logger = logging.getLogger(taskname)
     #    logging.basicConfig(filename=taskname+'.log', level=logging.INFO, format=config.General.logMsgFormat)
 
-    msg = f"Submiting migration request for block {block} ..."
+    msg = f"Submitting migration request for block {block} ..."
     logger.info(msg)
     sourceURL = sourceApi.url
     data = {'migration_url': sourceURL, 'migration_input': block}

--- a/src/python/Publisher/RunPublisher.py
+++ b/src/python/Publisher/RunPublisher.py
@@ -22,7 +22,7 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--config', help='Publisher config file', default='PublisherConfig.py')
-parser.add_argument('--service', help='Pubblisher_schedd or Publisher_rucio', default='Publisher_schedd')
+parser.add_argument('--service', help='Publisher_schedd or Publisher_rucio', default='Publisher_schedd')
 parser.add_argument('--testMode', help='run in sequential mode (no subprocesses)', action='store_true')
 parser.add_argument('--debug', help='start with pdb', action='store_true')
 args = parser.parse_args()

--- a/src/python/Publisher/TaskPublishRucio.py
+++ b/src/python/Publisher/TaskPublishRucio.py
@@ -327,9 +327,9 @@ def publishInDBS3(config, taskname, verbose, console):  # pylint: disable=too-ma
     # Print a publication status summary for this dataset.
     msg = "End of publication status:"
     msg += f" failed blocks: {failedBlocks}"
-    msg += f" succes blocks: {publishedBlocks}"
+    msg += f" success blocks: {publishedBlocks}"
     msg += f" failed files: {failedFiles}"
-    msg += f" succes files: {publishedFiles}"
+    msg += f" success files: {publishedFiles}"
     logger.info(msg)
 
     # save summary for PublisherMasterRucio

--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -335,7 +335,7 @@ def createDummyFile(filename, logger):
         with open(abspath, 'w') as fd:
             fd.write('This is a dummy file created by the crab checkwrite command on %s' % str(datetime.datetime.now().strftime('%d/%m/%Y at %H:%M:%S')))
     except IOError:
-        logger.info('Error: Failed to create file %s localy.' % filename)
+        logger.info('Error: Failed to create file %s locally.' % filename)
         raise
 
 
@@ -410,7 +410,7 @@ def isFailurePermanent(reason, gridJob=False):
         permanent failure and submit task or not.
     """
 
-    checkQuota = " Please check that you have write access to destination site and that your quota is not exceeded, use crab checkwrite for more informations."
+    checkQuota = " Please check that you have write access to destination site and that your quota is not exceeded, use crab checkwrite for more information."
     refuseToSubmit = " Can't submit task because write check at destination site fails."
     if gridJob:
         refuseToSubmit = ""
@@ -574,7 +574,7 @@ def checkTaskLifetime(submissionTime):
     # resubmitLifeTime is 23 days expressed in seconds
     resubmitLifeTime = TASKLIFETIME - NUM_DAYS_FOR_RESUBMITDRAIN * 24 * 60 * 60
     if time.time() > (submissionTime + resubmitLifeTime):
-        msg = "Resubmission of the task is not possble since less than {0} days".format(NUM_DAYS_FOR_RESUBMITDRAIN)
+        msg = "Resubmission of the task is not possible since less than {0} days".format(NUM_DAYS_FOR_RESUBMITDRAIN)
         msg += "are left before the task is removed from the""schedulers.\n"
         msg += "A task expires {0} days after its submission\n".format(TASKLIFETIME / (24 * 60 * 60))
         msg += "You can submit a 'recovery task' if you need to execute again the failed jobs\n"
@@ -821,7 +821,7 @@ def uploadToS3(crabserver=None, filepath=None, objecttype=None, taskname=None,
         uploadToS3ViaPSU(filepath=filepath, preSignedUrlFields=preSignedUrl, logger=logger)
     except Exception as e:
         raise Exception('Upload to S3 failed\n%s' % str(e))
-    logger.debug('%s %s successully uploaded to S3', objecttype, filepath)
+    logger.debug('%s %s successfully uploaded to S3', objecttype, filepath)
 
 
 def getDownloadUrlFromS3(crabserver=None, objecttype=None, taskname=None,

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -243,7 +243,7 @@ def validateLFNs(path, outputFiles):
         Lexicon.lfn(testLfn)  # will raise if testLfn is not a valid lfn
         # since Lexicon does not have lenght check, do it manually here.
         if len(testLfn) > 500:
-            msg = "\nYour task speficies an output LFN %d-char long " % len(testLfn)
+            msg = "\nYour task specifies an output LFN %d-char long " % len(testLfn)
             msg += "\n which exceeds maximum length of 500"
             msg += "\n and therefore can not be handled in our DataBase"
             raise TaskWorker.WorkerExceptions.TaskWorkerException(msg)
@@ -271,7 +271,7 @@ def validateUserLFNs(path, outputFiles):
         Lexicon.userLfn(testLfn)  # will raise if testLfn is not a valid lfn
         # since Lexicon does not have lenght check, do it manually here.
         if len(testLfn) > 500:
-            msg = "\nYour task speficies an output LFN %d-char long " % len(testLfn)
+            msg = "\nYour task specifies an output LFN %d-char long " % len(testLfn)
             msg += "\n which exceeds maximum length of 500"
             msg += "\n and therefore can not be handled in our DataBase"
             raise TaskWorker.WorkerExceptions.TaskWorkerException(msg)
@@ -375,7 +375,7 @@ class DagmanCreator(TaskAction):
         if m:
             _, _, arch, _ = m.groups()
             if arch not in SCRAM_TO_ARCH:
-                msg = f"Job configured for non-supoprted ScramArch '{arch}'"
+                msg = f"Job configured for non-supported ScramArch '{arch}'"
                 raise TaskWorker.WorkerExceptions.TaskWorkerException(msg)
             info['required_arch'] = SCRAM_TO_ARCH.get(arch)
             # if arch == "amd64":
@@ -587,7 +587,7 @@ class DagmanCreator(TaskAction):
                 validateUserLFNs(dest, outfiles)
                 validateUserLFNs(temp_dest, outfiles)
         except AssertionError as ex:
-            msg = "\nYour task speficies an output LFN which fails validation in"
+            msg = "\nYour task specifies an output LFN which fails validation in"
             msg += "\n WMCore/Lexicon and therefore can not be handled in our DataBase"
             msg += "\nError detail: %s" % (str(ex))
             raise TaskWorker.WorkerExceptions.TaskWorkerException(msg)

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -1070,7 +1070,7 @@ class ASOServerJob():
                 query_view = False
                 if not last_succeded:
                     #no point in continuing if the last query failed. Just defer the PJ and retry later
-                    msg = ("Not using info about transfer statuses from the trasnfer cache. "
+                    msg = ("Not using info about transfer statuses from the transfer cache. "
                            "Deferring the postjob."
                            "PJ num %s failed to load the information from the DB and cache has not expired yet." % last_jobid)
                     raise TransferCacheLoadError(msg)
@@ -1432,7 +1432,7 @@ class PostJob():
         if os.environ.get('TEST_DONT_REDIRECT_STDOUT', False):
             handler = logging.StreamHandler(sys.stdout)
         else:
-            print("Wrinting post-job output to %s." % (self.postjob_log_file_name))
+            print("Writing post-job output to %s." % (self.postjob_log_file_name))
             mode = 'w' if first_pj_execution() else 'a'
             handler = logging.FileHandler(filename=self.postjob_log_file_name, mode=mode)
         handler.setFormatter(self.logging_formatter)
@@ -1562,7 +1562,7 @@ class PostJob():
                           headers={"Content-Type": "application/json; charset=UTF-8"},
                           verify=False
                           )
-            msg = f"List of Brancehs sent to MONIT with status {r.status_code}. Output {r.text}"
+            msg = f"List of Branches sent to MONIT with status {r.status_code}. Output {r.text}"
             self.logger.info(msg)
         except Exception as ex:
             self.logger.error(f"Failed to send branch list to MONIT. Exception:\n{ex}")
@@ -1958,7 +1958,7 @@ class PostJob():
                     time.sleep(sleep_time)
                     counter += 1
                 if rc != 0:
-                    self.logger.error("%d tries, still cant't talk to schedd. Reschedule the PostJob", counter)
+                    self.logger.error("%d tries, still can't talk to schedd. Reschedule the PostJob", counter)
                     return 4
                 self.logger.info('History file %s created', job_ad_file_name)
 
@@ -2339,7 +2339,7 @@ class PostJob():
             msg += "\nPost-job timed out waiting for ASO transfers to complete."
             msg += "\nAttempts were made to cancel the ongoing transfers,"
             msg += " but cancellation failed for some transfers."
-            msg += "\nConsidering cancellation failures as a permament stageout error."
+            msg += "\nConsidering cancellation failures as a permanent stageout error."
             self.stageout_exit_codes.append(60317)
             raise PermanentStageoutError(msg)
 

--- a/src/python/TaskWorker/Actions/RetryJob.py
+++ b/src/python/TaskWorker/Actions/RetryJob.py
@@ -402,7 +402,7 @@ class RetryJob():
         """
         check if job stdout contains a message indicating a corrupted file and reports this
         via a json file taskname.corrupted.job.<crabid>.<retry>.json
-        returns True/Falso accordingly to corrupted yes/no
+        returns True/False accordingly to corrupted yes/no
         """
 
         corruptedFile = False
@@ -444,7 +444,7 @@ class RetryJob():
                         corruptedFile = False
                         suspiciousFile = True
                         errorLines.append('NOT CLEARLY CORRUPTED, OTHER ROOT ERROR ?')
-                        errorLines.append('DID Identification may not be corrrect')
+                        errorLines.append('DID Identification may not be correct')
                         self.logger.info("RootFatalError does not contain file info")
                     break
         if corruptedFile or suspiciousFile:


### PR DESCRIPTION
Hello. I saw some typos in the exception and printing statements (that did not seem to be parsed elsewhere as such misspellings), which I fixed. I also noticed the misspelled JSON parameter with 3 c's here: https://github.com/dmwm/CRABServer/blob/master/src/python/CRABInterface/RESTWorkerWorkflow.py#L160 
Is that intentional to not hit the exception below, or just a typo not tested with  enough malformed older REST inputs? https://github.com/dmwm/CRABServer/blob/master/src/python/CRABInterface/RESTUserWorkflow.py#L433 