### PR TITLE
PyPI images use local timezone

### DIFF
--- a/cicd/crabserver_pypi/Dockerfile
+++ b/cicd/crabserver_pypi/Dockerfile
@@ -17,6 +17,9 @@ RUN apt-get update \
     && apt-get install -y tini \
     && apt-get clean all
 
+# local timezone (hardcode)
+RUN ln -sf /usr/share/zoneinfo/Europe/Zurich /etc/localtime
+
 # Copy CERN tnsnames.ora
 COPY --from=tnsnames /etc/tnsnames.ora /etc/tnsnames.ora
 

--- a/cicd/crabtaskworker_pypi/Dockerfile
+++ b/cicd/crabtaskworker_pypi/Dockerfile
@@ -60,6 +60,9 @@ RUN apt-get update \
     && apt-get install -y tini git zip voms-clients-java fd-find ripgrep libsasl2-dev python3-dev libldap-dev libssl-dev \
     && apt-get clean all
 
+# local timezone (hardcode)
+RUN ln -sf /usr/share/zoneinfo/Europe/Zurich /etc/localtime
+
 # prepare build
 RUN mkdir /build
 WORKDIR /build


### PR DESCRIPTION
Fix https://github.com/dmwm/CRABServer/issues/8537
Tested: https://gitlab.cern.ch/crab3/CRABServer/-/pipelines/7719275

Note that I have hardcoded it to CERN timezone (`Europe/Zurich`).