### PR TITLE
Fix various CIs 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -123,21 +123,6 @@ build_monit_image:
         - src/python/TaskWorker/__init__.py
       policy: pull
 
-# if release, then tag monit image with `v3.latest.monit`
-tag_monit_latest:
-  rules:
-    - !reference [.default_rules, release]
-  stage: build_docker
-  needs: ["build_monit_image"]
-  image:
-    name: registry.cern.ch/cmscrab/buildtools
-    entrypoint: [""]
-  variables:
-    GIT_STRATEGY: none
-  script:
-    - crane auth login -u ${CMSCRAB_REGISTRY_USER} -p ${CMSCRAB_REGISTRY_PASSWORD} ${CMSCRAB_REGISTRY_URL}
-    - crane cp registry.cern.ch/cmscrab/crabtaskworker:${IMAGE_TAG}.monit registry.cern.ch/cmscrab/crabtaskworker:v3.latest.monit
-
 deploy_server:
   rules:
     - if: $SKIP_DEPLOY
@@ -271,3 +256,17 @@ release_stable:
     - crane auth login -u ${CMSCRAB_REGISTRY_USER} -p ${CMSCRAB_REGISTRY_PASSWORD} ${CMSCRAB_REGISTRY_URL}
     - crane cp registry.cern.ch/cmscrab/crabserver:${IMAGE_TAG} registry.cern.ch/cmscrab/crabserver:${RELEASE_IMAGE_TAG}
     - crane cp registry.cern.ch/cmscrab/crabtaskworker:${IMAGE_TAG} registry.cern.ch/cmscrab/crabtaskworker:${RELEASE_IMAGE_TAG}
+
+# if release, then tag monit image with `v3.latest.monit`
+tag_monit_latest:
+  rules:
+    - !reference [.default_rules, release]
+  stage: tagging_release
+  image:
+    name: registry.cern.ch/cmscrab/buildtools
+    entrypoint: [""]
+  variables:
+    GIT_STRATEGY: none
+  script:
+    - crane auth login -u ${CMSCRAB_REGISTRY_USER} -p ${CMSCRAB_REGISTRY_PASSWORD} ${CMSCRAB_REGISTRY_URL}
+    - crane cp registry.cern.ch/cmscrab/crabtaskworker:${IMAGE_TAG}.monit registry.cern.ch/cmscrab/crabtaskworker:v3.latest.monit

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,6 @@ get_env:
       - .env
     expire_in: 1 week
 
-# use pre_release stage
 set_version_name:
   rules:
     - !reference [.default_rules, release]
@@ -46,11 +45,10 @@ set_version_name:
     name: registry.cern.ch/cmscrab/buildtools
     entrypoint: [""]
   script:
-    - source .env
     - |
-        echo -e "\n__version__ = \"${RELEASE_NAME}\" #Automatically added during build process" >> src/python/TaskWorker/__init__.py;
+        echo -e "\n__version__ = \"${RELEASE_NAME:-$CI_COMMIT_TAG}\" #Automatically added during build process" >> src/python/TaskWorker/__init__.py;
     - |
-        echo -e "\n__version__ = \"${RELEASE_NAME}\" #Automatically added during build process" >> src/python/CRABInterface/__init__.py;
+        echo -e "\n__version__ = \"${RELEASE_NAME:-$CI_COMMIT_TAG}\" #Automatically added during build process" >> src/python/CRABInterface/__init__.py;
   cache:
     - key: $CI_PIPELINE_ID
       paths:
@@ -125,7 +123,7 @@ build_monit_image:
 
 deploy_server:
   rules:
-    - if: $SKIP_DEPLOY
+    - if: $SKIP_DEPLOY || $FORCE_RELEASE
       when: never
     - !reference [.default_rules, default]
     - !reference [.default_rules, release]
@@ -144,7 +142,7 @@ deploy_server:
 
 .deploy_tw_template:
   rules:
-    - if: $SKIP_DEPLOY
+    - if: $SKIP_DEPLOY || $FORCE_RELEASE
       when: never
     - !reference [.default_rules, default]
     - !reference [.default_rules, release]
@@ -180,7 +178,7 @@ task_submission_status_tracking:
     - if: $MANUAL_CI_PIPELINE_ID
       when: never
     - if: $SUBMIT_STATUS_TRACKING
-    - if: $SKIP_DEPLOY
+    - if: $SKIP_DEPLOY || $FORCE_RELEASE
       when: never
     - !reference [.default_rules, default]
     - !reference [.default_rules, release]
@@ -210,7 +208,7 @@ check_test_result:
   rules:
     - if: $SUBMIT_STATUS_TRACKING
     - if: $MANUAL_CI_PIPELINE_ID
-    - if: $SKIP_DEPLOY
+    - if: $SKIP_DEPLOY || $FORCE_RELEASE
       when: never
     - !reference [.default_rules, default]
     - !reference [.default_rules, release]
@@ -252,7 +250,7 @@ release_stable:
   variables:
     GIT_STRATEGY: none
   script:
-    - export RELEASE_IMAGE_TAG=${RELEASE_NAME:-${CI_COMMIT_TAG}-stable}
+    - export RELEASE_IMAGE_TAG=${RELEASE_NAME:-${CI_COMMIT_TAG}}-stable
     - crane auth login -u ${CMSCRAB_REGISTRY_USER} -p ${CMSCRAB_REGISTRY_PASSWORD} ${CMSCRAB_REGISTRY_URL}
     - crane cp registry.cern.ch/cmscrab/crabserver:${IMAGE_TAG} registry.cern.ch/cmscrab/crabserver:${RELEASE_IMAGE_TAG}
     - crane cp registry.cern.ch/cmscrab/crabtaskworker:${IMAGE_TAG} registry.cern.ch/cmscrab/crabtaskworker:${RELEASE_IMAGE_TAG}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -145,7 +145,6 @@ deploy_server:
     - !reference [.default_rules, default]
     - !reference [.default_rules, release]
   stage: deploy
-  needs: ["build_rest_image"]
   image:
     name: registry.cern.ch/cmscrab/buildtools
     entrypoint: [""]

--- a/cicd/gitlab/parseEnv.sh
+++ b/cicd/gitlab/parseEnv.sh
@@ -3,8 +3,8 @@
 # Parse deployment env from tag.
 # - If match regexp `^pypi-(<env1>|<env2>|...)-.*`, set ENV_NAME to the string
 #   in group. Valide env are preprod/test2/test11/test2
-#   - Allow override ENV_NAME (from push option or WebUI)
 # - If match release tag (e.g., v3.240501), set ENV_NAME to preprod.
+# Also allow override ENV_NAME (from push option or WebUI)
 
 set -euo pipefail
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
@@ -12,12 +12,12 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 TAG="${1}"
 
 # validate tag
-VALIDATE_DEV_TAG='^pypi-(preprod|test2|test11|test12)-.*'
-VALIDATE_RELEASE_TAG='^v3\.[0-9]{6}.*'
-if [[ $TAG =~ $VALIDATE_DEV_TAG ]]; then # Do not quote regexp variable here
+REGEX_DEV_TAG='^pypi-(preprod|test2|test11|test12)-.*'
+REGEX_RELEASE_TAG='^v3\.[0-9]{6}.*'
+if [[ $TAG =~ $REGEX_DEV_TAG ]]; then # Do not quote regexp variable here
     IFS='-' read -ra TMPSTR <<< "${TAG}"
     ENV_NAME=${ENV_NAME:-${TMPSTR[1]}}
-elif [[ $TAG =~ $VALIDATE_RELEASE_TAG ]]; then
+elif [[ $TAG =~ $REGEX_RELEASE_TAG ]]; then
     ENV_NAME=${ENV_NAME:-preprod}
 else
     >&2 echo "fail to parse env from string: $TAG"


### PR DESCRIPTION
1. Fix error in https://gitlab.cern.ch/crab3/CRABServer/-/jobs/40238792
    CI will not pull artifacts for a job if job does not specify "needs:" from job that created the artifact (I could not find the citation, but this is what I understand from working with Gitlab-CI).
2. Move `tag_monit_latest` job to `tagging_release` stage instead of same stage as build. Avoid blocking other stage if bug arise and it would be better to let it passing validation first.
3. Fix force release, CI code is already there but
    - Add `FORCE_RELEASE` variable to skip deploy and test, which is currently equivalent to `SKIP_DEPLOY` but more understandable.
    - Fix when we specify `RELEASE_NAME`, it will not suffix with `-stable`.
    - Fix in `set_version_name` job, default value of release name is the tag name. 