### PR TITLE
Reduce bind mount to single path for apps data

### DIFF
--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -40,19 +40,20 @@ check_link(){
 # directories/files that should be created before starting the container :
 # [[...]] is a trick to do partial string match from https://unix.stackexchange.com/a/465906
 if [[ $SERVICE == TaskWorker ]]; then
-  # -/data/hostdisk/${SERVICE}/cfg/TaskWorkerConfig.py
-  # -/data/hostdisk/${SERVICE}/logs
-  declare -A links=( ["current/TaskWorkerConfig.py"]="/data/hostdisk/${SERVICE}/cfg/TaskWorkerConfig.py" ["logs"]="/data/hostdisk/${SERVICE}/logs" ["nohup.out"]="/data/hostdisk/${SERVICE}/nohup.out")
+  declare -A links=(
+      ["current/TaskWorkerConfig.py"]="./hostdisk/cfg/TaskWorkerConfig.py"
+      ["nohup.out"]="./hostdisk/nohup.out"
+  )
 elif [[ $SERVICE == Publisher* ]]; then
-  # -/data/hostdisk/${SERVICE}/cfg/PublisherConfig.py
-  # -/data/hostdisk/${SERVICE}/logs
-  # -/data/hostdisk/${SERVICE}/PublisherFiles
-  declare -A links=( ["PublisherConfig.py"]="/data/hostdisk/${SERVICE}/cfg/PublisherConfig.py" ["logs"]="/data/hostdisk/${SERVICE}/logs" ["/data/srv/Publisher_files"]="/data/hostdisk/${SERVICE}/PublisherFiles" ["nohup.out"]="/data/hostdisk/${SERVICE}/nohup.out")
+  declare -A links=(
+      ["PublisherConfig.py"]="./hostdisk/cfg/PublisherConfig.py"
+      ["nohup.out"]="./hostdisk/nohup.out"
+  )
 fi
 
 for name in "${!links[@]}";
 do
-  check_link "${name}" || ln -s "${links[$name]}" "$name"
+  check_link "${name}" || ln -s "$(realpath "${links[$name]}")" "$name"
 done
 
 # run current instance

--- a/cicd/crabtaskworker_pypi/run.sh
+++ b/cicd/crabtaskworker_pypi/run.sh
@@ -27,15 +27,16 @@ check_link() {
 
 # directories/files that should be created before starting the container
 if [[ $SERVICE == TaskWorker ]]; then
-    declare -A links=(
-        ["current/TaskWorkerConfig.py"]="/data/hostdisk/${SERVICE}/cfg/TaskWorkerConfig.py"
-    )
     WORKDIR=/data/srv/TaskManager
-elif [[ "${SERVICE}" == Publisher* ]]; then
     declare -A links=(
-        ["current/PublisherConfig.py"]="/data/hostdisk/${SERVICE}/cfg/PublisherConfig.py"
+        ["current/TaskWorkerConfig.py"]="${WORKDIR}/hostdisk/cfg/TaskWorkerConfig.py"
     )
+
+elif [[ "${SERVICE}" == Publisher* ]]; then
     WORKDIR=/data/srv/Publisher
+    declare -A links=(
+        ["current/PublisherConfig.py"]="${WORKDIR}/hostdisk/cfg/PublisherConfig.py"
+    )
 else
     echo "Service unknown: ${SERVICE}"; exit 1;
 fi

--- a/src/script/Container/runContainer.sh
+++ b/src/script/Container/runContainer.sh
@@ -54,11 +54,8 @@ case $SERVICE in
     echo "$SERVICE is not a valid service to start. Specify whether you want to start one of the 'Publisher' variants or 'TaskWorker'." && helpFunction
 esac
 
-volumeMounts=()
 for d in "${dir[@]}"; do
-  if [ -e "$d" ]; then
-      volumeMounts+=("-v ${d}:/data/srv/${DIRECTORY}/$(basename "${d}")")
-  else
+  if ! [ -e "$d" ]; then
     echo "Make sure to create needed directories before starting container. Missing directory: $d" && exit 1
   fi
 done
@@ -87,15 +84,12 @@ fi
 # get os version
 OS_Version=$(cat /etc/os-release |grep VERSION_ID|cut -d= -f2|tr -d \"|cut -d. -f1)
 
-DOCKER_VOL="-v /data/container/:/data/hostdisk/ ${volumeMounts[@]} -v /data/srv/tmp/:/data/srv/tmp/"
+DOCKER_VOL="-v /data/container/${SERVICE}:/data/srv/${DIRECTORY}/hostdisk"
+DOCKER_VOL="${DOCKER_VOL} -v /data/certs/:/data/certs/"
 DOCKER_VOL="${DOCKER_VOL} -v /cvmfs:/cvmfs:shared" # https://cvmfs.readthedocs.io/en/stable/cpt-configure.html#bind-mount-from-the-host
 DOCKER_VOL="${DOCKER_VOL} -v /etc/grid-security/:/etc/grid-security/"
-DOCKER_VOL="${DOCKER_VOL} -v /data/certs/:/data/certs/"
 DOCKER_VOL="${DOCKER_VOL} -v /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
 DOCKER_VOL="${DOCKER_VOL} -v /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/pki/tls/certs/ca-bundle.crt"
-if [[ "$OS_Version" = "7" ]]; then
-    DOCKER_VOL="${DOCKER_VOL} -v /var/run/nscd/socket:/var/run/nscd/socket"
-fi
 
 DOCKER_OPT="-e SERVICE=${SERVICE} -w /data/srv/${DIRECTORY} "
 

--- a/src/script/Container/runContainer.sh
+++ b/src/script/Container/runContainer.sh
@@ -54,8 +54,11 @@ case $SERVICE in
     echo "$SERVICE is not a valid service to start. Specify whether you want to start one of the 'Publisher' variants or 'TaskWorker'." && helpFunction
 esac
 
+volumeMounts=()
 for d in "${dir[@]}"; do
-  if ! [ -e "$d" ]; then
+  if [ -e "$d" ]; then
+      volumeMounts+=("-v ${d}:/data/srv/${DIRECTORY}/$(basename "${d}")")
+  else
     echo "Make sure to create needed directories before starting container. Missing directory: $d" && exit 1
   fi
 done
@@ -84,12 +87,16 @@ fi
 # get os version
 OS_Version=$(cat /etc/os-release |grep VERSION_ID|cut -d= -f2|tr -d \"|cut -d. -f1)
 
-DOCKER_VOL="-v /data/container/${SERVICE}:/data/srv/${DIRECTORY}/hostdisk"
-DOCKER_VOL="${DOCKER_VOL} -v /data/certs/:/data/certs/"
+DOCKER_VOL="-v /data/container/:/data/hostdisk/ ${volumeMounts[@]} -v /data/srv/tmp/:/data/srv/tmp/"
+DOCKER_VOL="${DOCKER_VOL} -v /data/container/${SERVICE}:/data/srv/${DIRECTORY}/hostdisk"
 DOCKER_VOL="${DOCKER_VOL} -v /cvmfs:/cvmfs:shared" # https://cvmfs.readthedocs.io/en/stable/cpt-configure.html#bind-mount-from-the-host
 DOCKER_VOL="${DOCKER_VOL} -v /etc/grid-security/:/etc/grid-security/"
+DOCKER_VOL="${DOCKER_VOL} -v /data/certs/:/data/certs/"
 DOCKER_VOL="${DOCKER_VOL} -v /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
 DOCKER_VOL="${DOCKER_VOL} -v /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/pki/tls/certs/ca-bundle.crt"
+if [[ "$OS_Version" = "7" ]]; then
+    DOCKER_VOL="${DOCKER_VOL} -v /var/run/nscd/socket:/var/run/nscd/socket"
+fi
 
 DOCKER_OPT="-e SERVICE=${SERVICE} -w /data/srv/${DIRECTORY} "
 


### PR DESCRIPTION
Fix https://github.com/dmwm/CRABServer/issues/8402

This requires a change in the [run.sh](https://github.com/dmwm/CRABServer/blob/5572f119fa4a76f20ef85628744cabc4bad02089/Docker/run.sh) of crabtaskworker's RPM image in order to use the new bindmount's scheme.

runContainer.sh from this PR is backward compatibility with old RPM images; it is capable of deploying old, new, or pypi images without updating the configuration. Revert the [04ad23a6673b333fd188f948ef88f353ce772c61](https://github.com/dmwm/CRABServer/commit/04ad23a6673b333fd188f948ef88f353ce772c61) change to clean up, later.