### PR TITLE
monitoring image - some new additions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -134,7 +134,7 @@ build_monit_image:
     - source .env
     - docker context create mycontext
     - docker buildx create mycontext --use --name mybuilder --bootstrap
-    - docker buildx build --push --build-arg="BASE_TAG=${IMAGE_TAG}" -f "${CI_PROJECT_DIR}/cicd/monit_pypi/Dockerfile" --cache-to=type=registry,ref="registry.cern.ch/cmscrab/crabtwmonit:pypi-${REST_Instance}-cache",image-manifest=true,mode=max --cache-from=type=registry,ref="registry.cern.ch/cmscrab/crabtwmonit:pypi-${REST_Instance}-cache" -t "registry.cern.ch/cmscrab/crabtwmonit:${IMAGE_TAG}" .
+    - docker buildx build --push --build-arg="BASE_TAG=${IMAGE_TAG}" -f "${CI_PROJECT_DIR}/cicd/monit_pypi/Dockerfile" --cache-to=type=registry,ref="registry.cern.ch/cmscrab/crabtwmonit:pypi-${REST_Instance}-cache",image-manifest=true,mode=max --cache-from=type=registry,ref="registry.cern.ch/cmscrab/crabtwmonit:pypi-${REST_Instance}-cache" -t "registry.cern.ch/cmscrab/crabtwmonit:${IMAGE_TAG}" -t "registry.cern.ch/cmscrab/crabtwmonit:v3.latest" .
   cache:
     - key: $CI_PIPELINE_ID
       paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -134,7 +134,7 @@ build_monit_image:
     - source .env
     - docker context create mycontext
     - docker buildx create mycontext --use --name mybuilder --bootstrap
-    - docker buildx build --push --build-arg="BASE_TAG=${IMAGE_TAG}" -f "${CI_PROJECT_DIR}/cicd/monit_pypi/Dockerfile" --cache-to=type=registry,ref="registry.cern.ch/cmscrab/crabtaskworker:pypi-${REST_Instance}-cache-monit",image-manifest=true,mode=max --cache-from=type=registry,ref="registry.cern.ch/cmscrab/crabtaskworker:pypi-${REST_Instance}-cache-monit" -t "registry.cern.ch/cmscrab/crabtaskworker:${IMAGE_TAG}.monit" .
+    - docker buildx build --push --build-arg="BASE_TAG=${IMAGE_TAG}" -f "${CI_PROJECT_DIR}/cicd/monit_pypi/Dockerfile" --cache-to=type=registry,ref="registry.cern.ch/cmscrab/crabtwmonit:pypi-${REST_Instance}-cache",image-manifest=true,mode=max --cache-from=type=registry,ref="registry.cern.ch/cmscrab/crabtwmonit:pypi-${REST_Instance}-cache" -t "registry.cern.ch/cmscrab/crabtwmonit:${IMAGE_TAG}" .
   cache:
     - key: $CI_PIPELINE_ID
       paths:

--- a/src/script/Container/runContainer.sh
+++ b/src/script/Container/runContainer.sh
@@ -105,7 +105,11 @@ fi
 
 DOCKER_OPT="-d -e SERVICE=${SERVICE} -w /data/srv/${DIRECTORY} "
 
-DOCKER_IMAGE=${TW_REPO:-registry.cern.ch/cmscrab}/crabtaskworker:${TW_VERSION}
+if [[ "${SERVICE}" == TaskWorker_monit*  ]]; then
+  DOCKER_IMAGE=${TW_REPO:-registry.cern.ch/cmscrab}/crabtwmonit:${TW_VERSION}
+else
+  DOCKER_IMAGE=${TW_REPO:-registry.cern.ch/cmscrab}/crabtaskworker:${TW_VERSION}
+fi
 
 docker run --name ${SERVICE} -t --net host --privileged $DOCKER_OPT $DOCKER_VOL $DOCKER_IMAGE $COMMAND > $tmpfile
 if [[ "${SERVICE}" == TaskWorker_monit_*  ]]; then


### PR DESCRIPTION
I decided that:

- the docker image that we use for monit should have its own place in the registry: `cmscrab/crabtwmonit`, separate from crabtaskworker.
- every time we build the monit image, for example with `git push gitlab -o ci.variable="BUILD=t" $TAG`, then we also tag the monit image with `v3.latest`, so that crab-dev-tw02 starts using it.
- production will not be affected because it runs a validated docker monit image tag.
