### PR TITLE
Release pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,22 +4,27 @@ default:
     - crab3
 
 variables:
-  IMAGE_TAG: "${CI_COMMIT_REF_SLUG}"
+  IMAGE_TAG: "${CI_COMMIT_REF_SLUG}"  # to distinct it from commit tag and final image tag
 
 .default_rules:
-  rules:
-    - if: $CI_COMMIT_TAG =~ /pypi-.*/
+  default:
+    - if: $CI_COMMIT_TAG =~ /pypi-.*/         # pypi-devthree-1714418922
+    - if: $CI_COMMIT_TAG =~ /v3\.[0-9]{6}.*/  # v3.240423, v3.240423.hotfix1
+  release:
+    - if: $CI_COMMIT_TAG =~ /v3\.[0-9]{6}.*/  # same as above
 
 stages:
   - prepare_env
+  - prepare_release
   - build_docker
   - deploy
   - run_testsuite
   - check_testsuite
+  - tagging_release
 
 get_env:
   rules:
-    - !reference [.default_rules, rules]
+    - !reference [.default_rules, default]
   stage: prepare_env
   image:
     name: registry.cern.ch/cmscrab/buildtools
@@ -32,9 +37,30 @@ get_env:
       - .env
     expire_in: 1 week
 
+# use pre_release stage
+set_version_name:
+  rules:
+    - !reference [.default_rules, release]
+  stage: prepare_release
+  image:
+    name: registry.cern.ch/cmscrab/buildtools
+    entrypoint: [""]
+  script:
+    - source .env
+    - |
+        echo -e "\n__version__ = \"${RELEASE_NAME}\" #Automatically added during build process" >> src/python/TaskWorker/__init__.py;
+    - |
+        echo -e "\n__version__ = \"${RELEASE_NAME}\" #Automatically added during build process" >> src/python/CRABInterface/__init__.py;
+  cache:
+    - key: $CI_PIPELINE_ID
+      paths:
+        - src/python/TaskWorker/__init__.py
+        - src/python/CRABInterface/__init__.py
+      policy: push
+
 build_rest_image:
   rules:
-    - !reference [.default_rules, rules]
+    - !reference [.default_rules, default]
   stage: build_docker
   image:
     name: gcr.io/kaniko-project/executor:v1.14.0-debug
@@ -46,10 +72,15 @@ build_rest_image:
       --context "${CI_PROJECT_DIR}"
       --dockerfile "${CI_PROJECT_DIR}/cicd/crabserver_pypi/Dockerfile"
       --destination "registry.cern.ch/cmscrab/crabserver:${IMAGE_TAG}"
+  cache:
+    - key: $CI_PIPELINE_ID
+      paths:
+        - src/python/CRABInterface/__init__.py
+      policy: pull
 
 build_tw_image:
   rules:
-    - !reference [.default_rules, rules]
+    - !reference [.default_rules, default]
   stage: build_docker
   image:
     name: gcr.io/kaniko-project/executor:v1.14.0-debug
@@ -61,12 +92,17 @@ build_tw_image:
       --context "${CI_PROJECT_DIR}"
       --dockerfile "${CI_PROJECT_DIR}/cicd/crabtaskworker_pypi/Dockerfile"
       --destination "registry.cern.ch/cmscrab/crabtaskworker:${IMAGE_TAG}"
+  cache:
+    - key: $CI_PIPELINE_ID
+      paths:
+        - src/python/TaskWorker/__init__.py
+      policy: pull
 
 deploy_server:
   rules:
     - if: $SKIP_DEPLOY
       when: never
-    - !reference [.default_rules, rules]
+    - !reference [.default_rules, default]
   stage: deploy
   image:
     name: registry.cern.ch/cmscrab/buildtools
@@ -84,7 +120,7 @@ deploy_server:
   rules:
     - if: $SKIP_DEPLOY
       when: never
-    - !reference [.default_rules, rules]
+    - !reference [.default_rules, default]
   stage: deploy
   image:
     name: registry.cern.ch/cmscrab/buildtools
@@ -114,12 +150,12 @@ deploy_publisher_rucio:
 
 task_submission_status_tracking:
   rules:
-    - if: $SKIP_DEPLOY
-      when: never
     - if: $MANUAL_CI_PIPELINE_ID
       when: never
     - if: $SUBMIT_STATUS_TRACKING
-    - !reference [.default_rules, rules]
+    - if: $SKIP_DEPLOY
+      when: never
+    - !reference [.default_rules, default]
   stage: run_testsuite
   tags:
     - crab3-shell
@@ -144,11 +180,11 @@ task_submission_status_tracking:
 
 check_test_result:
   rules:
-    - if: $SKIP_DEPLOY
-      when: never
     - if: $SUBMIT_STATUS_TRACKING
     - if: $MANUAL_CI_PIPELINE_ID
-    - !reference [.default_rules, rules]
+    - if: $SKIP_DEPLOY
+      when: never
+    - !reference [.default_rules, default]
   stage: check_testsuite
   tags:
     - crab3-shell
@@ -175,3 +211,20 @@ check_test_result:
       paths:
         - workdir/submitted_tasks_TS
       policy: pull
+
+# if test is pass, retag with `*-stable`
+release_stable:
+  rules:
+    - !reference [.default_rules, release]
+  stage: tagging_release
+  image:
+    name: registry.cern.ch/cmscrab/buildtools
+    entrypoint: [""]
+  variables:
+    GIT_STRATEGY: none
+  script:
+    - source .env
+    - export RELEASE_TAG=${RELEASE_NAME}-stable
+    - crane auth login -u ${CMSCRAB_REGISTRY_USER} -p ${CMSCRAB_REGISTRY_PASSWORD} ${CMSCRAB_REGISTRY_URL}
+    - crane cp registry.cern.ch/cmscrab/crabserver:${IMAGE_TAG} registry.cern.ch/cmscrab/crabserver:${RELEASE_TAG}
+    - crane cp registry.cern.ch/cmscrab/crabtaskworker:${IMAGE_TAG} registry.cern.ch/cmscrab/crabtaskworker:${RELEASE_TAG}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,6 @@ variables:
 .default_rules:
   default:
     - if: $CI_COMMIT_TAG =~ /pypi-.*/         # pypi-devthree-1714418922
-    - if: $CI_COMMIT_TAG =~ /v3\.[0-9]{6}.*/  # v3.240423, v3.240423.hotfix1
   release:
     - if: $CI_COMMIT_TAG =~ /v3\.[0-9]{6}.*/  # same as above
 
@@ -25,6 +24,7 @@ stages:
 get_env:
   rules:
     - !reference [.default_rules, default]
+    - !reference [.default_rules, release]
   stage: prepare_env
   image:
     name: registry.cern.ch/cmscrab/buildtools
@@ -61,6 +61,7 @@ set_version_name:
 build_rest_image:
   rules:
     - !reference [.default_rules, default]
+    - !reference [.default_rules, release]
   stage: build_docker
   image:
     name: gcr.io/kaniko-project/executor:v1.14.0-debug
@@ -81,6 +82,7 @@ build_rest_image:
 build_tw_image:
   rules:
     - !reference [.default_rules, default]
+    - !reference [.default_rules, release]
   stage: build_docker
   image:
     name: gcr.io/kaniko-project/executor:v1.14.0-debug
@@ -103,6 +105,7 @@ deploy_server:
     - if: $SKIP_DEPLOY
       when: never
     - !reference [.default_rules, default]
+    - !reference [.default_rules, release]
   stage: deploy
   image:
     name: registry.cern.ch/cmscrab/buildtools
@@ -121,6 +124,7 @@ deploy_server:
     - if: $SKIP_DEPLOY
       when: never
     - !reference [.default_rules, default]
+    - !reference [.default_rules, release]
   stage: deploy
   image:
     name: registry.cern.ch/cmscrab/buildtools
@@ -156,6 +160,7 @@ task_submission_status_tracking:
     - if: $SKIP_DEPLOY
       when: never
     - !reference [.default_rules, default]
+    - !reference [.default_rules, release]
   stage: run_testsuite
   tags:
     - crab3-shell
@@ -185,6 +190,7 @@ check_test_result:
     - if: $SKIP_DEPLOY
       when: never
     - !reference [.default_rules, default]
+    - !reference [.default_rules, release]
   stage: check_testsuite
   tags:
     - crab3-shell

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -229,8 +229,7 @@ release_stable:
   variables:
     GIT_STRATEGY: none
   script:
-    - source .env
-    - export RELEASE_TAG=${RELEASE_NAME}-stable
+    - export RELEASE_IMAGE_TAG=${RELEASE_NAME:-${CI_COMMIT_TAG}-stable}
     - crane auth login -u ${CMSCRAB_REGISTRY_USER} -p ${CMSCRAB_REGISTRY_PASSWORD} ${CMSCRAB_REGISTRY_URL}
-    - crane cp registry.cern.ch/cmscrab/crabserver:${IMAGE_TAG} registry.cern.ch/cmscrab/crabserver:${RELEASE_TAG}
-    - crane cp registry.cern.ch/cmscrab/crabtaskworker:${IMAGE_TAG} registry.cern.ch/cmscrab/crabtaskworker:${RELEASE_TAG}
+    - crane cp registry.cern.ch/cmscrab/crabserver:${IMAGE_TAG} registry.cern.ch/cmscrab/crabserver:${RELEASE_IMAGE_TAG}
+    - crane cp registry.cern.ch/cmscrab/crabtaskworker:${IMAGE_TAG} registry.cern.ch/cmscrab/crabtaskworker:${RELEASE_IMAGE_TAG}

--- a/cicd/buildtools/Dockerfile
+++ b/cicd/buildtools/Dockerfile
@@ -1,3 +1,5 @@
+FROM gcr.io/go-containerregistry/crane:latest as crane
+
 FROM gitlab-registry.cern.ch/linuxsupport/alma9-base
 SHELL ["/bin/bash", "-c"]
 
@@ -8,3 +10,4 @@ RUN curl -LO https://dl.k8s.io/v1.28.3/kubernetes-client-linux-amd64.tar.gz \
     && /usr/bin/kubectl completion bash > /usr/share/bash-completion/completions/kubectl \
     && rm -r kubernetes-client-linux-amd64.tar.gz kubernetes
 RUN python3 -m ensurepip && python3 -m pip install yq
+COPY --from=crane /ko-app/crane /usr/bin/crane

--- a/cicd/gitlab/env/preprod
+++ b/cicd/gitlab/env/preprod
@@ -1,0 +1,3 @@
+KUBECONTEXT=cmsweb-testbed
+Environment=crab-preprod-tw01
+REST_Instance=preprod

--- a/cicd/gitlab/env/test11
+++ b/cicd/gitlab/env/test11
@@ -1,0 +1,3 @@
+KUBECONTEXT=cmsweb-test11
+Environment=crab-dev-tw02
+REST_Instance=test11

--- a/cicd/gitlab/env/test12
+++ b/cicd/gitlab/env/test12
@@ -1,0 +1,3 @@
+KUBECONTEXT=cmsweb-test12
+Environment=crab-dev-tw03
+REST_Instance=test12

--- a/cicd/gitlab/env/test2
+++ b/cicd/gitlab/env/test2
@@ -1,0 +1,3 @@
+KUBECONTEXT=cmsweb-test2
+Environment=crab-dev-tw01
+REST_Instance=test2

--- a/cicd/gitlab/parseEnv.sh
+++ b/cicd/gitlab/parseEnv.sh
@@ -4,8 +4,7 @@
 # - If match regexp `^pypi-(<env1>|<env2>|...)-.*`, set ENV_NAME to the string
 #   in group. Valide env are preprod/test2/test11/test2
 #   - Allow override ENV_NAME (from push option or WebUI)
-# - If match release tag (e.g., v3.240501), set ENV_NAME to preprod, canoverrid
-#   - Allow override RELEASE_NAME (from push option or WebUI)
+# - If match release tag (e.g., v3.240501), set ENV_NAME to preprod.
 
 set -euo pipefail
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
@@ -19,16 +18,13 @@ if [[ $TAG =~ $VALIDATE_DEV_TAG ]]; then # Do not quote regexp variable here
     IFS='-' read -ra TMPSTR <<< "${TAG}"
     ENV_NAME=${ENV_NAME:-${TMPSTR[1]}}
 elif [[ $TAG =~ $VALIDATE_RELEASE_TAG ]]; then
-    ENV_NAME=${ENV_NAME:-test12}
-    RELEASE_NAME="${RELEASE_NAME:-}-stable"
+    ENV_NAME=${ENV_NAME:-preprod}
 else
     >&2 echo "fail to parse env from string: $TAG"
     exit 1
 fi
 
 echo "Use env: ${ENV_NAME}"
-echo "Release tag: ${RELEASE_NAME:-}"
 cp "${SCRIPT_DIR}/env/${ENV_NAME}" .env
-echo "RELEASE_NAME=${RELEASE_NAME:-}" >> .env
 echo ".env content:"
 cat .env

--- a/cicd/gitlab/parseEnv.sh
+++ b/cicd/gitlab/parseEnv.sh
@@ -1,21 +1,34 @@
 #! /bin/bash
-set -euo pipefail
 
-# assume $CI_COMMIT_TAG is `pypi-`
-TAG=$1
-VALIDATE_TAG='^pypi-(devthree|preprod).*'
-if [[ ! $TAG =~ $VALIDATE_TAG ]]; then
+# Parse deployment env from tag.
+# - If match regexp `^pypi-(<env1>|<env2>|...)-.*`, set ENV_NAME to the string
+#   in group. Valide env are preprod/test2/test11/test2
+#   - Allow override ENV_NAME (from push option or WebUI)
+# - If match release tag (e.g., v3.240501), set ENV_NAME to preprod, canoverrid
+#   - Allow override RELEASE_NAME (from push option or WebUI)
+
+set -euo pipefail
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+TAG="${1}"
+
+# validate tag
+VALIDATE_DEV_TAG='^pypi-(preprod|test2|test11|test12)-.*'
+VALIDATE_RELEASE_TAG='^v3\.[0-9]{6}.*'
+if [[ $TAG =~ $VALIDATE_DEV_TAG ]]; then # Do not quote regexp variable here
+    IFS='-' read -ra TMPSTR <<< "${TAG}"
+    ENV_NAME=${ENV_NAME:-${TMPSTR[1]}}
+elif [[ $TAG =~ $VALIDATE_RELEASE_TAG ]]; then
+    ENV_NAME=${ENV_NAME:-test12}
+    RELEASE_NAME="${RELEASE_NAME:-}-stable"
+else
     >&2 echo "fail to parse env from string: $TAG"
     exit 1
 fi
-IFS='-' read -ra TMPSTR <<< "${TAG}"
-DEV_ENV=${TMPSTR[1]}
 
-echo -n > .env
-if [[ ${DEV_ENV} == 'devthree' ]]; then
-    {
-        echo "KUBECONTEXT=cmsweb-test12"
-        echo "Environment=crab-dev-tw03"
-        echo "REST_Instance=test12"
-    } >> .env
-fi
+echo "Use env: ${ENV_NAME}"
+echo "Release tag: ${RELEASE_NAME:-}"
+cp "${SCRIPT_DIR}/env/${ENV_NAME}" .env
+echo "RELEASE_NAME=${RELEASE_NAME:-}" >> .env
+echo ".env content:"
+cat .env


### PR DESCRIPTION
Complete the https://github.com/dmwm/CRABServer/issues/8401

The release pipeline is based on [build-deploy-test](https://cmscrab.docs.cern.ch/technical/crab-cicd/gitlab/pipelines/build-deploy-test.html) pipeline but has 2 more stages:
- `prepare_release`: changing the version number in source files.
- `tagging_release`: tagging docker images with the release name.

The git tag name must match `v3\.[0-9]{6}.*` regex in order to trigger above jobs.
The final docker image tag, `RELEASE_NAME`, will be `v3.YYMMDD-stable` as we agreed in the issue.

This change also allow to do force release by pushing the git tag name same as above condition (the convention is `v3.YYMMDD__somestring`), provides `RELEASE_NAME=final-tag-name-including-stable` and `SKIP_DEPLOY=t` variable to CI.  