### PR TITLE
print time zone in logs and when next test iteration will be

### DIFF
--- a/cicd/gitlab/executeStatusTracking.sh
+++ b/cicd/gitlab/executeStatusTracking.sh
@@ -46,7 +46,7 @@ fi
 echo -e """**Test:** Task Submission Status Tracking\n\
 **Result:** ${TEST_RESULT}\n\
 **Attempt:** ${RETRY} out of ${RETRY_MAX}. ${MESSAGE}\n\
-**Finished at:** `(date '+%Y-%m-%d %H:%M:%S')`\n\
+**Finished at:** `(date '+%Y-%m-%d %H:%M:%S %Z')`\n\
 """
 
 echo -e "\`\`\`\n`cat result`\n\`\`\`" || true

--- a/cicd/gitlab/executeTests.sh
+++ b/cicd/gitlab/executeTests.sh
@@ -57,5 +57,5 @@ else
             echo -e "Task submission for **${test}** successfully ended.\n\`\`\`\n`cat "$path"`\n\`\`\`\n"
         fi
     done
-    echo -e "Finished at: `(date '+%Y-%m-%d %H:%M:%S')`\n"
+    echo -e "Finished at: `(date '+%Y-%m-%d %H:%M:%S %Z')`\n"
 fi

--- a/cicd/gitlab/retry.sh
+++ b/cicd/gitlab/retry.sh
@@ -19,7 +19,8 @@ while true; do
                 echo "Reach max retry count: $RETRY"
                 exit 1
             fi
-            echo "Sleep for ${RETRY_SLEEP_SECONDS} seconds."
+            echo -n "Sleep for ${RETRY_SLEEP_SECONDS} seconds."
+	    echo " Until " `date -d "now + ${RETRY_SLEEP_SECONDS} seconds" +"%H:%M %Z"` 
             sleep "${RETRY_SLEEP_SECONDS}"
             RETRY=$((RETRY + 1))
             continue


### PR DESCRIPTION
I think that pipeline logs are in UTC. Usually we have all logs in local time zone. So I often get confused and worry because I can't match messages to task logs in other places etc. So I would like to add time zone whenever a data is printed.

I also added that when in the retry loop it prints when it will run next time, I am not good at making the addition myself and I need to scroll up and look for last date, which is not convenient.

Check whether you like this.
testing in https://gitlab.cern.ch/crab3/CRABServer/-/pipelines/7653955