### PR TITLE
monit - runcontainer improved

### DIFF
--- a/src/script/Container/runContainer.sh
+++ b/src/script/Container/runContainer.sh
@@ -111,6 +111,7 @@ docker run --name ${SERVICE} -t --net host --privileged $DOCKER_OPT $DOCKER_VOL 
 if [[ "${SERVICE}" == TaskWorker_monit_*  ]]; then
   echo "TaskWorker_monit_* detected, waiting for it to finish..."
   docker_wait_return=$(docker wait ${SERVICE})
+  docker logs $SERVICE > $tmpfile
   if [ $docker_wait_return -eq 0 ]; then
     # if the crontab does not fail, remove the log file
     rm -f $tmpfile


### PR DESCRIPTION
fixing a bug in #8640 that caused all the stdout of the monit container not to reach the email in case of problems. I tested this on crab-dev-tw02 and it works fine