### PR TITLE
cmsrun - adapt to deprecated -p parameter

### DIFF
--- a/test/statusTrackingTasks/withNoneEDM.sh
+++ b/test/statusTrackingTasks/withNoneEDM.sh
@@ -5,4 +5,4 @@ set -x
 
 dd if=/dev/urandom of=miniaodfake.root bs=1M count=10
 
-cmsRun -j FrameworkJobReport.xml -p PSet.py
+cmsRun -j FrameworkJobReport.xml PSet.py


### PR DESCRIPTION
fixes #8622

I did not test this, but it feels pretty safe, it is the same command as in

https://github.com/dmwm/CRABServer/blob/43208f8307874dab3d255415b62aa45c0cd1e32f/scripts/CMSRunAnalysis.py#L701

It think it is safe to merge.