### PR TITLE
Fix successful_publication log line

### DIFF
--- a/src/python/Publisher/PublisherMaster.py
+++ b/src/python/Publisher/PublisherMaster.py
@@ -525,7 +525,7 @@ class Master():  # pylint: disable=too-many-instance-attributes
                         logger.info('Taskname %s is OK. Nothing to do', taskname)
                     else:
                         msg = f"Taskname {taskname} is OK. Published {summary['publishedFiles']} "
-                        msg += f"in {summary['publishedBlocks']} blocks."
+                        msg += f"files in {summary['publishedBlocks']} blocks."
                         if summary['nextIterFiles']:
                             msg += f" {summary['nextIterFiles']} files left for next iteration."
                         logger.info(msg)


### PR DESCRIPTION
Fixing https://github.com/dmwm/CRABServer/issues/8445

Current version:
```
2024-05-30 18:10:05,752:INFO:PublisherMaster,531:Taskname 240528_102302:lrygaard_crab_TTZToLLNuNu_LLPnanoAODv1 is OK. Published 2 in 1 blocks.
```

Expected: 
```
2024-05-28 00:20:04,315:INFO:PublisherMaster,731:Taskname 240524_022359:shiyi_crab_SPS_RESONANECE_FEEDDOWN_GEN_v2_n5 is OK. Published 42 files in 1 blocks.
```

The "files" after `summary['publishedFiles']` is missing.