### PR TITLE
add env.sh scripts, monit scripts compatible with pypi containers

### DIFF
--- a/cicd/build/monit-taskworker/Dockerfile
+++ b/cicd/build/monit-taskworker/Dockerfile
@@ -1,7 +1,7 @@
 ARG TAG=latest
 FROM registry.cern.ch/cmscrab/crabtaskworker:${TAG}
 
-RUN source /data/srv/TaskManager/env.sh && \
+RUN source /data/srv/TaskManager/env.sh -c && \
   python3 -m ensurepip && \
   python3 -m pip install pyjwt
 

--- a/cicd/build/monit-taskworker/entrypoint.sh
+++ b/cicd/build/monit-taskworker/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source /data/srv/TaskManager/env.sh
+source /data/srv/TaskManager/env.sh -c
 
 # ensure container has needed mounts
 check_link(){

--- a/cicd/build/monit-taskworker/monit_build.sh
+++ b/cicd/build/monit-taskworker/monit_build.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-## bash ./cicd/build/monit-taskworker/monit_build.sh v3.240111
+## bash ./cicd/build/monit-taskworker/monit_build.sh
 
-TAG=v3.240325
+TAG=pypi-test2-1716833532
 
 docker build \
   --build-arg "TAG=$TAG" \
   --network=host \
-  -t registry.cern.ch/cmscrab/crabtaskworker:$TAG.monittw \
+  -t registry.cern.ch/cmscrab/crabtaskworker:$TAG-monittw \
   ./ \
   -f ./cicd/build/monit-taskworker/Dockerfile
 

--- a/cicd/crabserver_pypi/Dockerfile
+++ b/cicd/crabserver_pypi/Dockerfile
@@ -57,7 +57,13 @@ RUN ls /data/srv/current/ \
 RUN rm /data/manage
 
 # copy running script files
-COPY cicd/crabserver_pypi/run.sh cicd/crabserver_pypi/manage.sh cicd/crabserver_pypi/entrypoint.sh cicd/crabserver_pypi/start.sh cicd/crabserver_pypi/stop.sh /data/
+COPY cicd/crabserver_pypi/run.sh \
+     cicd/crabserver_pypi/manage.sh \
+     cicd/crabserver_pypi/entrypoint.sh \
+     cicd/crabserver_pypi/env.sh \
+     cicd/crabserver_pypi/start.sh \
+     cicd/crabserver_pypi/stop.sh \
+     /data/
 
 # make sure all files is the same user/group as running user
 RUN chown -R 1000:1000 /data && chmod +x /data/*.sh

--- a/cicd/crabserver_pypi/env.sh
+++ b/cicd/crabserver_pypi/env.sh
@@ -1,0 +1,47 @@
+#! /bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+helpFunction() {
+    echo -e "Usage example: ./start.sh -c | -g [-d]"
+    echo -e "\t-c start current crabserver instance"
+    echo -e "\t-g start crabserver instance from GitHub repo"
+    echo -e "\t-d start crabserver in debug mode. Option can be combined with -c or -g"
+    exit 1
+}
+
+DEBUG=''
+MODE=''
+while getopts ":dDcCgGhH" o; do
+    case "${o}" in
+        h|H) helpFunction ;;
+        g|G) MODE="fromGH" ;;
+        c|C) MODE="current" ;;
+        d|D) DEBUG=true ;;
+        * ) echo "Unimplemented option: -$OPTARG"; helpFunction ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if ! [[ -v MODE ]]; then
+  echo "Please set how you want to start crabserver (add -c or -g option)." && helpFunction
+fi
+
+case $MODE in
+    current)
+        # current mode: run current instance
+        PYTHONPATH=/data/srv/current/lib/python/site-packages:${PYTHONPATH:-}
+        ;;
+    fromGH)
+        # private mode: run private instance from GH
+        PYTHONPATH=/data/repos/WMCore/src/python:/data/repos/CRABServer/src/python:${PYTHONPATH:-}
+        ;;
+    *) echo "Unimplemented mode: $MODE\n"; helpFunction ;;
+esac
+
+# passing DEBUG and PYTHONPATH  to ./manage.sh scripts
+export DEBUG
+export PYTHONPATH
+

--- a/cicd/crabserver_pypi/start.sh
+++ b/cicd/crabserver_pypi/start.sh
@@ -4,44 +4,6 @@ set -euo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-helpFunction() {
-    echo -e "Usage example: ./start.sh -c | -g [-d]"
-    echo -e "\t-c start current crabserver instance"
-    echo -e "\t-g start crabserver instance from GitHub repo"
-    echo -e "\t-d start crabserver in debug mode. Option can be combined with -c or -g"
-    exit 1
-}
+source ${SCRIPT_DIR}/env.sh "$@"
 
-DEBUG=''
-MODE=''
-while getopts ":dDcCgGhH" o; do
-    case "${o}" in
-        h|H) helpFunction ;;
-        g|G) MODE="fromGH" ;;
-        c|C) MODE="current" ;;
-        d|D) DEBUG=true ;;
-        * ) echo "Unimplemented option: -$OPTARG"; helpFunction ;;
-    esac
-done
-shift $((OPTIND-1))
-
-if ! [[ -v MODE ]]; then
-  echo "Please set how you want to start crabserver (add -c or -g option)." && helpFunction
-fi
-
-case $MODE in
-    current)
-        # current mode: run current instance
-        PYTHONPATH=/data/srv/current/lib/python/site-packages:${PYTHONPATH:-}
-        ;;
-    fromGH)
-        # private mode: run private instance from GH
-        PYTHONPATH=/data/repos/WMCore/src/python:/data/repos/CRABServer/src/python:${PYTHONPATH:-}
-        ;;
-    *) echo "Unimplemented mode: $MODE\n"; helpFunction ;;
-esac
-
-# passing DEBUG/APP_PATH to ./manage.sh scripts
-export DEBUG
-export PYTHONPATH
 "${SCRIPT_DIR}/manage.sh" start

--- a/cicd/crabtaskworker_pypi/Dockerfile
+++ b/cicd/crabtaskworker_pypi/Dockerfile
@@ -111,6 +111,7 @@ RUN mkdir -p ${WDIR}/srv/Publisher/current \
 # copy process executor scripts
 ## TaskWorker
 COPY cicd/crabtaskworker_pypi/TaskWorker/start.sh \
+     cicd/crabtaskworker_pypi/TaskWorker/env.sh \
      cicd/crabtaskworker_pypi/TaskWorker/stop.sh \
      cicd/crabtaskworker_pypi/TaskWorker/manage.sh \
      cicd/crabtaskworker_pypi/updateDatafiles.sh \

--- a/cicd/crabtaskworker_pypi/Dockerfile
+++ b/cicd/crabtaskworker_pypi/Dockerfile
@@ -119,6 +119,7 @@ COPY cicd/crabtaskworker_pypi/TaskWorker/start.sh \
 
 ## publisher
 COPY cicd/crabtaskworker_pypi/Publisher/start.sh \
+     cicd/crabtaskworker_pypi/Publisher/env.sh \
      cicd/crabtaskworker_pypi/Publisher/stop.sh \
      cicd/crabtaskworker_pypi/Publisher/manage.sh \
      ${WDIR}/srv/Publisher/

--- a/cicd/crabtaskworker_pypi/Publisher/env.sh
+++ b/cicd/crabtaskworker_pypi/Publisher/env.sh
@@ -1,14 +1,15 @@
-##H Usage example: ./env.sh -c | -g [-d]"
-##H     -c start current crabserver instance"
-##H     -g start crabserver instance from GitHub repo"
-##H     -d start crabserver in debug mode. Option can be combined with -c or -g"
+#!/bin/bash
+
+##H Usage example: ./env.sh -c | -g [-d]
+##H     -c start current crabserver instance
+##H     -g start crabserver instance from GitHub repo
+##H     -d start crabserver in debug mode. Option can be combined with -c or -g
 
 set -euo pipefail
 
 helpFunction() {
     grep "^##H" "${0}" | sed -r "s/##H(| )//g"
 }
-
 
 DEBUG=''
 MODE=''
@@ -26,28 +27,19 @@ shift $((OPTIND-1))
 if ! [[ -v MODE ]]; then
   echo "Please set how you want to start crabserver (add -c or -g option)." && helpFunction
 fi
-markmodify_path=/data/srv/current/data_files_modified
 case $MODE in
     current)
         # current mode: run current instance
-        # Refuse to start when data_files directry is modified.
-        if [[ -f ${markmodify_path} ]]; then
-            echo "data_files directory has been modifed."
-            echo "Refuse to start with -c option."
-            exit 1
-        fi
         PYTHONPATH=/data/srv/current/lib/python/site-packages:${PYTHONPATH:-}
         ;;
     fromGH)
         # private mode: run private instance from GH
         PYTHONPATH=/data/repos/CRABServer/src/python:/data/repos/WMCore/src/python:${PYTHONPATH:-}
-        # update runtime (create TaskManagerRun.tar.gz from source)
-        touch ${markmodify_path}
-        ./updateDatafiles.sh
         ;;
     *) echo "Unimplemented mode: $MODE"; exit 1 ;;
 esac
 
-# Export PYTHONPATH and DEBUG to ./manage.sh
+# export PYTHONPATH and DEBUG to ./manage.sh
 export PYTHONPATH
 export DEBUG
+

--- a/cicd/crabtaskworker_pypi/Publisher/start.sh
+++ b/cicd/crabtaskworker_pypi/Publisher/start.sh
@@ -8,39 +8,6 @@
 set -euo pipefail
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-helpFunction() {
-    grep "^##H" "${0}" | sed -r "s/##H(| )//g"
-}
+source ${SCRIPT_DIR}/env.sh "$@"
 
-DEBUG=''
-MODE=''
-while getopts ":dDcCgGhH" o; do
-    case "${o}" in
-        h|H) helpFunction ;;
-        g|G) MODE="fromGH" ;;
-        c|C) MODE="current" ;;
-        d|D) DEBUG=true ;;
-        * ) echo "Unimplemented option: -$OPTARG"; helpFunction; exit 1 ;;
-    esac
-done
-shift $((OPTIND-1))
-
-if ! [[ -v MODE ]]; then
-  echo "Please set how you want to start crabserver (add -c or -g option)." && helpFunction
-fi
-case $MODE in
-    current)
-        # current mode: run current instance
-        PYTHONPATH=/data/srv/current/lib/python/site-packages:${PYTHONPATH:-}
-        ;;
-    fromGH)
-        # private mode: run private instance from GH
-        PYTHONPATH=/data/repos/CRABServer/src/python:/data/repos/WMCore/src/python:${PYTHONPATH:-}
-        ;;
-    *) echo "Unimplemented mode: $MODE"; exit 1;;
-esac
-
-# export APP_PATH and DEBUG to ./manage.sh
-export PYTHONPATH
-export DEBUG
 "${SCRIPT_DIR}/manage.sh" start

--- a/cicd/crabtaskworker_pypi/TaskWorker/env.sh
+++ b/cicd/crabtaskworker_pypi/TaskWorker/env.sh
@@ -1,0 +1,54 @@
+##H Usage example: ./start.sh -c | -g [-d]"
+##H     -c start current crabserver instance"
+##H     -g start crabserver instance from GitHub repo"
+##H     -d start crabserver in debug mode. Option can be combined with -c or -g"
+
+set -euo pipefail
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+helpFunction() {
+    grep "^##H" "${0}" | sed -r "s/##H(| )//g"
+}
+
+
+DEBUG=''
+MODE=''
+while getopts ":dDcCgGhH" o; do
+    case "${o}" in
+        h|H) helpFunction ;;
+        g|G) MODE="fromGH" ;;
+        c|C) MODE="current" ;;
+        d|D) DEBUG=true ;;
+        * ) echo "Unimplemented option: -$OPTARG"; helpFunction; exit 1 ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if ! [[ -v MODE ]]; then
+  echo "Please set how you want to start crabserver (add -c or -g option)." && helpFunction
+fi
+markmodify_path=/data/srv/current/data_files_modified
+case $MODE in
+    current)
+        # current mode: run current instance
+        # Refuse to start when data_files directry is modified.
+        if [[ -f ${markmodify_path} ]]; then
+            echo "data_files directory has been modifed."
+            echo "Refuse to start with -c option."
+            exit 1
+        fi
+        PYTHONPATH=/data/srv/current/lib/python/site-packages:${PYTHONPATH:-}
+        ;;
+    fromGH)
+        # private mode: run private instance from GH
+        PYTHONPATH=/data/repos/CRABServer/src/python:/data/repos/WMCore/src/python:${PYTHONPATH:-}
+        # update runtime (create TaskManagerRun.tar.gz from source)
+        touch ${markmodify_path}
+        ./updateDatafiles.sh
+        ;;
+    *) echo "Unimplemented mode: $MODE"; exit 1 ;;
+esac
+
+# Export PYTHONPATH and DEBUG to ./manage.sh
+export PYTHONPATH
+export DEBUG

--- a/cicd/crabtaskworker_pypi/TaskWorker/start.sh
+++ b/cicd/crabtaskworker_pypi/TaskWorker/start.sh
@@ -1,57 +1,14 @@
 #!/bin/bash
 
-##H Usage example: ./start.sh -c | -g [-d]"
-##H     -c start current crabserver instance"
-##H     -g start crabserver instance from GitHub repo"
-##H     -d start crabserver in debug mode. Option can be combined with -c or -g"
+##H Usage example: ./start.sh -c | -g [-d]
+##H     -c start current crabserver instance
+##H     -g start crabserver instance from GitHub repo
+##H     -d start crabserver in debug mode. Option can be combined with -c or -g
 
 set -euo pipefail
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-helpFunction() {
-    grep "^##H" "${0}" | sed -r "s/##H(| )//g"
-}
+source ${SCRIPT_DIR}/env.sh "$@"
 
-
-DEBUG=''
-MODE=''
-while getopts ":dDcCgGhH" o; do
-    case "${o}" in
-        h|H) helpFunction ;;
-        g|G) MODE="fromGH" ;;
-        c|C) MODE="current" ;;
-        d|D) DEBUG=true ;;
-        * ) echo "Unimplemented option: -$OPTARG"; helpFunction; exit 1 ;;
-    esac
-done
-shift $((OPTIND-1))
-
-if ! [[ -v MODE ]]; then
-  echo "Please set how you want to start crabserver (add -c or -g option)." && helpFunction
-fi
-markmodify_path=/data/srv/current/data_files_modified
-case $MODE in
-    current)
-        # current mode: run current instance
-        # Refuse to start when data_files directry is modified.
-        if [[ -f ${markmodify_path} ]]; then
-            echo "data_files directory has been modifed."
-            echo "Refuse to start with -c option."
-            exit 1
-        fi
-        PYTHONPATH=/data/srv/current/lib/python/site-packages:${PYTHONPATH:-}
-        ;;
-    fromGH)
-        # private mode: run private instance from GH
-        PYTHONPATH=/data/repos/CRABServer/src/python:/data/repos/WMCore/src/python:${PYTHONPATH:-}
-        # update runtime (create TaskManagerRun.tar.gz from source)
-        touch ${markmodify_path}
-        ./updateDatafiles.sh
-        ;;
-    *) echo "Unimplemented mode: $MODE"; exit 1 ;;
-esac
-
-# Export PYTHONPATH and DEBUG to ./manage.sh
-export PYTHONPATH
-export DEBUG
 "${SCRIPT_DIR}/manage.sh" start

--- a/src/script/Container/runContainer.sh
+++ b/src/script/Container/runContainer.sh
@@ -64,15 +64,14 @@ for d in "${dir[@]}"; do
 done
 
 uuid=$(uuidgen)
-if [ -n "${LOGUUID}+1" ]; then
+if [ ! -z "${LOGUUID}" ]; then
     # if LOGUUID is set, then use it
     uuid=${LOGUUID}
 fi
 tmpfile=/tmp/monit-${uuid}.txt
 
 if [[ "${SERVICE}" == TaskWorker_monit_*  ]]; then
-  countrunning=$(docker ps | grep ${SERVICE} | wc -l)
-  if [[ ! $countrunning -eq "0" ]]; then
+  if docker ps | grep ${SERVICE} | wc -l ; then
     msg="There already is a running container for $SERVICE. It is likely stuck. Stopping, removing and then starting again."
     echo $msg
     # writing now that the previous execution of the script is hanging.
@@ -81,7 +80,9 @@ if [[ "${SERVICE}" == TaskWorker_monit_*  ]]; then
     echo $msg > $tmpfile
     docker container stop $SERVICE
   fi
-  docker container rm $SERVICE
+  if docker ps -a | grep ${SERVICE} | wc -l ; then
+    docker container rm $SERVICE
+  fi
 fi
 
 # get os version


### PR DESCRIPTION
This PR 

### status

tested

latest images from this PR built by: https://gitlab.cern.ch/crab3/CRABServer/-/commit/7b433f3566eeda5096a7d462b0a61eb84a5324c4/pipelines

### details

this PR contains the following changes

- added `env.sh` script for crabserver, TW and publishers
- the code for the env.sh script is extracted from the code inserted in `start.sh`. meaning that these new `env.sh` scripts now require `-c` / `-g` option. we can set a default in the future if we want `env.sh` to work without any argument
- runContainer.sh required a couple of changes in if conditions for monitoring scripts to adapt to `set -o pipefail`