### PR TITLE
schedd.xquery is deprecated. Use schedd.query. Fix #8447

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanSubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanSubmitter.py
@@ -318,7 +318,7 @@ class DagmanSubmitter(TaskAction.TaskAction):
                         '&& (isUndefined(CRAB_Attempt) || CRAB_Attempt == 0)'
 
             self.logger.debug("Duplicate check is querying the schedd: %s", rootConst)
-            results = list(schedd.xquery(rootConst, []))
+            results = list(schedd.query(rootConst, []))
             self.logger.debug("Schedd queried %s", results)
         except Exception as exp:
             msg = "The CRAB server backend was not able to contact the Grid scheduler."

--- a/src/python/TaskWorker/Actions/Recurring/RenewRemoteProxies.py
+++ b/src/python/TaskWorker/Actions/Recurring/RenewRemoteProxies.py
@@ -150,7 +150,7 @@ class CRAB3ProxyRenewer():
         self.logger.debug("Schedd found at %s", schedd_ad['MyAddress'])
         schedd = htcondor.Schedd(schedd_ad)
         self.logger.debug("Querying schedd for CRAB3 tasks.")
-        task_ads = list(schedd.xquery('TaskType =?= "ROOT" && CRAB_HC =!= "True"', QUERY_ATTRS))
+        task_ads = list(schedd.query('TaskType =?= "ROOT" && CRAB_HC =!= "True"', QUERY_ATTRS))
         self.logger.info("There were %d tasks found.", len(task_ads))
         ads = {}
         now = time.time()

--- a/src/script/Monitor/GenerateMONIT.py
+++ b/src/script/Monitor/GenerateMONIT.py
@@ -292,11 +292,11 @@ class CRAB3CreateJson:
                     continue
                 schedd = htcondor.Schedd(scheddAdd)
                 try:
-                    idleDags = list(schedd.xquery(pickSchedulerIdle))
+                    idleDags = list(schedd.query(pickSchedulerIdle))
                 except Exception:
                     idleDags = []
                 try:
-                    runningTPs = list(schedd.xquery(pickLocalRunning))
+                    runningTPs = list(schedd.query(pickLocalRunning))
                 except Exception:
                     runningTPs = []
                 numDagIdle = len(idleDags)


### PR DESCRIPTION
I did not change `src/python/CRABInterface/HTCondorDataWorkflow.py` since calls to HTCondor in the REST will be removed #8338 