### PR TITLE
store also scope in tm_dbs_blockname. Quick fix for #8525

### DIFF
--- a/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
+++ b/src/python/ASO/Rucio/Actions/MonitorLockStatus.py
@@ -1,3 +1,4 @@
+# pylint: disable=logging-fstring-interpolation
 """
 Monitoring replicas' transfer status and adding them to publish the container.
 """
@@ -261,11 +262,12 @@ class MonitorLockStatus:
         # TODO: may need to refactor later along with rest and publisher part
         # This can be optimize to single REST API call together with updateTransfers's subresources
         num = len(fileDocs)
+        scope = self.transfer.rucioScope
         restFileDoc = {
             'asoworker': 'rucio',
             'list_of_ids': [x['id'] for x in fileDocs],
             'list_of_transfer_state': ['DONE']*num,
-            'list_of_dbs_blockname': [x['dataset'] for x in fileDocs],
+            'list_of_dbs_blockname': [f"{scope}:{x['dataset']}" for x in fileDocs],
             'list_of_block_complete': [x['blockcomplete'] for x in fileDocs],
             'list_of_fts_instance': ['https://fts3-cms.cern.ch:8446/']*num,
             'list_of_failure_reason': None, # omit


### PR DESCRIPTION
quick and dirty fix which appears to work by looking at FileTransfersDB  content in e.g. https://cmsweb-test2.cern.ch/crabserver/ui/task/240626_200922%3Abelforte_crab_rucio_transfers_20240626_220918
 and https://cmsweb-test2.cern.ch/crabserver/ui/task/240626_203056%3Abelforte_crab_rucio_transfers_group_20240626_223054

A more elegant solution is beyond what I can do now and would require to deepen my understanding of ASO/Rucio first see https://github.com/dmwm/CRABServer/issues/8525#issuecomment-2192593099
