### PR TITLE
update HTC to 23.9.6 in TW pypi image

### DIFF
--- a/cicd/crabtaskworker_pypi/requirements.txt
+++ b/cicd/crabtaskworker_pypi/requirements.txt
@@ -3,7 +3,7 @@
 
 dbs3-client~=4.0.12
 future~=0.18.2
-htcondor==23.9.0a3
+htcondor==23.9.6
 psutil~=5.9.1
 pycurl~=7.45.1
 pyOpenSSL~=18.0.0


### PR DESCRIPTION
now that HTC 23.9 is out, no need for the prerelease build anymore