### PR TITLE
Small fixes for rucio publisher

### DIFF
--- a/src/python/Publisher/PublisherMasterRucio.py
+++ b/src/python/Publisher/PublisherMasterRucio.py
@@ -378,8 +378,7 @@ class Master():  # pylint: disable=too-many-instance-attributes
 
             if toFail:
                 logger.info('Did not find useful metadata for %d files. Mark as failed', len(toFail))
-                nMarked = self.markAsFailed(lfns=toFail, reason='FileMetadata not found')
-                logger.info('marked %d files as Failed', nMarked)
+                self.markAsFailed(lfns=toFail, reason='FileMetadata not found')
 
             # call taskPublishRucio
             self.runTaskPublish(workflow, logger)
@@ -393,9 +392,8 @@ class Master():  # pylint: disable=too-many-instance-attributes
         """
         handy wrapper for PublisherUtils/markFailed
         """
-        nMarked = markFailed(files=lfns, crabserver=self.crabserver, failureReason=reason,
+        markFailed(files=lfns, crabserver=self.crabserver, failureReason=reason,
                              asoworker=self.config.asoworker, logger=self.logger)
-        return nMarked
 
     def pollInterval(self):
         """

--- a/src/python/Publisher/PublisherMasterRucio.py
+++ b/src/python/Publisher/PublisherMasterRucio.py
@@ -1,4 +1,4 @@
-# pylint: disable=invalid-name  # have a lot of snake_case varaibles here from "old times"
+# pylint: disable=invalid-name  # have a lot of snake_case variables here from "old times"
 
 """
 Here's the algorithm
@@ -314,7 +314,7 @@ class Master():  # pylint: disable=too-many-instance-attributes
                     lfnsToPublish.append(fileDict['destination_lfn'])
             FilesInfoFromTBDInBlock[blockName] = filesInfo
 
-        logger.info(f"Prepare publish info for {len(blocksToPublish)} blocks")
+        logger.info("Prepare publish info for %s blocks", len(blocksToPublish))
 
         # so far so good
 

--- a/src/python/Publisher/PublisherMasterRucio.py
+++ b/src/python/Publisher/PublisherMasterRucio.py
@@ -392,7 +392,7 @@ class Master():  # pylint: disable=too-many-instance-attributes
         """
         handy wrapper for PublisherUtils/markFailed
         """
-        markFailed(files=lfns, crabserver=self.crabserver, failureReason=reason,
+        markFailed(files=lfns, crabServer=self.crabserver, failureReason=reason,
                              asoworker=self.config.asoworker, logger=self.logger)
 
     def pollInterval(self):

--- a/src/python/Publisher/TaskPublish.py
+++ b/src/python/Publisher/TaskPublish.py
@@ -29,7 +29,8 @@ def publishInDBS3(config, taskname, verbose, console):
     """
     # a few dictionaries to pass global information around all these functions
     # initialized here to None simply as documentation
-    log = {'logger': None, 'logdir': None, 'logTaskDir': None, 'taskFilesDir': None}
+    log = {'logger': None, 'logdir': None, 'logTaskDir': None,
+           'taskFilesDir': None, 'migrationLogDir': None}
     DBSApis = {'source': None, 'destRead': None, 'destWrite': None, 'global': None, 'migrate': None}
     nothingToDo = {}  # a pre-filled SummaryFile in case of no useful input or errors
 

--- a/src/python/Publisher/TaskPublishRucio.py
+++ b/src/python/Publisher/TaskPublishRucio.py
@@ -30,7 +30,8 @@ def publishInDBS3(config, taskname, verbose, console):  # pylint: disable=too-ma
     """
     # a few dictionaries to pass global information around all these functions
     # initialized here to None simply as documentation
-    log = {'logger': None, 'logdir': None, 'logTaskDir': None, 'taskFilesDir': None}
+    log = {'logger': None, 'logdir': None, 'logTaskDir': None,
+           'taskFilesDir': None, 'migrationLogDir': None}
     DBSApis = {'source': None, 'destRead': None, 'destWrite': None, 'global': None, 'migrate': None}
     nothingToDo = {}  # a pre-filled SummaryFile in case of no useful input or errors
 
@@ -115,7 +116,8 @@ def publishInDBS3(config, taskname, verbose, console):  # pylint: disable=too-ma
                     statusCode, failureMsg = migrateByBlockDBS3(
                         taskname,
                         DBSApis['migrate'], DBSApis['destRead'], DBSApis['global'],
-                        globalParentBlocks, logger=logger, verbose=verbose)
+                        globalParentBlocks,
+                        log['migrationLogDir'], logger=logger, verbose=verbose)
                 except Exception as ex:
                     logger.exception('Exception raised inside migrateByBlockDBS3\n%s', ex)
                     statusCode = 1


### PR DESCRIPTION
this PR addresses a couple of bugs and a pylint complain found by pylint when running on PR https://github.com/dmwm/CRABServer/pull/8562

```text
Warnings from pylint by file and severity

    src/python/Publisher/Main.py
    src/python/Publisher/PublisherMasterRucio.py
        E1111, line 396 in Master.markAsFailed: Assigning result of a function call, where the function has no return
        E1123, line 396 in Master.markAsFailed: Unexpected keyword argument 'crabserver' in function call
        W1203, line 317 in Master.startSlave: Use lazy % formatting in logging functions
    src/python/Publisher/RunPublisher.py
    src/python/Publisher/TaskPublishRucio.py
        E1120, line 115 in publishInDBS3.publishOneBlockInDBS: No value for argument 'migLogDir' in function call
```