### PR TITLE
pypi - add filebeat to TW image

### DIFF
--- a/cicd/crabtaskworker_pypi/Dockerfile
+++ b/cicd/crabtaskworker_pypi/Dockerfile
@@ -60,6 +60,13 @@ RUN apt-get update \
     && apt-get install -y tini git zip voms-clients-java fd-find ripgrep libsasl2-dev python3-dev libldap-dev libssl-dev \
     && apt-get clean all
 
+# install filebeat
+RUN wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add  - && \
+  apt-get install apt-transport-https && \
+  echo "deb https://artifacts.elastic.co/packages/oss-8.x/apt stable main" |  tee -a /etc/apt/sources.list.d/elastic-8.x.list && \
+  apt-get update && apt-get install filebeat && \
+  apt-get clean all
+
 # local timezone (hardcode)
 RUN ln -sf /usr/share/zoneinfo/Europe/Zurich /etc/localtime
 
@@ -105,6 +112,8 @@ RUN useradd -m ${USER} \
 
 # create working directory
 RUN mkdir -p ${WDIR}/srv/tmp
+RUN mkdir /var/lib/filebeat && chown crab3:crab3 /var/lib/filebeat && \
+    mkdir /var/log/filebeat && chown crab3:crab3 /var/log/filebeat 
 ## taskworker
 RUN mkdir -p ${WDIR}/srv/TaskManager/current \
            ${WDIR}/srv/TaskManager/cfg \
@@ -135,6 +144,7 @@ COPY cicd/crabtaskworker_pypi/Publisher/start.sh \
 
 ## entrypoint
 COPY cicd/crabtaskworker_pypi/run.sh /data
+COPY cicd/crabtaskworker_pypi/monitor.sh /data
 
 # for debuggin purpose
 RUN echo "${USER} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/01-crab3

--- a/cicd/crabtaskworker_pypi/monitor.sh
+++ b/cicd/crabtaskworker_pypi/monitor.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if  [ -f /data/hostdisk/filebeat.yaml ] && [ -f /usr/bin/filebeat ]; then
+    ldir=/tmp/filebeat
+    mkdir -p $ldir/data
+    nohup /usr/bin/filebeat \
+        -c /data/hostdisk/filebeat.yaml \
+        --path.data $ldir/data --path.logs $ldir -e 2>&1 1>& $ldir/log < /dev/null &
+fi
+

--- a/cicd/crabtaskworker_pypi/run.sh
+++ b/cicd/crabtaskworker_pypi/run.sh
@@ -50,6 +50,8 @@ pushd "${WORKDIR}"
 
 # execute
 ./start.sh -c
+/data/monitor.sh
+
 
 while true; do
     sleep 3600


### PR DESCRIPTION
fix #8573 

### status

tested on crab-dev-tw02, working [1]

### description

- [x] install filebeat from elasticsearch own repos, similar to what cmsweb is doing [2]. following official instructions [3] and chosing the repo that provides software under apache 2.0 license (i do not even want to look at what the elastic license sould mean for us)
- [x] copied `monitor.sh` from ./Docker into ./cicd/crabtaskworker_pypi without any modification
- [x] run `/data/monitor.sh` from `/data/run.sh`, after `./start.sh -c`, before the while-true loop

I am open to suggestions! :)

---

[1] https://monit-grafana.cern.ch/goto/7rYneG9Sg?orgId=11 selecting `crab-dev-tw02` from the TW host dropdown menu
[2] https://github.com/dmwm/CMSKubernetes/blob/0cb2d75f9b74ff4aea5b80f679c04651aadcf14c/docker/cmsweb/Dockerfile#L17 
[3] https://www.elastic.co/guide/en/beats/filebeat/current/setup-repositories.html

