### PR TITLE
[CI] Add Vijay dev env

### DIFF
--- a/cicd/gitlab/env/test1
+++ b/cicd/gitlab/env/test1
@@ -1,0 +1,4 @@
+KUBECONTEXT=cmsweb-test1
+Environment=crab-dev-tw05
+REST_Instance=test1
+CRABClient_version=GH

--- a/cicd/gitlab/parseEnv.sh
+++ b/cicd/gitlab/parseEnv.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 TAG="${1}"
 
 # validate tag
-REGEX_DEV_TAG='^pypi-(preprod|test2|test11|test12)-.*'
+REGEX_DEV_TAG='^pypi-(preprod|test2|test11|test12|test1)-.*'
 REGEX_RELEASE_TAG='^v3\.[0-9]{6}.*'
 if [[ $TAG =~ $REGEX_DEV_TAG ]]; then # Do not quote regexp variable here
     IFS='-' read -ra TMPSTR <<< "${TAG}"

--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -47,7 +47,8 @@ FILE_MEMORY_LIMIT = 512 * 1024
 SERVICE_INSTANCES = {'prod': {'restHost': 'cmsweb.cern.ch', 'dbInstance': 'prod'},
                      'preprod': {'restHost': 'cmsweb-testbed.cern.ch', 'dbInstance': 'preprod'},
                      'auth': {'restHost': 'cmsweb-auth.cern.ch', 'dbInstance': 'preprod'},
-                     'test1': {'restHost': 'cmsweb-test1.cern.ch', 'dbInstance': 'dev'},
+                     # Vijay's tmp env
+                     'test1': {'restHost': 'cmsweb-test1.cern.ch', 'dbInstance': 'devfour'},
                      'test2': {'restHost': 'cmsweb-test2.cern.ch', 'dbInstance': 'dev'},
                      'test3': {'restHost': 'cmsweb-test3.cern.ch', 'dbInstance': 'dev'},
                      'test4': {'restHost': 'cmsweb-test4.cern.ch', 'dbInstance': 'dev'},


### PR DESCRIPTION
Hi @belforte @mapellidario ,

I modified `test1` in ServerUtility.py to point to Vijay dev env (cmsweb-test1/devfour/tw05).
This is now possible without rebuilding crabclient because https://github.com/dmwm/CRABServer/pull/8554.

What do you think?

cc: @aspiringmind-code 