### PR TITLE
Fix TRACE in script and reduce verbosity of updateDatafiles.sh

### DIFF
--- a/cicd/crabtaskworker_pypi/TaskWorker/manage.sh
+++ b/cicd/crabtaskworker_pypi/TaskWorker/manage.sh
@@ -16,6 +16,10 @@
 ##H   - PYTHONPATH: inherit from ./start.sh
 
 set -euo pipefail
+if [[ -n ${TRACE+x} ]]; then
+    set -x
+    export TRACE
+fi
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 ## some variable use in start_srv

--- a/cicd/crabtaskworker_pypi/buildDatafiles.sh
+++ b/cicd/crabtaskworker_pypi/buildDatafiles.sh
@@ -12,11 +12,10 @@
 # CRABSERVERDIR=./ WMCOREDIR=../WMCore TRACE=true bash cicd/crabtaskworker/buildDatafiles.sh
 
 set -euo pipefail
-TRACE=${TRACE:-}
-if [[ -n $TRACE ]]; then
-    set +x
+if [[ -n ${TRACE+x} ]]; then
+    set -x
+    export TRACE
 fi
-
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 RUNTIME_WORKDIR="${RUNTIME_WORKDIR:-./make_runtime}"

--- a/cicd/crabtaskworker_pypi/updateDatafiles.sh
+++ b/cicd/crabtaskworker_pypi/updateDatafiles.sh
@@ -5,7 +5,10 @@
 # See description of variables in cicd/crabtaskworker_pypi/buildDataFiles.sh
 
 set -euo pipefail
-#set -x
+if [[ -n ${TRACE+x} ]]; then
+    set -x
+    export TRACE
+fi
 
 # use "convention path" of repos to build datafiles inside /data/build
 DATAFILES_WORKDIR=/data/build/datafiles_dir
@@ -22,7 +25,14 @@ export DATAFILES_WORKDIR
 export RUNTIME_WORKDIR
 export WMCOREDIR
 export CRABSERVERDIR
-bash cicd/crabtaskworker_pypi/buildDatafiles.sh
+# the buildDatafiles is too verbose, pipe it to file instead if not TRACE
+if [[ -n ${TRACE+x} ]]; then
+    bash cicd/crabtaskworker_pypi/buildDatafiles.sh
+else
+    logpath=/tmp/buildDatafiles-$(date +"%Y%m%d-%H%M%S").log
+    bash cicd/crabtaskworker_pypi/buildDatafiles.sh &> "${logpath}"
+    echo "buildDatafiles.sh log path: ${logpath}"
+fi
 popd
 
 # copy new data files to data files path


### PR DESCRIPTION
Especially when execute `buildDatafiles.sh`. 
Now much better:

![Screenshot from 2024-06-28 18-04-44](https://github.com/dmwm/CRABServer/assets/2346664/ff031d83-e19d-4c04-bcb8-22167856b12f)

