### PR TITLE
fix logging format

### DIFF
--- a/src/python/TaskWorker/Actions/PreJob.py
+++ b/src/python/TaskWorker/Actions/PreJob.py
@@ -521,8 +521,8 @@ class PreJob:
             filename=prejob_log_file_name,
             encoding='utf-8',
             level=logging.DEBUG,
-            format='%(asctime)s:%(levelname)s:%(module)s %(message)s", \
-                                      datefmt="%a, %d %b %Y %H:%M:%S %Z(%z)"'
+            format="%(asctime)s:%(levelname)s:%(module)s %(message)s", \
+                                      datefmt="%a, %d %b %Y %H:%M:%S %Z(%z)"
         )
 
         ## Redirect stdout and stderr to the pre-job log file.


### PR DESCRIPTION
somehow there were un-balanced quotes in the logging format.... maybe since 1st creation, maybe a misstype along the line... who knows