### PR TITLE
add SUBMITREFUSED to task statuses to monitor. Fix #8620

### DIFF
--- a/src/script/Monitor/GenerateMONIT.py
+++ b/src/script/Monitor/GenerateMONIT.py
@@ -1,5 +1,4 @@
-# pylint: disable=W0703
-from __future__ import print_function
+# pylint: disable=broad-except
 import os
 import sys
 import time
@@ -230,7 +229,7 @@ class CRAB3CreateJson:
         twStatus = self.getCountTasksByStatus()
 
         statesFilter = ['SUBMITTED', 'FAILED', 'QUEUED', 'NEW', 'KILLED', 'KILLFAILED', 'RESUBMITFAILED',
-                         'SUBMITFAILED', 'TAPERECALL']
+                         'SUBMITFAILED', 'SUBMITREFUSED', 'TAPERECALL']
         if len(twStatus) > 0:
             for state in twStatus.keys():
                 if state in statesFilter:
@@ -240,7 +239,7 @@ class CRAB3CreateJson:
         twStatus = self.getCountTasksByStatusAbs()
 
         statesFilter = ['KILL', 'RESUBMIT', 'NEW', 'QUEUED', 'KILLFAILED', 'RESUBMITFAILED', 'SUBMITFAILED',
-                         'UPLOADED', 'TAPERECALL']
+                         'SUBMITREFUSED', 'UPLOADED', 'TAPERECALL']
         if len(twStatus) > 0:
             for state in statesFilter:
                 self.jsonDoc['abs_task_states'].update({str(state): 0})


### PR DESCRIPTION
I verified that this change adds the info to the json doc and does not break the code.
I think we need to merge and deploy on crab-prod-tw02 to see if data appears in OpenSeach and add a query to grafana panel
I guess I can kick off a gitlab pipeline to test this from my local repo ? What do you think @mapellidario ?
But there's no way to deploy it on prod2, via gitlab, right ?