### PR TITLE
spark monitoring cronjobs - a small refactor

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -162,6 +162,28 @@ build_crabtwfilebeat_image:
         - src/python/TaskWorker/__init__.py
       policy: pull
 
+build_spark_image:
+  rules:
+    - if: $BUILD
+    - !reference [.default_rules, release]
+  stage: build_docker
+  image:
+    name: docker:27.1.1
+  services:
+    - name: docker:27.1.1-dind
+  script:
+    - docker login -u $CMSCRAB_REGISTRY_USER -p $CMSCRAB_REGISTRY_PASSWORD $CMSCRAB_REGISTRY_URL
+    - source .env
+    - docker context create mycontext
+    - docker buildx create mycontext --use --name mybuilder --bootstrap
+    - docker buildx build --push --build-arg="BASE_TAG=${IMAGE_TAG}" -f "${CI_PROJECT_DIR}/cicd/monit_spark/Dockerfile" --cache-to=type=registry,ref="registry.cern.ch/cmscrab/crabspark:pypi-${REST_Instance}-cache",image-manifest=true,mode=max --cache-from=type=registry,ref="registry.cern.ch/cmscrab/crabspark:pypi-${REST_Instance}-cache" -t "registry.cern.ch/cmscrab/crabspark:${IMAGE_TAG}" -t "registry.cern.ch/cmscrab/crabspark:latest" .
+  cache:
+    - key: $CI_PIPELINE_ID
+      paths:
+        - src/python/TaskWorker/__init__.py
+      policy: pull
+
+
 deploy_server:
   rules:
     - if: $BUILD_DEPLOY

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,11 +177,6 @@ build_spark_image:
     - docker context create mycontext
     - docker buildx create mycontext --use --name mybuilder --bootstrap
     - docker buildx build --push --build-arg="BASE_TAG=${IMAGE_TAG}" -f "${CI_PROJECT_DIR}/cicd/monit_spark/Dockerfile" --cache-to=type=registry,ref="registry.cern.ch/cmscrab/crabspark:pypi-${REST_Instance}-cache",image-manifest=true,mode=max --cache-from=type=registry,ref="registry.cern.ch/cmscrab/crabspark:pypi-${REST_Instance}-cache" -t "registry.cern.ch/cmscrab/crabspark:${IMAGE_TAG}" -t "registry.cern.ch/cmscrab/crabspark:latest" .
-  cache:
-    - key: $CI_PIPELINE_ID
-      paths:
-        - src/python/TaskWorker/__init__.py
-      policy: pull
 
 
 deploy_server:

--- a/cicd/monit_pypi/Dockerfile
+++ b/cicd/monit_pypi/Dockerfile
@@ -1,6 +1,9 @@
 ARG BASE_TAG=latest
 FROM registry.cern.ch/cmscrab/crabtaskworker:${BASE_TAG}
 
+## build with
+# docker buildx build -t registry.cern.ch/cmscrab/??:?? -f cicd/monit_pypi/Dockerfile .
+
 RUN pip install --user pandas 
 
 RUN mkdir -p /data/srv/monit/

--- a/cicd/monit_pypi/Dockerfile
+++ b/cicd/monit_pypi/Dockerfile
@@ -1,9 +1,6 @@
 ARG BASE_TAG=latest
 FROM registry.cern.ch/cmscrab/crabtaskworker:${BASE_TAG}
 
-## build with
-# docker buildx build -t registry.cern.ch/cmscrab/??:?? -f cicd/monit_pypi/Dockerfile .
-
 RUN pip install --user pandas 
 
 RUN mkdir -p /data/srv/monit/

--- a/cicd/monit_spark/Dockerfile
+++ b/cicd/monit_spark/Dockerfile
@@ -1,0 +1,25 @@
+FROM registry.cern.ch/cmsmonitoring/cmsmon-spark:v0.5.0.1 
+
+## build with from dmwm/CRABServer, root directory
+# docker buildx build -t registry.cern.ch/cmscrab/crabspark:(date +%s) -f cicd/monit_spark/Dockerfile .
+
+RUN yum install -y \
+    tini \
+    && yum clean all \
+    && rm -rf /var/cache/yum
+
+RUN mkdir -p /data/srv/spark/
+COPY ./src/script/Monitor/crab-spark/workdir/osearch.py \
+     ./src/script/Monitor/crab-spark/workdir/bootstrap.sh \
+     ./src/script/Monitor/crab-spark/cronjobs/crab_condor_daily.py \
+     ./src/script/Monitor/crab-spark/cronjobs/crab_tape_recall_rules_history_daily.py \
+     ./src/script/Monitor/crab-spark/cronjobs/run_spark.sh \
+     ./src/script/Monitor/crab-spark/cronjobs/crab_data_daily.py \
+     ./src/script/Monitor/crab-spark/cronjobs/crab_tape_recall_updated_rules_daily.py \
+     /data/srv/spark
+
+ENTRYPOINT ["tini", "--"]
+
+CMD ["echo", "no default script for spark docker image"]
+
+

--- a/src/script/Monitor/crab-spark/cronjobs/crab_condor_daily.py
+++ b/src/script/Monitor/crab-spark/cronjobs/crab_condor_daily.py
@@ -5,8 +5,23 @@ os.environ['PYSPARK_PYTHON'] = sys.executable
 os.environ['PYSPARK_DRIVER_PYTHON'] = sys.executable
 
 import time
+import numpy as np
+import pandas as pd
 
 from datetime import datetime, date, timedelta
+
+import osearch
+
+import argparse
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument("-s", "--start-date", default=None,
+  help="process data starting from this day, inclusive (YYYY-MM-DD)",)
+parser.add_argument("-e", "--end-date", default=None,
+  help="process data until this day, not included (YYYY-MM-DD)",)
+args = parser.parse_args()
+print(f"timerange: [{args.start_date} {args.end_date})" )
+
+
 from pyspark.sql.functions import (
     col,
     lit,
@@ -17,8 +32,6 @@ from pyspark.sql.functions import (
     date_format,
     from_unixtime
 )
-import numpy as np
-import pandas as pd
 from pyspark.sql.types import (
     StructType,
     LongType,
@@ -28,7 +41,6 @@ from pyspark.sql.types import (
     IntegerType,
 )
 
-import osearch
 from pyspark.sql import SparkSession
 
 spark = SparkSession\
@@ -38,156 +50,198 @@ spark = SparkSession\
 
 # CRAB table date
 
-TODAY = str(datetime.now())[:10]
-wa_date = TODAY
-
 # condor data and query date
+# if args.end_date:
+#     end_date = datetime.strptime(args.end_date, '%Y-%m-%d')
+# else:
+#     end_date = datetime.now()
+#     end_date = end_date.replace(minute=0, hour=0, second=0, microsecond=0)
+# 
+# if args.start_date:
+#     start_date = datetime.strptime(args.start_date, '%Y-%m-%d')
+# else:
+#     start_date = end_date - timedelta(days=1)
 
-end_date = datetime.now()
-end_date = end_date.replace(minute=0, hour=0, second=0, microsecond=0)
-start_date = end_date-timedelta(days=1)
+if args.end_date:
+    end_date = datetime.strptime(args.end_date, '%Y-%m-%d')
+else:
+    end_date = datetime.now()
+    end_date = end_date.replace(minute=0, hour=0, second=0, microsecond=0)
+
+if args.start_date:
+    start_date = datetime.strptime(args.start_date, '%Y-%m-%d')
+else:
+    start_date = end_date - timedelta(days=1)
+
+date_list = pd.date_range(
+    start=start_date,
+    end=end_date,
+    ).to_pydatetime().tolist()
 
 # Import condor data
 
-_DEFAULT_HDFS_FOLDER = "/project/monitoring/archive/condor/raw/metric"
+def process_single_day(day):
 
-def _get_schema():
-    return StructType(
-        [
-            StructField(
-                "data",
-                StructType(
-                    [
-                        StructField("RecordTime", LongType(), nullable=False),
-                        StructField("CMSPrimaryDataTier", StringType(), nullable=True),
-                        StructField("Status", StringType(), nullable=True),
-                        StructField("WallClockHr", DoubleType(), nullable=True),
-                        StructField("CoreHr", DoubleType(), nullable=True),
-                        StructField("CpuTimeHr", DoubleType(), nullable=True),
-                        StructField("Type", StringType(), nullable=True),
-                        StructField("CRAB_DataBlock", StringType(), nullable=True),
-                        StructField("GlobalJobId", StringType(), nullable=False),
-                        StructField("ExitCode", LongType(), nullable=True),
-                        StructField("CRAB_Workflow", StringType(), nullable=True),
-                        StructField("CommittedCoreHr", StringType(), nullable=True),
-                        StructField("CommittedWallClockHr", StringType(), nullable=True),
-                    ]
+    start_date = day
+    end_date = day + timedelta(days=1)
+    print(f"START PROCESSING: from {start_date} to {end_date}")
+
+    _DEFAULT_HDFS_FOLDER = "/project/monitoring/archive/condor/raw/metric"
+    
+    def _get_schema():
+        return StructType(
+            [
+                StructField(
+                    "data",
+                    StructType(
+                        [
+                            StructField("RecordTime", LongType(), nullable=False),
+                            StructField("CMSPrimaryDataTier", StringType(), nullable=True),
+                            StructField("Status", StringType(), nullable=True),
+                            StructField("WallClockHr", DoubleType(), nullable=True),
+                            StructField("CoreHr", DoubleType(), nullable=True),
+                            StructField("CpuTimeHr", DoubleType(), nullable=True),
+                            StructField("Type", StringType(), nullable=True),
+                            StructField("CRAB_DataBlock", StringType(), nullable=True),
+                            StructField("GlobalJobId", StringType(), nullable=False),
+                            StructField("ExitCode", LongType(), nullable=True),
+                            StructField("CRAB_Workflow", StringType(), nullable=True),
+                            StructField("CommittedCoreHr", StringType(), nullable=True),
+                            StructField("CommittedWallClockHr", StringType(), nullable=True),
+                        ]
+                    ),
                 ),
-            ),
+            ]
+        )
+    
+    def get_candidate_files(start_date, end_date, spark, base=_DEFAULT_HDFS_FOLDER):
+        st_date = start_date - timedelta(days=0)
+        ed_date = end_date + timedelta(days=0)
+        days = (ed_date - st_date).days
+    
+        sc = spark.sparkContext
+        FileSystem = sc._gateway.jvm.org.apache.hadoop.fs.FileSystem
+        URI = sc._gateway.jvm.java.net.URI
+        Path = sc._gateway.jvm.org.apache.hadoop.fs.Path
+        fs = FileSystem.get(URI("hdfs:///"), sc._jsc.hadoopConfiguration())
+        candidate_files = [
+            f"{base}/{(st_date + timedelta(days=i)).strftime('%Y/%m/%d')}"
+            for i in range(0, days)
+        ]    
+        candidate_files = [url for url in candidate_files if fs.globStatus(Path(url))]
+        print("No. of Compacted files:", len(candidate_files))
+    
+        pre_candidate_files = [
+            f"{base}/{(st_date + timedelta(days=i)).strftime('%Y/%m/%d')}.tmp"
+            for i in range(0, days)
         ]
-    )
-
-def get_candidate_files(start_date, end_date, spark, base=_DEFAULT_HDFS_FOLDER):
-    st_date = start_date - timedelta(days=0)
-    ed_date = end_date + timedelta(days=0)
-    days = (ed_date - st_date).days
-    pre_candidate_files = [
-        "{base}/{day}{{,.tmp}}".format(
-            base=base, day=(st_date + timedelta(days=i)).strftime("%Y/%m/%d")
-        )
-        for i in range(0, days)
-    ]
-    sc = spark.sparkContext
-    candidate_files = [
-        f"{base}/{(st_date + timedelta(days=i)).strftime('%Y/%m/%d')}"
-        for i in range(0, days)
-    ]
-    FileSystem = sc._gateway.jvm.org.apache.hadoop.fs.FileSystem
-    URI = sc._gateway.jvm.java.net.URI
-    Path = sc._gateway.jvm.org.apache.hadoop.fs.Path
-    fs = FileSystem.get(URI("hdfs:///"), sc._jsc.hadoopConfiguration())
-    candidate_files = [url for url in candidate_files if fs.globStatus(Path(url))]
-    return candidate_files
+        pre_candidate_files = [url for url in pre_candidate_files if fs.globStatus(Path(url))]
+        print("No. of uncompacted files:", len(pre_candidate_files))
+        
+        return candidate_files + pre_candidate_files
     
-schema = _get_schema()
-
-condor_df = (
-        spark.read.option("basePath", _DEFAULT_HDFS_FOLDER)
-        .json(
-            get_candidate_files(start_date, end_date, spark, base=_DEFAULT_HDFS_FOLDER),
-            schema=schema,
-        ).select("data.*")
-        .filter(
-            f"""Status IN ('Completed')
-            AND Type IN ('analysis')
-            AND RecordTime >= {start_date.timestamp() * 1000}
-            AND RecordTime < {end_date.timestamp() * 1000}
-            """
-        )
-        .drop_duplicates(["GlobalJobId"])
-#	.cache()
-    )
-
-# Convert file type by saving and recall it again (.json too complex for spark)
-
-condor_df.write.mode('overwrite').parquet("/cms/users/cmscrab/condor_vir_data" ,compression='zstd')
-condor_df = spark.read.format('parquet').load('/cms/users/cmscrab/condor_vir_data')
-
-# Import CRAB data
-
-HDFS_CRAB_part = f'/project/awg/cms/crab/tasks/{wa_date}/'
-crab_df = spark.read.format('avro').load(HDFS_CRAB_part)
-crab_df = crab_df.select('TM_TASKNAME', 'TM_IGNORE_LOCALITY')
-
-print("==============================================="
-      , "Condor Matrix and CRAB Table"
-      , "==============================================="
-      , "File Directory:", HDFS_CRAB_part, get_candidate_files(start_date, end_date, spark, base=_DEFAULT_HDFS_FOLDER)
-      , "Work Directory:", os.getcwd()
-      , "==============================================="
-      , "===============================================", sep='\n')
-
-# Join condor job with CRAB data
-
-result_df = condor_df.join(crab_df, crab_df["TM_TASKNAME"] == condor_df["CRAB_Workflow"])\
-    .select('RecordTime', 'CMSPrimaryDataTier', 'WallClockHr', 'CoreHr', 'CpuTimeHr', 'ExitCode'
-            , "CRAB_DataBlock", "TM_IGNORE_LOCALITY", "GlobalJobId", "CommittedCoreHr", "CommittedWallClockHr")
     
-# Convert database to dictionary
-
-docs = result_df.toPandas().to_dict('records')
-
-# Extract 'CRAB_Type' from 'CRAB_DataBlock'
-
-for i in range(len(docs)):
-    if docs[i]['CRAB_DataBlock'] == 'MCFakeBlock':
-        docs[i]['CRAB_Type'] = 'PrivateMC'
-    else:
-        docs[i]['CRAB_Type'] = 'Analysis'
-
-# Define type of each schema
-
-def get_index_schema():
-    return {
-        "settings": {"index": {"number_of_shards": "1", "number_of_replicas": "1"}},
-        "mappings": {
-            "properties": {
-                "RecordTime": {"format": "epoch_millis", "type": "date"},
-                "CMSPrimaryDataTier": {"ignore_above": 2048, "type": "keyword"},
-                "GlobalJobId": {"ignore_above": 2048, "type": "keyword"},
-                "WallClockHr": {"type": "long"},
-                "CoreHr": {"type": "long"},
-                "CpuTimeHr": {"type": "long"},
-                "ExitCode": {"ignore_above": 2048, "type": "keyword"},
-                "TM_IGNORE_LOCALITY": {"ignore_above": 2048, "type": "keyword"},
-                "CRAB_Type": {"ignore_above": 2048, "type": "keyword"},
-                "CRAB_DataBlock": {"ignore_above": 2048, "type": "keyword"},
-                "CommittedCoreHr": {"type": "long"}, 
-                "CommittedWallClockHr": {"type": "long"},
+    schema = _get_schema()
+    
+    condor_df = (
+            spark.read.option("basePath", _DEFAULT_HDFS_FOLDER)
+            .json(
+                get_candidate_files(start_date, end_date, spark, base=_DEFAULT_HDFS_FOLDER),
+                schema=schema,
+            ).select("data.*")
+            .filter(
+                f"""Status IN ('Completed')
+                AND Type IN ('analysis')
+                AND RecordTime >= {start_date.timestamp() * 1000}
+                AND RecordTime < {end_date.timestamp() * 1000}
+                """
+            )
+            .drop_duplicates(["GlobalJobId"])
+    #	.cache()
+        )
+    
+    # Convert file type by saving and recall it again (.json too complex for spark)
+    
+    crab_username = os.getenv("CRAB_KRB5_USERNAME", "cmscrab")
+    condor_df.write.mode('overwrite').parquet(f"/cms/users/{crab_username}/condor_vir_data" ,compression='zstd')
+    condor_df = spark.read.format('parquet').load(f"/cms/users/{crab_username}/condor_vir_data")
+    
+    # Import CRAB data
+    wa_date = day.strftime("%Y-%m-%d")    
+    HDFS_CRAB_part = f'/project/awg/cms/crab/tasks/{wa_date}/'
+    crab_df = spark.read.format('avro').load(HDFS_CRAB_part)
+    crab_df = crab_df.select('TM_TASKNAME', 'TM_IGNORE_LOCALITY')
+    
+    print("==============================================="
+          , "Condor Matrix and CRAB Table"
+          , "==============================================="
+          , "File Directory:", HDFS_CRAB_part, get_candidate_files(start_date, end_date, spark, base=_DEFAULT_HDFS_FOLDER)
+          , "Work Directory:", os.getcwd()
+          , "==============================================="
+          , "===============================================", sep='\n')
+    
+    # Join condor job with CRAB data
+    
+    result_df = condor_df.join(crab_df, crab_df["TM_TASKNAME"] == condor_df["CRAB_Workflow"])\
+        .select('RecordTime', 'CMSPrimaryDataTier', 'WallClockHr', 'CoreHr', 'CpuTimeHr', 'ExitCode'
+                , "CRAB_DataBlock", "TM_IGNORE_LOCALITY", "GlobalJobId", "CommittedCoreHr", "CommittedWallClockHr")
+        
+    # Convert database to dictionary
+    
+    docs = result_df.toPandas()
+    docs["CRAB_Type"] = docs.apply(lambda row: "PrivateMC" if row["CRAB_DataBlock"] == "MCFakeBlock" else "Analysis", axis=1)
+    print(f"pandas dataframe size: {docs.memory_usage(deep=True).apply(lambda x: x / 1024 / 1024).sum()} MB")
+    
+    
+    def get_index_schema():
+        return {
+            "settings": {"index": {"number_of_shards": "1", "number_of_replicas": "1"}},
+            "mappings": {
+                "properties": {
+                    "RecordTime": {"format": "epoch_millis", "type": "date"},
+                    "CMSPrimaryDataTier": {"ignore_above": 2048, "type": "keyword"},
+                    "GlobalJobId": {"ignore_above": 2048, "type": "keyword"},
+                    "WallClockHr": {"type": "long"},
+                    "CoreHr": {"type": "long"},
+                    "CpuTimeHr": {"type": "long"},
+                    "ExitCode": {"ignore_above": 2048, "type": "keyword"},
+                    "TM_IGNORE_LOCALITY": {"ignore_above": 2048, "type": "keyword"},
+                    "CRAB_Type": {"ignore_above": 2048, "type": "keyword"},
+                    "CRAB_DataBlock": {"ignore_above": 2048, "type": "keyword"},
+                    "CommittedCoreHr": {"type": "long"}, 
+                    "CommittedWallClockHr": {"type": "long"},
+                }
             }
         }
-    }
+    
+    # Send data to Opensearch
+    
+    _index_template = 'crab-condor-taskdb'
+    client = osearch.get_es_client("os-cms.cern.ch/es", '/data/certs/monit.d/monit_spark_crab.txt', get_index_schema())
+    idx = client.get_or_create_index(timestamp=day.strftime("%s"), index_template=_index_template, index_mod="M")
+    docs_rows = len(docs)
+    sent = 0
+    batch = 50000
+    import gc
+    while sent < docs_rows:
+        gc.collect()
+        start = sent
+        end = start + batch if start + batch < docs_rows else docs_rows
+        docs_tmp = docs.iloc[start:end]
+        docs_tmp = docs_tmp.to_dict('records')
+        no_of_fail_saved = client.send(idx, docs_tmp, metadata=None, batch_size=10000, drop_nulls=False)
+        sent = end
+    
+        print("=================================== Condor Matrix and CRAB Table =====================================",
+              "FINISHED : ",
+              f"start {start}, end {end}",
+              len(docs_tmp), "ROWS ARE SENT",
+              no_of_fail_saved, "ROWS ARE FAILED",
+              "=================================== Condor Matrix and CRAB Table =====================================", 
+            sep='\n')
+    
+    
+for day in date_list:
+    process_single_day(day)
 
-# Send data to Opensearch
-
-_index_template = 'crab-condor-ekong'
-client = osearch.get_es_client("es-cms1.cern.ch/es", 'secret_opensearch.txt', get_index_schema())
-idx = client.get_or_create_index(timestamp=time.time(), index_template=_index_template, index_mod="M")
-no_of_fail_saved = client.send(idx, docs, metadata=None, batch_size=10000, drop_nulls=False)
-
-print("=================================== Condor Matrix and CRAB Table ====================================="
-      , "FINISHED : "
-      , len(docs), "ROWS ARE SENT"
-      , no_of_fail_saved, "ROWS ARE FAILED"
-      , "=================================== Condor Matrix and CRAB Table =====================================", sep='\n')
 

--- a/src/script/Monitor/crab-spark/cronjobs/crab_condor_daily.py
+++ b/src/script/Monitor/crab-spark/cronjobs/crab_condor_daily.py
@@ -228,6 +228,9 @@ def process_single_day(day):
         start = sent
         end = start + batch if start + batch < docs_rows else docs_rows
         docs_tmp = docs.iloc[start:end]
+        # the following line requires a lot of RAM, better do it 50_000
+        # items at a time only. Keep in mind that the pandas datafram usually
+        # contains about 1_000_000 rows
         docs_tmp = docs_tmp.to_dict('records')
         no_of_fail_saved = client.send(idx, docs_tmp, metadata=None, batch_size=10000, drop_nulls=False)
         sent = end

--- a/src/script/Monitor/crab-spark/cronjobs/crab_data_daily.py
+++ b/src/script/Monitor/crab-spark/cronjobs/crab_data_daily.py
@@ -7,6 +7,22 @@ import pandas as pd
 # import pprint
 import time
 # from dateutil.relativedelta import relativedelta
+
+import numpy as np
+import json
+import osearch
+
+import argparse
+
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument("-s", "--start-date", default=None,
+  help="process data starting from this day, inclusive (YYYY-MM-DD)",)
+parser.add_argument("-e", "--end-date", default=None,
+  help="process data until this day, not included (YYYY-MM-DD)",)
+args = parser.parse_args()
+print(f"timerange: [{args.start_date} {args.end_date})" )
+
+
 from pyspark import SparkContext, StorageLevel
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import (
@@ -19,16 +35,10 @@ from pyspark.sql.functions import (
     round as _round,
     sum as _sum,
 )
-
 from pyspark.sql.types import (
     LongType,
 )
-
-import numpy as np
-import json
-import osearch
 from pyspark.sql import SparkSession
-
 spark = SparkSession\
         .builder\
         .appName("crab_tape_recall")\
@@ -36,85 +46,109 @@ spark = SparkSession\
 
 # Query date
 
-TODAY = str(datetime.now())[:10]
-YESTERDAY = str(datetime.now()-timedelta(days=1))[:10]
+#TODAY = str(datetime.now())[:10]
+#YESTERDAY = str(datetime.now()-timedelta(days=1))[:10]
+#wa_date = TODAY
 
-# Data date
+if args.end_date:
+    end_date = datetime.strptime(args.end_date, '%Y-%m-%d')
+else:
+    end_date = datetime.now()
+    end_date = end_date.replace(minute=0, hour=0, second=0, microsecond=0)
 
-wa_date = TODAY
+if args.start_date:
+    start_date = datetime.strptime(args.start_date, '%Y-%m-%d')
+else:
+    start_date = end_date - timedelta(days=1)
+
+date_list = pd.date_range(
+    start=start_date,
+    end=end_date,
+    ).to_pydatetime().tolist()
 
 # Import data into database form
 
-HDFS_CRAB_part = f'/project/awg/cms/crab/tasks/{wa_date}/'
-print("==============================================="
-      , "CRAB Table"
-      , "==============================================="
-      , "File Directory:", HDFS_CRAB_part
-      , "Work Directory:", os.getcwd()
-      , "==============================================="
-      , "===============================================", sep='\n')
+def process_single_day(day):
 
-crab_part = spark.read.format('avro').load(HDFS_CRAB_part)
-df = crab_part.select("TM_TASKNAME","TM_START_TIME","TM_TASK_STATUS","TM_SPLIT_ALGO","TM_USERNAME","TM_USER_ROLE","TM_JOB_TYPE","TM_IGNORE_LOCALITY","TM_SCRIPTEXE","TM_USER_CONFIG")
-df.createOrReplaceTempView("crab_algo")
+    wa_date = day.strftime("%Y-%m-%d")
+    TODAY = wa_date
+    YESTERDAY = (day-timedelta(days=1)).strftime("%Y-%m-%d")
 
-# Query daily data
-
-query = f"""\
-SELECT *
-FROM crab_algo 
-WHERE 1=1
-AND TM_START_TIME >= unix_timestamp("{YESTERDAY} 00:00:00", "yyyy-MM-dd HH:mm:ss")*1000 
-AND TM_START_TIME < unix_timestamp("{TODAY} 00:00:00", "yyyy-MM-dd HH:mm:ss")*1000 
-"""
-
-tmpdf = spark.sql(query)
-tmpdf.show(10)
-
-# Convert database to dictionary
-
-docs = tmpdf.toPandas().to_dict('records')
-
-# Extract 'REQUIRE_ACCELERATOR' from 'TM_USER_CONFIG'
-
-for i in range(len(docs)):
-    if docs[i]['TM_USER_CONFIG'] is not None:
-        data = json.loads(docs[i]['TM_USER_CONFIG'])
-        if "requireaccelerator" in data:
-            docs[i]['REQUIRE_ACCELERATOR'] = data["requireaccelerator"]
+    HDFS_CRAB_part = f'/project/awg/cms/crab/tasks/{wa_date}/'
+    print("==============================================="
+          , "CRAB Table"
+          , "==============================================="
+          , "File Directory:", HDFS_CRAB_part
+          , "Work Directory:", os.getcwd()
+          , "==============================================="
+          , "===============================================", sep='\n')
+    
+    crab_part = spark.read.format('avro').load(HDFS_CRAB_part)
+    df = crab_part.select("TM_TASKNAME","TM_START_TIME","TM_TASK_STATUS","TM_SPLIT_ALGO","TM_USERNAME","TM_USER_ROLE","TM_JOB_TYPE","TM_IGNORE_LOCALITY","TM_SCRIPTEXE","TM_USER_CONFIG")
+    df.createOrReplaceTempView("crab_algo")
+    
+    # Query daily data
+    
+    query = f"""\
+    SELECT *
+    FROM crab_algo 
+    WHERE 1=1
+    AND TM_START_TIME >= unix_timestamp("{YESTERDAY} 00:00:00", "yyyy-MM-dd HH:mm:ss")*1000 
+    AND TM_START_TIME < unix_timestamp("{TODAY} 00:00:00", "yyyy-MM-dd HH:mm:ss")*1000 
+    """
+    
+    tmpdf = spark.sql(query)
+    tmpdf.show(10)
+    
+    # Convert database to dictionary
+    
+    docs = tmpdf.toPandas().to_dict('records')
+    
+    # Extract 'REQUIRE_ACCELERATOR' from 'TM_USER_CONFIG'
+    
+    for i in range(len(docs)):
+        if docs[i]['TM_USER_CONFIG'] is not None:
+            data = json.loads(docs[i]['TM_USER_CONFIG'])
+            if "requireaccelerator" in data:
+                docs[i]['REQUIRE_ACCELERATOR'] = data["requireaccelerator"]
+            else:
+                docs[i]['REQUIRE_ACCELERATOR'] = None
         else:
             docs[i]['REQUIRE_ACCELERATOR'] = None
-    else:
-        docs[i]['REQUIRE_ACCELERATOR'] = None
-
-# Define type of each schema
-
-def get_index_schema():
-    return {
-        "settings": {"index": {"number_of_shards": "1", "number_of_replicas": "1"}},
-        "mappings": {
-            "properties": {
-                "TM_TASKNAME": {"ignore_above": 2048, "type": "keyword"},
-                "TM_START_TIME": {"format": "epoch_millis", "type": "date"},
-                'TM_TASK_STATUS': {"ignore_above": 2048, "type": "keyword"},
-                "TM_SPLIT_ALGO": {"ignore_above": 2048, "type": "keyword"},
-                "TM_USERNAME": {"ignore_above": 2048, "type": "keyword"},
-                "TM_USER_ROLE": {"ignore_above": 2048, "type": "keyword"},
-                "TM_JOB_TYPE": {"ignore_above": 2048, "type": "keyword"},
-                "TM_IGNORE_LOCALITY": {"ignore_above": 2048, "type": "keyword"},
-                "TM_SCRIPTEXE": {"ignore_above": 2048, "type": "keyword"},
-                "REQUIRE_ACCELERATOR": {"ignore_above": 2048, "type": "keyword"},
+    
+    # Define type of each schema
+    
+    def get_index_schema():
+        return {
+            "settings": {"index": {"number_of_shards": "1", "number_of_replicas": "1"}},
+            "mappings": {
+                "properties": {
+                    "TM_TASKNAME": {"ignore_above": 2048, "type": "keyword"},
+                    "TM_START_TIME": {"format": "epoch_millis", "type": "date"},
+                    'TM_TASK_STATUS': {"ignore_above": 2048, "type": "keyword"},
+                    "TM_SPLIT_ALGO": {"ignore_above": 2048, "type": "keyword"},
+                    "TM_USERNAME": {"ignore_above": 2048, "type": "keyword"},
+                    "TM_USER_ROLE": {"ignore_above": 2048, "type": "keyword"},
+                    "TM_JOB_TYPE": {"ignore_above": 2048, "type": "keyword"},
+                    "TM_IGNORE_LOCALITY": {"ignore_above": 2048, "type": "keyword"},
+                    "TM_SCRIPTEXE": {"ignore_above": 2048, "type": "keyword"},
+                    "REQUIRE_ACCELERATOR": {"ignore_above": 2048, "type": "keyword"},
+                }
             }
         }
-    }
+    
+    # Send data to Opensearch
+    
+    _index_template = 'crab-taskdb'
+    client = osearch.get_es_client("os-cms.cern.ch/es", '/data/certs/monit.d/monit_spark_crab.txt', get_index_schema())
+    idx = client.get_or_create_index(timestamp=day.strftime("%s"), index_template=_index_template, index_mod="M")
+    no_of_fail_saved = client.send(idx, docs, metadata=None, batch_size=10000, drop_nulls=False)
+    
+    print("================================= CRAB Table ======================================="
+          , "FINISHED : ", len(docs), "ROWS ARE SENT", no_of_fail_saved, "ROWS ARE FAILED"
+          , "=================================  CRAB Table =======================================", sep='\n')
 
-# Send data to Opensearch
 
-_index_template = 'crab-data-ekong1'
-client = osearch.get_es_client("es-cms1.cern.ch/es", 'secret_opensearch.txt', get_index_schema())
-idx = client.get_or_create_index(timestamp=time.time(), index_template=_index_template, index_mod="M")
-no_of_fail_saved = client.send(idx, docs, metadata=None, batch_size=10000, drop_nulls=False)
+for day in date_list:
+    process_single_day(day)
 
-print("================================= CRAB Table ======================================="
-      , "FINISHED : ", len(docs), "ROWS ARE SENT", no_of_fail_saved, "ROWS ARE FAILED"
-      , "=================================  CRAB Table =======================================", sep='\n')

--- a/src/script/Monitor/crab-spark/cronjobs/crab_tape_recall_rules_history_daily.py
+++ b/src/script/Monitor/crab-spark/cronjobs/crab_tape_recall_rules_history_daily.py
@@ -7,6 +7,17 @@ import pandas as pd
 # import pprint
 import time
 # from dateutil.relativedelta import relativedelta
+
+import argparse
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument("-s", "--start-date", default=None,
+  help="process data starting from this day, inclusive (YYYY-MM-DD)",)
+parser.add_argument("-e", "--end-date", default=None,
+  help="process data until this day, not included (YYYY-MM-DD)",)
+args = parser.parse_args()
+print(f"timerange: [{args.start_date} {args.end_date})" )
+
+
 from pyspark import SparkContext, StorageLevel
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import (
@@ -34,99 +45,120 @@ spark = SparkSession\
         .appName("crab_tape_recall")\
         .getOrCreate()
 
-# Query date
-
-TODAY = str(datetime.now())[:10]
-TOYEAR = TODAY[:4]
-YESTERDAY = str(datetime.now()-timedelta(days=1))[:10]
-
 # Data date
 
-wa_date = TODAY
+if args.end_date:
+    end_date = datetime.strptime(args.end_date, '%Y-%m-%d')
+else:
+    end_date = datetime.now()
+    end_date = end_date.replace(minute=0, hour=0, second=0, microsecond=0)
 
-# Import data into database form
+if args.start_date:
+    start_date = datetime.strptime(args.start_date, '%Y-%m-%d')
+else:
+    start_date = end_date - timedelta(days=1)
 
-HDFS_RUCIO_RULES_HISTORY = f'/project/awg/cms/rucio/{wa_date}/rules_history/'
+date_list = pd.date_range(
+    start=start_date,
+    end=end_date,
+    ).to_pydatetime().tolist()
 
-print("==============================================="
-      , "RUCIO : Rules History"
-      , "==============================================="
-      , "File Directory:", HDFS_RUCIO_RULES_HISTORY
-      , "Work Directory:", os.getcwd()
-      , "==============================================="
-      , "===============================================", sep='\n')
-
-rucio_rules_history = spark.read.format('avro').load(HDFS_RUCIO_RULES_HISTORY).withColumn('ID', lower(_hex(col('ID'))))
-
-# Query data in daily
-
-rucio_rules_history = rucio_rules_history.select("ID", "NAME", "STATE", "EXPIRES_AT", "UPDATED_AT", "CREATED_AT", "ACCOUNT").filter(f"""ACCOUNT IN ('crab_tape_recall')""").cache()
-rucio_rules_history.createOrReplaceTempView("rules_history")
-
-query = query = f"""\
-WITH filter_t AS (
-SELECT ID, NAME, STATE, EXPIRES_AT, UPDATED_AT, CREATED_AT
-FROM rules_history 
-WHERE 1=1
-AND CREATED_AT >= unix_timestamp("{TOYEAR}-01-01 00:00:00", "yyyy-MM-dd HH:mm:ss")*1000
-),
-rn_t AS (
-SELECT ID, NAME, STATE, EXPIRES_AT, UPDATED_AT, CREATED_AT,
-row_number() over(partition by ID order by UPDATED_AT desc) as rn
-FROM filter_t
-),
-calc_days_t AS (
-SELECT ID, NAME, STATE, EXPIRES_AT, UPDATED_AT, CREATED_AT,
-   CASE 
-      WHEN STATE = 'O' THEN ceil((UPDATED_AT-CREATED_AT)/86400000)  
-      WHEN STATE != 'O' AND EXPIRES_AT < unix_timestamp("{wa_date} 00:00:00", "yyyy-MM-dd HH:mm:ss")*1000 THEN ceil((EXPIRES_AT-CREATED_AT)/86400000)
-      ELSE 0
-   END AS DAYS
-FROM rn_t
-WHERE rn = 1
-)
-SELECT * 
-FROM calc_days_t
-WHERE 1=1
-AND EXPIRES_AT >= unix_timestamp("{YESTERDAY} 00:00:00", "yyyy-MM-dd HH:mm:ss")*1000
-AND EXPIRES_AT < unix_timestamp("{TODAY} 00:00:00", "yyyy-MM-dd HH:mm:ss")*1000 
-"""
-
-tmpdf = spark.sql(query)
-tmpdf.show()
-
-# Convert database to dictionary
-
-docs = tmpdf.toPandas().to_dict('records')
-
-# Define type of each schema
-
-def get_index_schema():
-    return {
-        "settings": {"index": {"number_of_shards": "1", "number_of_replicas": "1"}},
-        "mappings": {
-            "properties": {
-                "timestamp": {"format": "epoch_second", "type": "date"},
-                "ID": {"ignore_above": 1024, "type": "keyword"},
-                "NAME": {"ignore_above": 2048, "type": "keyword"},
-                "STATE": {"ignore_above": 1024, "type": "keyword"},
-                "EXPIRES_AT": {"format": "epoch_millis", "type": "date"},
-                "UPDATED_AT": {"format": "epoch_millis", "type": "date"},
-                "CREATED_AT": {"format": "epoch_millis", "type": "date"},
-                "DAYS": {"type": "long"},
+def process_single_day(day):
+    
+    # Query date
+    
+    wa_date = day.strftime("%Y-%m-%d")
+    TODAY = wa_date
+    YESTERDAY = (day-timedelta(days=1)).strftime("%Y-%m-$d")
+    TOYEAR = day.strftime("%Y")
+    
+    # Import data into database form
+    
+    HDFS_RUCIO_RULES_HISTORY = f'/project/awg/cms/rucio/{wa_date}/rules_history/'
+    
+    print("==============================================="
+          , "RUCIO : Rules History"
+          , "==============================================="
+          , "File Directory:", HDFS_RUCIO_RULES_HISTORY
+          , "Work Directory:", os.getcwd()
+          , "==============================================="
+          , "===============================================", sep='\n')
+    
+    rucio_rules_history = spark.read.format('avro').load(HDFS_RUCIO_RULES_HISTORY).withColumn('ID', lower(_hex(col('ID'))))
+    
+    # Query data in daily
+    
+    rucio_rules_history = rucio_rules_history.select("ID", "NAME", "STATE", "EXPIRES_AT", "UPDATED_AT", "CREATED_AT", "ACCOUNT").filter(f"""ACCOUNT IN ('crab_tape_recall')""").cache()
+    rucio_rules_history.createOrReplaceTempView("rules_history")
+    
+    query = query = f"""\
+    WITH filter_t AS (
+    SELECT ID, NAME, STATE, EXPIRES_AT, UPDATED_AT, CREATED_AT
+    FROM rules_history 
+    WHERE 1=1
+    AND CREATED_AT >= unix_timestamp("{TOYEAR}-01-01 00:00:00", "yyyy-MM-dd HH:mm:ss")*1000
+    ),
+    rn_t AS (
+    SELECT ID, NAME, STATE, EXPIRES_AT, UPDATED_AT, CREATED_AT,
+    row_number() over(partition by ID order by UPDATED_AT desc) as rn
+    FROM filter_t
+    ),
+    calc_days_t AS (
+    SELECT ID, NAME, STATE, EXPIRES_AT, UPDATED_AT, CREATED_AT,
+       CASE 
+          WHEN STATE = 'O' THEN ceil((UPDATED_AT-CREATED_AT)/86400000)  
+          WHEN STATE != 'O' AND EXPIRES_AT < unix_timestamp("{wa_date} 00:00:00", "yyyy-MM-dd HH:mm:ss")*1000 THEN ceil((EXPIRES_AT-CREATED_AT)/86400000)
+          ELSE 0
+       END AS DAYS
+    FROM rn_t
+    WHERE rn = 1
+    )
+    SELECT * 
+    FROM calc_days_t
+    WHERE 1=1
+    AND EXPIRES_AT >= unix_timestamp("{YESTERDAY} 00:00:00", "yyyy-MM-dd HH:mm:ss")*1000
+    AND EXPIRES_AT < unix_timestamp("{TODAY} 00:00:00", "yyyy-MM-dd HH:mm:ss")*1000 
+    """
+    
+    tmpdf = spark.sql(query)
+    tmpdf.show()
+    
+    # Convert database to dictionary
+    
+    docs = tmpdf.toPandas().to_dict('records')
+    
+    # Define type of each schema
+    
+    def get_index_schema():
+        return {
+            "settings": {"index": {"number_of_shards": "1", "number_of_replicas": "1"}},
+            "mappings": {
+                "properties": {
+                    "timestamp": {"format": "epoch_second", "type": "date"},
+                    "ID": {"ignore_above": 1024, "type": "keyword"},
+                    "NAME": {"ignore_above": 2048, "type": "keyword"},
+                    "STATE": {"ignore_above": 1024, "type": "keyword"},
+                    "EXPIRES_AT": {"format": "epoch_millis", "type": "date"},
+                    "UPDATED_AT": {"format": "epoch_millis", "type": "date"},
+                    "CREATED_AT": {"format": "epoch_millis", "type": "date"},
+                    "DAYS": {"type": "long"},
+                }
             }
         }
-    }
+    
+    # Send data to Opensearch
+    
+    _index_template = 'crab-tape-recall-daily'
+    client = osearch.get_es_client("os-cms.cern.ch/es", '/data/certs/monit.d/monit_spark_crab.txt', get_index_schema())
+    idx = client.get_or_create_index(timestamp=day.strftime("%s"), index_template=_index_template, index_mod="M")
+    no_of_fail_saved = client.send(idx, docs, metadata=None, batch_size=10000, drop_nulls=False)
+    
+    print("=================================== RUCIO : Rules History ====================================="
+          , "FINISHED : "
+          , len(docs), "ROWS ARE SENT"
+          , no_of_fail_saved, "ROWS ARE FAILED"
+          , "=================================== RUCIO : Rules History =====================================", sep='\n')
+    
 
-# Send data to Opensearch
-
-_index_template = 'crab-tape-recall-daily'
-client = osearch.get_es_client("os-cms.cern.ch/es", '/data/certs/monit.d/monit_spark_crab.txt', get_index_schema())
-idx = client.get_or_create_index(timestamp=day.strftime("%s"), index_template=_index_template, index_mod="M")
-no_of_fail_saved = client.send(idx, docs, metadata=None, batch_size=10000, drop_nulls=False)
-
-print("=================================== RUCIO : Rules History ====================================="
-      , "FINISHED : "
-      , len(docs), "ROWS ARE SENT"
-      , no_of_fail_saved, "ROWS ARE FAILED"
-      , "=================================== RUCIO : Rules History =====================================", sep='\n')
+for day in date_list:
+    process_single_day(day)

--- a/src/script/Monitor/crab-spark/cronjobs/crab_tape_recall_rules_history_daily.py
+++ b/src/script/Monitor/crab-spark/cronjobs/crab_tape_recall_rules_history_daily.py
@@ -120,9 +120,9 @@ def get_index_schema():
 
 # Send data to Opensearch
 
-_index_template = 'crab-tape-recall-daily-ekong'
-client = osearch.get_es_client("es-cms1.cern.ch/es", 'secret_opensearch.txt', get_index_schema())
-idx = client.get_or_create_index(timestamp=time.time(), index_template=_index_template, index_mod="M")
+_index_template = 'crab-tape-recall-daily'
+client = osearch.get_es_client("os-cms.cern.ch/es", '/data/certs/monit.d/monit_spark_crab.txt', get_index_schema())
+idx = client.get_or_create_index(timestamp=day.strftime("%s"), index_template=_index_template, index_mod="M")
 no_of_fail_saved = client.send(idx, docs, metadata=None, batch_size=10000, drop_nulls=False)
 
 print("=================================== RUCIO : Rules History ====================================="

--- a/src/script/Monitor/crab-spark/cronjobs/crab_tape_recall_updated_rules_daily.py
+++ b/src/script/Monitor/crab-spark/cronjobs/crab_tape_recall_updated_rules_daily.py
@@ -3,6 +3,17 @@ from datetime import datetime, timedelta
 import os
 import pandas as pd
 import time
+
+import argparse
+
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument("-s", "--start-date", default=None,
+  help="process data starting from this day, inclusive (YYYY-MM-DD)",)
+parser.add_argument("-e", "--end-date", default=None,
+  help="process data until this day, not included (YYYY-MM-DD)",)
+args = parser.parse_args()
+print(f"timerange: [{args.start_date} {args.end_date})" )
+
 from pyspark import SparkContext, StorageLevel
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import (
@@ -15,11 +26,9 @@ from pyspark.sql.functions import (
     round as _round,
     sum as _sum,
 )
-
 from pyspark.sql.types import (
     LongType,
 )
-
 import numpy as np
 import osearch
 from pyspark.sql import SparkSession
@@ -31,102 +40,124 @@ spark = SparkSession\
 
 # Data date
 
-TODAY = str(datetime.now())[:10]
-wa_date = TODAY
+if args.end_date:
+    end_date = datetime.strptime(args.end_date, '%Y-%m-%d')
+else:
+    end_date = datetime.now()
+    end_date = end_date.replace(minute=0, hour=0, second=0, microsecond=0)
 
-# Import data into database form
+if args.start_date:
+    start_date = datetime.strptime(args.start_date, '%Y-%m-%d')
+else:
+    start_date = end_date - timedelta(days=1)
 
-HDFS_RUCIO_DATASET_LOCKS = f'/project/awg/cms/rucio/{wa_date}/dataset_locks/part*.avro'
-HDFS_RUCIO_RSES =          f'/project/awg/cms/rucio/{wa_date}/rses/part*.avro'
-HDFS_RUCIO_RULES =         f'/project/awg/cms/rucio/{wa_date}/rules'
-print("===============================================", "File Directory:", HDFS_RUCIO_DATASET_LOCKS, "Work Directory:", os.getcwd(), "===============================================", sep='\n')
+date_list = pd.date_range(
+    start=start_date,
+    end=end_date,
+    ).to_pydatetime().tolist()
 
-print("==============================================="
-      , "RUCIO : Rules, RSEs, Dataset"
-      , "==============================================="
-      , "File Directory:", HDFS_RUCIO_DATASET_LOCKS
-      , "Work Directory:", os.getcwd()
-      , "==============================================="
-      , "===============================================", sep='\n')
-rucio_dataset_locks = spark.read.format('avro').load(HDFS_RUCIO_DATASET_LOCKS)\
-    .withColumn('BYTES', col('BYTES').cast(LongType()))\
-    .withColumn('RULE_ID', lower(_hex(col('RULE_ID'))))\
-    .withColumn('RSE_ID', lower(_hex(col('RSE_ID'))))
-rucio_dataset_locks.createOrReplaceTempView("dataset_locks")
+def process_single_day(day):
 
-rucio_rses = spark.read.format('avro').load(HDFS_RUCIO_RSES)\
-    .withColumn('ID', lower(_hex(col('ID'))))
-rucio_rses.createOrReplaceTempView("rses")
-
-rucio_rules = spark.read.format('avro').load(HDFS_RUCIO_RULES)\
-    .withColumn('ID', lower(_hex(col('ID'))))
-rucio_rules.createOrReplaceTempView("rules")
-
-# filter and query
-
-rucio_dataset_locks = rucio_dataset_locks.filter(f"""ACCOUNT IN ('crab_tape_recall')""").cache()
-rucio_rses = rucio_rses.select('ID', 'RSE', 'RSE_TYPE').cache()
-rucio_rules = rucio_rules.select('ID', 'ACCOUNT', 'DID_TYPE', 'EXPIRES_AT').cache()
-
-result_df = rucio_dataset_locks.join(rucio_rses, rucio_rses["ID"] == rucio_dataset_locks["RSE_ID"])\
-        .join(rucio_rules, rucio_rules["ID"] == rucio_dataset_locks["RULE_ID"]).drop('ID', 'RULE_ID', 'RSE_ID', 'ACCESSED_AT', 'ACCOUNT')
-
-# Convert database to dictionary
-
-docs = result_df.toPandas().to_dict('records')
-
-# Add TIMESTAMP column and convert TiB
-TIME = datetime.strptime(f"""{wa_date} 00:00:00""", "%Y-%m-%d %H:%M:%S").timestamp()*1000
-for i in range(len(docs)):
-    docs[i]['TIMESTAMP'] = TIME
-    docs[i]['SIZE_TiB'] = docs[i]["BYTES"]/1099511627776
-    del docs[i]["BYTES"]
-
-    # break down the name
-    NAME_i = docs[i]['NAME']
-    split_NAME = NAME_i.split('#')[0]
-    docs[i]['NAME_'] = NAME_i.split('#')[0]
-    split_NAME = docs[i]['NAME_'].split('/')
-    if len(split_NAME) != 4:
-        print("YO HOO !!, something wrong.", NAME_i)
-    docs[i]['PriDataset'] = split_NAME[1]
-    docs[i]['DataTier'] = split_NAME[-1]
-
-# Define type of each schema
-
-def get_index_schema():
-    return {
-        "settings": {"index": {"number_of_shards": "1", "number_of_replicas": "1"}},
-        "mappings": {
-            "properties": {
-                'SCOPE': {"ignore_above": 2048, "type": "keyword"},
-                'NAME': {"ignore_above": 2048, "type": "keyword"},
-                'STATE': {"ignore_above": 1024, "type": "keyword"},
-                'LENGTH': {"ignore_above": 1024, "type": "keyword"},
-                'SIZE_TiB': {"type": "long"},
-                'UPDATED_AT': {"format": "epoch_millis", "type": "date"},
-                'CREATED_AT': {"format": "epoch_millis", "type": "date"},
-                'RSE': {"ignore_above": 2048, "type": "keyword"},
-                'RSE_TYPE': {"ignore_above": 2048, "type": "keyword"},
-                'DID_TYPE': {"ignore_above": 1024, "type": "keyword"},
-                'EXPIRES_AT': {"format": "epoch_millis", "type": "date"},
-                'TIMESTAMP': {"format": "epoch_millis", "type": "date"},
-                'NAME_': {"ignore_above": 2048, "type": "keyword"},
-                'PriDataset': {"ignore_above": 2048, "type": "keyword"},
-                'DataTier': {"ignore_above": 2048, "type": "keyword"},
+    wa_date = day.strftime("%Y-%m-%d")
+    
+    # Import data into database form
+    
+    HDFS_RUCIO_DATASET_LOCKS = f'/project/awg/cms/rucio/{wa_date}/dataset_locks/part*.avro'
+    HDFS_RUCIO_RSES =          f'/project/awg/cms/rucio/{wa_date}/rses/part*.avro'
+    HDFS_RUCIO_RULES =         f'/project/awg/cms/rucio/{wa_date}/rules'
+    print("===============================================", "File Directory:", HDFS_RUCIO_DATASET_LOCKS, "Work Directory:", os.getcwd(), "===============================================", sep='\n')
+    
+    print("==============================================="
+          , "RUCIO : Rules, RSEs, Dataset"
+          , "==============================================="
+          , "File Directory:", HDFS_RUCIO_DATASET_LOCKS
+          , "Work Directory:", os.getcwd()
+          , "==============================================="
+          , "===============================================", sep='\n')
+    rucio_dataset_locks = spark.read.format('avro').load(HDFS_RUCIO_DATASET_LOCKS)\
+        .withColumn('BYTES', col('BYTES').cast(LongType()))\
+        .withColumn('RULE_ID', lower(_hex(col('RULE_ID'))))\
+        .withColumn('RSE_ID', lower(_hex(col('RSE_ID'))))
+    rucio_dataset_locks.createOrReplaceTempView("dataset_locks")
+    
+    rucio_rses = spark.read.format('avro').load(HDFS_RUCIO_RSES)\
+        .withColumn('ID', lower(_hex(col('ID'))))
+    rucio_rses.createOrReplaceTempView("rses")
+    
+    rucio_rules = spark.read.format('avro').load(HDFS_RUCIO_RULES)\
+        .withColumn('ID', lower(_hex(col('ID'))))
+    rucio_rules.createOrReplaceTempView("rules")
+    
+    # filter and query
+    
+    rucio_dataset_locks = rucio_dataset_locks.filter(f"""ACCOUNT IN ('crab_tape_recall')""").cache()
+    rucio_rses = rucio_rses.select('ID', 'RSE', 'RSE_TYPE').cache()
+    rucio_rules = rucio_rules.select('ID', 'ACCOUNT', 'DID_TYPE', 'EXPIRES_AT').cache()
+    
+    result_df = rucio_dataset_locks.join(rucio_rses, rucio_rses["ID"] == rucio_dataset_locks["RSE_ID"])\
+            .join(rucio_rules, rucio_rules["ID"] == rucio_dataset_locks["RULE_ID"]).drop('ID', 'RULE_ID', 'RSE_ID', 'ACCESSED_AT', 'ACCOUNT')
+    
+    # Convert database to dictionary
+    
+    docs = result_df.toPandas().to_dict('records')
+    
+    # Add TIMESTAMP column and convert TiB
+    TIME = datetime.strptime(f"""{wa_date} 00:00:00""", "%Y-%m-%d %H:%M:%S").timestamp()*1000
+    for i in range(len(docs)):
+        docs[i]['TIMESTAMP'] = TIME
+        docs[i]['SIZE_TiB'] = docs[i]["BYTES"]/1099511627776
+        del docs[i]["BYTES"]
+    
+        # break down the name
+        NAME_i = docs[i]['NAME']
+        split_NAME = NAME_i.split('#')[0]
+        docs[i]['NAME_'] = NAME_i.split('#')[0]
+        split_NAME = docs[i]['NAME_'].split('/')
+        if len(split_NAME) != 4:
+            print("YO HOO !!, something wrong.", NAME_i)
+        docs[i]['PriDataset'] = split_NAME[1]
+        docs[i]['DataTier'] = split_NAME[-1]
+    
+    # Define type of each schema
+    
+    def get_index_schema():
+        return {
+            "settings": {"index": {"number_of_shards": "1", "number_of_replicas": "1"}},
+            "mappings": {
+                "properties": {
+                    'SCOPE': {"ignore_above": 2048, "type": "keyword"},
+                    'NAME': {"ignore_above": 2048, "type": "keyword"},
+                    'STATE': {"ignore_above": 1024, "type": "keyword"},
+                    'LENGTH': {"ignore_above": 1024, "type": "keyword"},
+                    'SIZE_TiB': {"type": "long"},
+                    'UPDATED_AT': {"format": "epoch_millis", "type": "date"},
+                    'CREATED_AT': {"format": "epoch_millis", "type": "date"},
+                    'RSE': {"ignore_above": 2048, "type": "keyword"},
+                    'RSE_TYPE': {"ignore_above": 2048, "type": "keyword"},
+                    'DID_TYPE': {"ignore_above": 1024, "type": "keyword"},
+                    'EXPIRES_AT': {"format": "epoch_millis", "type": "date"},
+                    'TIMESTAMP': {"format": "epoch_millis", "type": "date"},
+                    'NAME_': {"ignore_above": 2048, "type": "keyword"},
+                    'PriDataset': {"ignore_above": 2048, "type": "keyword"},
+                    'DataTier': {"ignore_above": 2048, "type": "keyword"},
+                }
             }
         }
-    }
+        
+    # Send data to Opensearch
     
-# Send data to Opensearch
+    _index_template = 'crab-tape-recall-rules'
+    client = osearch.get_es_client("os-cms.cern.ch/es", '/data/certs/monit.d/monit_spark_crab.txt', get_index_schema())
+    idx = client.get_or_create_index(timestamp=day.strftime("%s"), index_template=_index_template, index_mod="M")
+    no_of_fail_saved = client.send(idx, docs, metadata=None, batch_size=10000, drop_nulls=False)
+    
+    print("==================================== RUCIO : Rules, RSEs, Dataset ===================================="
+          , "FINISHED : "
+          , len(docs), "ROWS ARE SENT"
+          , no_of_fail_saved, "ROWS ARE FAILED"
+          , "==================================== RUCIO : Rules, RSEs, Dataset ====================================", sep='\n')
 
-_index_template = 'crab-tape-recall-rules-ekong'
-client = osearch.get_es_client("es-cms1.cern.ch/es", 'secret_opensearch.txt', get_index_schema())
-idx = client.get_or_create_index(timestamp=time.time(), index_template=_index_template, index_mod="M")
-no_of_fail_saved = client.send(idx, docs, metadata=None, batch_size=10000, drop_nulls=False)
 
-print("==================================== RUCIO : Rules, RSEs, Dataset ===================================="
-      , "FINISHED : "
-      , len(docs), "ROWS ARE SENT"
-      , no_of_fail_saved, "ROWS ARE FAILED"
-      , "==================================== RUCIO : Rules, RSEs, Dataset ====================================", sep='\n')
+for day in date_list:
+    process_single_day(day)
+

--- a/src/script/Monitor/crab-spark/cronjobs/cron_daily.sh
+++ b/src/script/Monitor/crab-spark/cronjobs/cron_daily.sh
@@ -1,17 +1,27 @@
 #!/bin/bash
 
+## this file is deprecated, it is kept around for reference and historycal reasons
+
 docker run --rm --net=host -v /cvmfs:/cvmfs:shared -v $HOME/workdir:/workdir \
-  registry.cern.ch/cmsmonitoring/cmsmon-spark:v0.4.1.10 \
+  -v /data/certs/monit.d/monit_spark_crab.txt:/data/certs/monit.d/monit_spark_crab.txt \
+  -v /data/certs/keytabs.d/cmscrab.keytab:/data/certs/keytabs.d/cmscrab.keytab \
+  registry.cern.ch/cmsmonitoring/cmsmon-spark:v0.5.0.1 \
   bash /workdir/CRABServer/src/script/Monitor/crab-spark/cronjobs/run_spark.sh /workdir/CRABServer/src/script/Monitor/crab-spark/cronjobs/crab_data_daily.py
 
 docker run --rm --net=host -v /cvmfs:/cvmfs:shared -v $HOME/workdir:/workdir \
-  registry.cern.ch/cmsmonitoring/cmsmon-spark:v0.4.1.10 \
+  -v /data/certs/monit.d/monit_spark_crab.txt:/data/certs/monit.d/monit_spark_crab.txt \
+  -v /data/certs/keytabs.d/cmscrab.keytab:/data/certs/keytabs.d/cmscrab.keytab \
+  registry.cern.ch/cmsmonitoring/cmsmon-spark:v0.5.0.1 \
   bash /workdir/CRABServer/src/script/Monitor/crab-spark/cronjobs/run_spark.sh /workdir/CRABServer/src/script/Monitor/crab-spark/cronjobs/crab_tape_recall_updated_rules_daily.py
 
 docker run --rm --net=host -v /cvmfs:/cvmfs:shared -v $HOME/workdir:/workdir \
-  registry.cern.ch/cmsmonitoring/cmsmon-spark:v0.4.1.10 \
+  -v /data/certs/monit.d/monit_spark_crab.txt:/data/certs/monit.d/monit_spark_crab.txt \
+  -v /data/certs/keytabs.d/cmscrab.keytab:/data/certs/keytabs.d/cmscrab.keytab \
+  registry.cern.ch/cmsmonitoring/cmsmon-spark:v0.5.0.1 \
   bash /workdir/CRABServer/src/script/Monitor/crab-spark/cronjobs/run_spark.sh /workdir/CRABServer/src/script/Monitor/crab-spark/cronjobs/crab_tape_recall_rules_history_daily.py
 
 docker run --rm --net=host -v /cvmfs:/cvmfs:shared -v $HOME/workdir:/workdir \
-  registry.cern.ch/cmsmonitoring/cmsmon-spark:v0.4.1.10 \
+  -v /data/certs/monit.d/monit_spark_crab.txt:/data/certs/monit.d/monit_spark_crab.txt \
+  -v /data/certs/keytabs.d/cmscrab.keytab:/data/certs/keytabs.d/cmscrab.keytab \
+  registry.cern.ch/cmsmonitoring/cmsmon-spark:v0.5.0.1 \
   bash /workdir/CRABServer/src/script/Monitor/crab-spark/cronjobs/run_spark.sh /workdir/CRABServer/src/script/Monitor/crab-spark/cronjobs/crab_condor_daily.py

--- a/src/script/Monitor/crab-spark/cronjobs/cron_daily.sh
+++ b/src/script/Monitor/crab-spark/cronjobs/cron_daily.sh
@@ -1,27 +1,31 @@
 #!/bin/bash
 
-## this file is deprecated, it is kept around for reference and historycal reasons
+TAG=latest
+if [[ -n $1 ]]; then
+  TAG=$1
+fi
 
-docker run --rm --net=host -v /cvmfs:/cvmfs:shared -v $HOME/workdir:/workdir \
+docker run --rm --net=host -v /cvmfs:/cvmfs:shared \
+      -v /data/certs/monit.d/monit_spark_crab.txt:/data/certs/monit.d/monit_spark_crab.txt \
+      -v /data/certs/keytabs.d/cmscrab.keytab:/data/certs/keytabs.d/cmscrab.keytab \
+      registry.cern.ch/cmscrab/crabspark:${TAG} \
+      bash /data/srv/spark/run_spark.sh /data/srv/spark/crab_data_daily.py \
+
+docker run --rm --net=host -v /cvmfs:/cvmfs:shared \
+      -v /data/certs/monit.d/monit_spark_crab.txt:/data/certs/monit.d/monit_spark_crab.txt \
+      -v /data/certs/keytabs.d/cmscrab.keytab:/data/certs/keytabs.d/cmscrab.keytab \
+      registry.cern.ch/cmscrab/crabspark:${TAG} \
+      bash /data/srv/spark/run_spark.sh /data/srv/spark/crab_condor_daily.py
+
+ docker run --rm --net=host -v /cvmfs:/cvmfs:shared \
+      -v /data/certs/monit.d/monit_spark_crab.txt:/data/certs/monit.d/monit_spark_crab.txt \
+      -v /data/certs/keytabs.d/cmscrab.keytab:/data/certs/keytabs.d/cmscrab.keytab \
+      registry.cern.ch/cmscrab/crabspark:${TAG} \
+      bash /data/srv/spark/run_spark.sh /data/srv/spark/crab_tape_recall_rules_history_daily.py 
+
+docker run --rm --net=host -v /cvmfs:/cvmfs:shared \
   -v /data/certs/monit.d/monit_spark_crab.txt:/data/certs/monit.d/monit_spark_crab.txt \
   -v /data/certs/keytabs.d/cmscrab.keytab:/data/certs/keytabs.d/cmscrab.keytab \
-  registry.cern.ch/cmsmonitoring/cmsmon-spark:v0.5.0.1 \
-  bash /workdir/CRABServer/src/script/Monitor/crab-spark/cronjobs/run_spark.sh /workdir/CRABServer/src/script/Monitor/crab-spark/cronjobs/crab_data_daily.py
+  registry.cern.ch/cmscrab/crabspark:${TAG} \
+  bash /data/srv/spark/run_spark.sh /data/srv/spark/crab_tape_recall_updated_rules_daily.py
 
-docker run --rm --net=host -v /cvmfs:/cvmfs:shared -v $HOME/workdir:/workdir \
-  -v /data/certs/monit.d/monit_spark_crab.txt:/data/certs/monit.d/monit_spark_crab.txt \
-  -v /data/certs/keytabs.d/cmscrab.keytab:/data/certs/keytabs.d/cmscrab.keytab \
-  registry.cern.ch/cmsmonitoring/cmsmon-spark:v0.5.0.1 \
-  bash /workdir/CRABServer/src/script/Monitor/crab-spark/cronjobs/run_spark.sh /workdir/CRABServer/src/script/Monitor/crab-spark/cronjobs/crab_tape_recall_updated_rules_daily.py
-
-docker run --rm --net=host -v /cvmfs:/cvmfs:shared -v $HOME/workdir:/workdir \
-  -v /data/certs/monit.d/monit_spark_crab.txt:/data/certs/monit.d/monit_spark_crab.txt \
-  -v /data/certs/keytabs.d/cmscrab.keytab:/data/certs/keytabs.d/cmscrab.keytab \
-  registry.cern.ch/cmsmonitoring/cmsmon-spark:v0.5.0.1 \
-  bash /workdir/CRABServer/src/script/Monitor/crab-spark/cronjobs/run_spark.sh /workdir/CRABServer/src/script/Monitor/crab-spark/cronjobs/crab_tape_recall_rules_history_daily.py
-
-docker run --rm --net=host -v /cvmfs:/cvmfs:shared -v $HOME/workdir:/workdir \
-  -v /data/certs/monit.d/monit_spark_crab.txt:/data/certs/monit.d/monit_spark_crab.txt \
-  -v /data/certs/keytabs.d/cmscrab.keytab:/data/certs/keytabs.d/cmscrab.keytab \
-  registry.cern.ch/cmsmonitoring/cmsmon-spark:v0.5.0.1 \
-  bash /workdir/CRABServer/src/script/Monitor/crab-spark/cronjobs/run_spark.sh /workdir/CRABServer/src/script/Monitor/crab-spark/cronjobs/crab_condor_daily.py

--- a/src/script/Monitor/crab-spark/cronjobs/run_spark.sh
+++ b/src/script/Monitor/crab-spark/cronjobs/run_spark.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # work directory
-cd /workdir/CRABServer/src/script/Monitor/crab-spark/workdir/
+cd /data/srv/spark
 
 # source the environment for spark submit
 source ./bootstrap.sh
 
 # submit $1 to spark, where $1 supposes to be a data pulling file (.py)
-spark-submit --master yarn --packages org.apache.spark:spark-avro_2.12:3.3.1 $1
+spark-submit --master yarn --packages org.apache.spark:spark-avro_2.12:3.5.0 $@

--- a/src/script/Monitor/crab-spark/workdir/bootstrap.sh
+++ b/src/script/Monitor/crab-spark/workdir/bootstrap.sh
@@ -1,6 +1,16 @@
 # source the environment for spark submit
-kinit cmscrab@CERN.CH -k -t /workdir/cmscrab.keytab
-source hadoop-setconf.sh analytix 3.2 spark3
-export PYSPARK_PYTHON=/cvmfs/sft.cern.ch/lcg/releases/Python/3.9.6-b0f98/x86_64-centos7-gcc8-opt/bin/python3
-source /cvmfs/sft.cern.ch/lcg/views/LCG_103swan/x86_64-centos7-gcc11-opt/setup.sh
-python3 -m pip install opensearch-py
+kinit cmscrab@CERN.CH -k -t /data/certs/keytabs.d/cmscrab.keytab
+source hadoop-setconf.sh analytix 
+
+LCG_VER=/cvmfs/sft.cern.ch/lcg/views/LCG_105a_swan/x86_64-el9-gcc13-opt
+source  $LCG_VER/setup.sh
+export PYSPARK_PYTHON=$LCG_VER/bin/python3
+
+# i know, ugly, we should install software in the dockerfile
+# however, we really need an environment from cvmfs, and i am not sure we 
+# can have access to cvmfs at build time in gitlab
+python3 -m pip install --user opensearch-py
+
+# finish the environment
+export CRAB_KRB5_USERNAME=$(klist | grep -i Default | cut -d":" -f2 | cut -d"@" -f"1" | awk '{$1=$1};1')
+


### PR DESCRIPTION
This PR aims at refactoring a bit our spark cronjobs:

- we have a new docker image: registry.cern.ch/cmscrab/crabspark
- it is now possible to process more than one day calling a script only once [1]

I added all the data that comes from these jobs at [2] and i copied  couple of panels from there into "CRAB Overview"

[1]

it works with every script, i will use `crab_data_daily.py` as an example

```bash
docker run --rm --net=host -v /cvmfs:/cvmfs:shared \
  -v /data/certs/monit.d/monit_spark_crab.txt:/data/certs/monit.d/monit_spark_crab.txt \
  -v /data/certs/keytabs.d/cmscrab.keytab:/data/certs/keytabs.d/cmscrab.keytab \
  registry.cern.ch/cmscrab/crabspark:1723819475 \
  bash /data/srv/spark/run_spark.sh /data/srv/spark/crab_data_daily.py -s 2024-08-10 -e 2024-08-15
```

[2] https://monit-grafana.cern.ch/d/beac1005-c457-4423-8d24-714bab6c3a6a/user-dmapelli-crab-usage-spark?orgId=11