### PR TITLE
Publisher rucio to check block completion 8491

### DIFF
--- a/src/python/Publisher/PublisherMasterRucio.py
+++ b/src/python/Publisher/PublisherMasterRucio.py
@@ -259,7 +259,7 @@ class Master():  # pylint: disable=too-many-instance-attributes
         # a change in Publisher/stop.sh otherwise that script will break
         self.logger.info("Next cycle will start at %s", newStartTime)
 
-    def startSlave(self, task):  # pylint: disable=too-many-branches
+    def startSlave(self, task):  # pylint: disable=too-many-branches, too-many-locals
         """
         start a slave process to deal with publication for a single task
         :param task: one tuple describing  a task as returned by  active_tasks()
@@ -281,7 +281,7 @@ class Master():  # pylint: disable=too-many-instance-attributes
         for fileDict in task['fileDicts']:
             if fileDict['block_complete'] == 'OK':
                 blockName = fileDict['dbs_blockname']
-                if not blockName in numAcquiredFilesPerBlock:
+                if blockName not in numAcquiredFilesPerBlock:
                     numAcquiredFilesPerBlock[blockName] = 0
                 numAcquiredFilesPerBlock[blockName] += 1
             blocksToPublish.add(blockName)
@@ -294,9 +294,9 @@ class Master():  # pylint: disable=too-many-instance-attributes
             # beware group scope
             destLfnParts = task['fileDicts'][0]['destination_lfn'].split('/')
             if destLfnParts[2] == 'group':
-                groupName =  destLfnParts[4]
+                groupName = destLfnParts[4]
                 rucioScope = f"group.{groupName}"
-            countOfFilesInRucioDataset =  len(list(self.rucio.list_content(scope=rucioScope, name=blockName)))
+            countOfFilesInRucioDataset = len(list(self.rucio.list_content(scope=rucioScope, name=blockName)))
             if countOfAcquiredFilesInBlock != countOfFilesInRucioDataset:
                 # wait until we have acquired all files which Rucio says are in this block
                 blocksToPublish.remove(blockName)
@@ -314,9 +314,7 @@ class Master():  # pylint: disable=too-many-instance-attributes
                     lfnsToPublish.append(fileDict['destination_lfn'])
             FilesInfoFromTBDInBlock[blockName] = filesInfo
 
-
-
-        print(f"Prepare publish info for {len(blocksToPublish)} blocks")
+        logger.info(f"Prepare publish info for {len(blocksToPublish)} blocks")
 
         # so far so good
 

--- a/src/python/Publisher/PublisherMasterRucio.py
+++ b/src/python/Publisher/PublisherMasterRucio.py
@@ -21,6 +21,7 @@ from WMCore.Configuration import loadConfigurationFile
 
 from ServerUtilities import encodeRequest, oracleOutputMapping, executeCommand
 from TaskWorker.WorkerUtilities import getCrabserver
+from RucioUtils import getNativeRucioClient
 
 from PublisherUtils import createLogdir, setRootLogger, setSlaveLogger, logVersionAndConfig
 from PublisherUtils import getInfoFromFMD, markFailed
@@ -65,6 +66,9 @@ class Master():  # pylint: disable=too-many-instance-attributes
 
         # CRAB REST API
         self.crabServer = getCrabserver(restConfig=config.REST, agentName='CRABPublisher', logger=self.logger)
+
+        # Rucio Client
+        self.rucio = getNativeRucioClient(config=config.Rucio, logger=self.logger)
 
         self.startTime = time.time()
 

--- a/src/python/RucioUtils.py
+++ b/src/python/RucioUtils.py
@@ -26,14 +26,21 @@ def getNativeRucioClient(config=None, logger=None):
     cl = logging.getLogger('charset_normalizer')
     cl.setLevel(logging.ERROR)
 
-    rucioCert = getattr(config.Services, "Rucio_cert", config.TaskWorker.cmscert)
-    rucioKey = getattr(config.Services, "Rucio_key", config.TaskWorker.cmskey)
+    # allow for both old and new configuration style
+
+    if getattr(config, 'Services', None):
+        rucioConfig = config.Services
+    else:
+        rucioConfig = config
+
+    rucioCert = getattr(rucioConfig, "Rucio_cert")
+    rucioKey = getattr(rucioConfig, "Rucio_key")
     logger.debug("Using cert [%s]\n and key [%s] for rucio client.", rucioCert, rucioKey)
     nativeClient = Client(
-        rucio_host=config.Services.Rucio_host,
-        auth_host=config.Services.Rucio_authUrl,
-        ca_cert=config.Services.Rucio_caPath,
-        account=config.Services.Rucio_account,
+        rucio_host=rucioConfig.Rucio_host,
+        auth_host=rucioConfig.Rucio_authUrl,
+        ca_cert=rucioConfig.Rucio_caPath,
+        account=rucioConfig.Rucio_account,
         creds={"client_cert": rucioCert, "client_key": rucioKey},
         auth_type='x509',
         logger=rucioLogger

--- a/src/python/RucioUtils.py
+++ b/src/python/RucioUtils.py
@@ -5,6 +5,7 @@ from TaskWorker.WorkerExceptions import TaskWorkerException
 from rucio.client import Client
 from rucio.common.exception import RSENotFound
 
+
 def getNativeRucioClient(config=None, logger=None):
     """
     instantiates a Rucio python Client for use in CRAB TaskWorker


### PR DESCRIPTION
initial implementation.
* If a Rucio group scope was used, code here uses the destination LFN to figure it out. After #8525 we will pick scope directly from CRAB DataBase.
* I have also introduced the `config.RUCIO` section in the configuration to make it easy to instantiate the Rucio client. I will add it to the PublisherConfig template too: https://gitlab.cern.ch/ai/it-puppet-hostgroup-vocmsglidein/-/merge_requests/215