### PR TITLE
[CI] Support CRABClient GH

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,9 +194,8 @@ task_submission_status_tracking:
   script:
     - source .env
     - export X509_USER_PROXY=$(cicd/gitlab/credFile.sh $X509_USER_PROXY x509)
-    - export CRABClient_version=prod
-    - export CRABServer_tag=HEAD
-    - export REST_Instance # from .env
+    - export CRABClient_version  # from .env
+    - export REST_Instance  # from .env
     - export CMSSW_release=CMSSW_13_0_2
     - export Task_Submission_Status_Tracking=true
     - bash -x cicd/gitlab/executeTests.sh
@@ -224,11 +223,11 @@ check_test_result:
   script:
     - source .env
     - export X509_USER_PROXY=$(cicd/gitlab/credFile.sh $X509_USER_PROXY x509)
-    - export REST_Instance
+    - export REST_Instance  # from .env
+    - export CRABClient_version  # from .env
     - export CMSSW_release=CMSSW_13_0_2
     - export SCRAM_ARCH=el8_amd64_gcc11
     - export Check_Publication_Status=Yes
-    - export CRABClient_version=prod
     - echo ${MANUAL_CI_PIPELINE_ID}
     # manual task name
     - |

--- a/cicd/gitlab/env/preprod
+++ b/cicd/gitlab/env/preprod
@@ -1,3 +1,4 @@
 KUBECONTEXT=cmsweb-testbed
 Environment=crab-preprod-tw01
 REST_Instance=preprod
+CRABClient_version=prod

--- a/cicd/gitlab/env/test11
+++ b/cicd/gitlab/env/test11
@@ -1,3 +1,4 @@
 KUBECONTEXT=cmsweb-test11
 Environment=crab-dev-tw02
 REST_Instance=test11
+CRABClient_version=prod

--- a/cicd/gitlab/env/test12
+++ b/cicd/gitlab/env/test12
@@ -1,3 +1,4 @@
 KUBECONTEXT=cmsweb-test12
 Environment=crab-dev-tw03
 REST_Instance=test12
+CRABClient_version=prod

--- a/cicd/gitlab/env/test2
+++ b/cicd/gitlab/env/test2
@@ -1,3 +1,4 @@
 KUBECONTEXT=cmsweb-test2
 Environment=crab-dev-tw01
 REST_Instance=test2
+CRABClient_version=prod

--- a/cicd/gitlab/setupCRABClient.sh
+++ b/cicd/gitlab/setupCRABClient.sh
@@ -6,10 +6,10 @@ set -euo pipefail
 
 #Script can be used to setup CRABClient:
 # 1. dev - CRABClient from Intergration Build (IB);
-# 2. GH - CRABClient from CRABClient GH repository master branch. This option requires to set which CRABServer tag to use;
+# 2. GH - CRABClient from CRABClient GH repository master branch.
 # 3. prod - production CRABClient from cvmfs;
-# Variables ${SCRAM_ARCH}, ${CMSSW_release}, ${CRABServer_tag}, ${CRABClient_version}
-# comes from Jenkins job CRABServer_ExecuteTests configuration.
+# Variables ${SCRAM_ARCH}, ${CMSSW_release}, ${CRABClient_version}
+# comes from caller/CI variables
 
 # ignore all bash fail from script from /cvmfs/cms-ib.cern.ch
 set +euo pipefail
@@ -37,51 +37,36 @@ if echo ${CMSSW_release} | grep -q CMSSW_7; then
   fi
 fi
 
-#cd ${WORK_DIR}
-#[ ! -d 'CRABServer' ] && git clone git@github.com:dmwm/CRABServer
-
 case $CRABClient_version in
-  #dev)
-  #  source /cvmfs/cms-ib.cern.ch/latest/common/crab-setup.sh dev
-  #  alias crab='crab-dev'
-  #  ;;
-  #GH)
-  #  set -euo pipefail
-  #  #cd CRABServer; git checkout ${CRABServer_tag}; cd ..
-  #  rm -rf CRABClient
-  #  git clone https://github.com/${CRABCLIENT_FORK}/CRABClient CRABClient -b $CRABCLIENT_TAG
-  #  cp src/python/ServerUtilities.py CRABClient/src/python/
-  #  cp src/python/RESTInteractions.py CRABClient/src/python/
-  #  #$ghprbPullId is used for PR testing. If this variable is set, that means
-  #  #we need to run test against specific commit
-  #  #if [ ! -z "$ghprbPullId" ]; then
-  #  #	cd CRABClient
-  #  #	git fetch origin pull/${ghprbPullId}/merge:PR_MERGE
-  #  #	export COMMIT=`git rev-parse "PR_MERGE^{commit}"`
-  #  #	git checkout -f ${COMMIT}
-  #  #	cd ..
-  #  #fi
-  #  cd ${WORK_DIR}
-  #  GitDir=${WORK_DIR}
-  #
-  #  MY_CRAB=${GitDir}/CRABClient
-  #
-  #  # install the fake WMCore dependency for CRABClient, taking inspiration from
-  #  # https://github.com/cms-sw/cmsdist/blob/b38a4b3339f12706513917153a2ec6cdcb23741c/crab-build.file#L37
-  #  mkdir -p ${GitDir}/WMCore/src/python/WMCore
-  #  touch ${GitDir}/WMCore/src/python/__init__.py
-  #  touch ${GitDir}/WMCore/src/python/WMCore/__init__.py
-  #  cp ${GitDir}/CRABClient/src/python/CRABClient/WMCoreConfiguration.py ${GitDir}/WMCore/src/python/WMCore/Configuration.py
-  #
-  #  export PYTHONPATH=${MY_CRAB}/src/python:${PYTHONPATH:-}
-  #  export PYTHONPATH=${GitDir}/WMCore/src/python:$PYTHONPATH
-  #
-  #  export PATH=${MY_CRAB}/bin:$PATH
-  #  set +euo pipefail
-  #  source ${MY_CRAB}/etc/crab-bash-completion.sh
-  #  ;;
+  dev)
+    set +euo pipefail
+    source /cvmfs/cms-ib.cern.ch/latest/common/crab-setup.sh dev
+    set -euo pipefail
+    alias crab='crab-dev'
+    ;;
+  GH)
+    # TODO: specific fork/commit of crabclient repo still not support
+    MY_CRAB=${PWD}/CRABClient
+    rm -rf CRABClient
+    git clone https://github.com/dmwm/CRABClient ${MY_CRAB} -b master
+    cp ${ROOT_DIR}/src/python/ServerUtilities.py ${MY_CRAB}/src/python/
+    cp ${ROOT_DIR}/src/python/RESTInteractions.py ${MY_CRAB}/src/python/
+    # install the fake WMCore dependency for CRABClient, taking inspiration from
+    # https://github.com/cms-sw/cmsdist/blob/b38a4b3339f12706513917153a2ec6cdcb23741c/crab-build.file#L37
+    mkdir -p ${MY_CRAB}/WMCore/src/python/WMCore
+    touch ${MY_CRAB}/WMCore/src/python/__init__.py
+    touch ${MY_CRAB}/WMCore/src/python/WMCore/__init__.py
+    cp ${MY_CRAB}/src/python/CRABClient/WMCoreConfiguration.py ${MY_CRAB}/WMCore/src/python/WMCore/Configuration.py
+
+    export PYTHONPATH=${MY_CRAB}/src/python:${PYTHONPATH:-}
+    export PYTHONPATH=${MY_CRAB}/WMCore/src/python:$PYTHONPATH
+    export PATH=${MY_CRAB}/bin:$PATH
+    source ${MY_CRAB}/etc/crab-bash-completion.sh
+    ;;
   prod)
+    set +euo pipefail
 	source /cvmfs/cms.cern.ch/common/crab-setup.sh prod
+    set -euo pipefail
 esac
 
 #cd "${CURRENT_DIR}"

--- a/cicd/gitlab/st/test_executeTestsStatusTracking.sh
+++ b/cicd/gitlab/st/test_executeTestsStatusTracking.sh
@@ -15,7 +15,6 @@ export REST_Instance=test12
 # ci
 export X509_USER_PROXY="$(cicd/gitlab/credFile.sh $X509_USER_PROXY)"
 export CRABClient_version=prod
-export CRABServer_tag=HEAD
 export REST_Instance # from .env
 export CMSSW_release=CMSSW_13_0_2
 export Task_Submission_Status_Tracking=true


### PR DESCRIPTION
This also allows us to use ServerUtility.py from the commits that trigger the pipeline.

Thanks @mapellidario for help me on this. It is easier than I thought.