### PR TITLE
Enable install WMCore from private repository

### DIFF
--- a/cicd/crabserver_pypi/Dockerfile
+++ b/cicd/crabserver_pypi/Dockerfile
@@ -31,13 +31,18 @@ COPY --chown=${USER}:${USER} cicd/crabserver_pypi/monitor.sh ${WDIR}/monitor.sh
 RUN mkdir /build
 WORKDIR /build
 
-COPY cicd/crabserver_pypi/requirements.txt cicd/crabserver_pypi/wmcore_requirements.txt .
-# Install wmcore/crab dependencies
+COPY cicd/crabserver_pypi/requirements.txt .
+# Install dependencies
 RUN pip install -r requirements.txt
-# Getting the version number from wmcore_requirements.txt and install it with `--no-deps`.
-# When reading from file, `grep -v '^\s*#'` to ignore all comment lines, including the ones with leading whitespace ('\s' to match whitespace).
-RUN wmcore_version="$(grep -v '^\s*#' wmcore_requirements.txt | cut -d' ' -f2)" \
-    && pip install --no-deps WMCore==${wmcore_version}
+
+# create install dir
+RUN install -d -o ${USER} -g ${USER} ${WDIR}/srv/current/lib/python/site-packages
+
+# Install wmcore
+COPY cicd/crabserver_pypi/wmcore_requirements.txt \
+     cicd/crabserver_pypi/installWMCore.sh \
+     ./
+RUN ./installWMCore.sh wmcore_requirements.txt ${WDIR}/srv/current/lib/python/site-packages
 
 # Install CRAB.
 COPY --chown=${USER}:${USER} src/python/ ${WDIR}/srv/current/lib/python/site-packages

--- a/cicd/crabserver_pypi/installWMCore.sh
+++ b/cicd/crabserver_pypi/installWMCore.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    >&2 echo "Error: position arguments required."
+    >&2 echo "Usage: $0 <wmcore_requirements.txt_path> <install_path>"
+    exit 1
+fi
+
+reqfile="${1}"
+installpath="${2}"
+
+if [[ ! -d "${installpath}" ]]; then
+    >&2 echo "Error: Install path ${installpath} does not exist or not directory."
+    exit 1
+fi
+
+wmcore_repo="$(grep -v '^\s*#' "${reqfile}" | cut -d' ' -f1)"
+wmcore_version="$(grep -v '^\s*#' "${reqfile}" | cut -d' ' -f2)"
+if [[ ${wmcore_repo} =~ /github.com\/dmwm\/WMCore ]]; then
+    echo "Installing WMCore ${wmcore_version} from official repository via pip..."
+    pip install --no-deps "wmcore==${wmcore_version}"
+else
+    # simply copy all src/python to install directory
+    echo "Installing WMCore ${wmcore_version} from ${wmcore_repo} via clone..."
+    git clone  --depth 1 "${wmcore_repo}" -b "${wmcore_version}" WMCore
+    cp -rp WMCore/src/python/* "${installpath}"
+    cp -rp WMCore/bin/wmc-httpd /usr/local/bin
+    rm -rf WMCore
+fi

--- a/cicd/crabserver_pypi/installWMCore.sh
+++ b/cicd/crabserver_pypi/installWMCore.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+# This script is select proper source of WMCore according wmcore_requirements.txt
+# which has format:
+# <repo> <tag>
+# If <repo> is match "github.com/dmwm/WMCore",
+# then it will install wmcore from pip via pip.
+# Otherwise, clone tag and copy content from WMCore/src/python to install
+# directory.
+# In case the new tag is not available in PyPI, please clone tag into your
+# private repo and change wmcore_requirements.txt point to it.
+
 set -euo pipefail
 
 if [[ $# -ne 2 ]]; then
@@ -15,9 +25,11 @@ if [[ ! -d "${installpath}" ]]; then
     exit 1
 fi
 
+# Note for regex: "Match line start with zero whitespace or more , following by
+# '#' character" (the '\s' is the whitespace character).
 wmcore_repo="$(grep -v '^\s*#' "${reqfile}" | cut -d' ' -f1)"
 wmcore_version="$(grep -v '^\s*#' "${reqfile}" | cut -d' ' -f2)"
-if [[ ${wmcore_repo} =~ /github.com\/dmwm\/WMCore ]]; then
+if [[ ${wmcore_repo} =~ github.com\/dmwm\/WMCore ]]; then
     echo "Installing WMCore ${wmcore_version} from official repository via pip..."
     pip install --no-deps "wmcore==${wmcore_version}"
 else

--- a/cicd/crabserver_pypi/wmcore_requirements.txt
+++ b/cicd/crabserver_pypi/wmcore_requirements.txt
@@ -1,6 +1,9 @@
-# WMCore dependency version.
-# Only for parsing repo url and version number in the building script later.
+# Specify WMCore version to use with CRAB
 # Beware, the format is not the same as the normal python requirements.txt
+#
 # Format:
-# <repository clone url> <tag>
+# <repository url> <tag>
+#
+# Specifying repo other than "dmwm/WMCore" will use "clone-and-copy" method instead
+# of "pip install". See more detail in cicd/crabserver/installWMCore.sh
 https://github.com/dmwm/WMCore 2.3.6rc2

--- a/cicd/crabtaskworker_pypi/Dockerfile
+++ b/cicd/crabtaskworker_pypi/Dockerfile
@@ -1,14 +1,3 @@
-# caching wmcore src, need for building TaskManagerRun.tar.gz
-FROM python:3.8 AS wmcore-src
-SHELL ["/bin/bash", "-c"]
-# Use the "magic" requirements.txt from crabserver pypi
-COPY cicd/crabserver_pypi/ .
-RUN wmcore_repo="$(grep -v '^\s*#' wmcore_requirements.txt | cut -d' ' -f1)" \
-    && wmcore_version="$(grep -v '^\s*#' wmcore_requirements.txt | cut -d' ' -f2)" \
-    && git clone ${wmcore_repo} -b "${wmcore_version}" /WMCore \
-    && ( cd /WMCore; git status ) \
-    && echo "${wmcore_version}" > /wmcore_version
-
 # create data files ./data
 FROM python:3.8 AS build-data
 SHELL ["/bin/bash", "-c"]
@@ -17,11 +6,17 @@ RUN mkdir /build \
     && apt-get install -y curl zip git \
     && apt-get clean all
 WORKDIR /build
-COPY cicd/crabtaskworker_pypi/buildTWTarballs.sh cicd/crabtaskworker_pypi/buildDatafiles.sh /build/
+COPY cicd/crabtaskworker_pypi/buildTWTarballs.sh \
+     cicd/crabtaskworker_pypi/buildDatafiles.sh \
+     cicd/crabserver_pypi/wmcore_requirements.txt /build/
 COPY setup.py /build
 COPY src /build/src
 COPY scripts /build/scripts
-COPY --from=wmcore-src /WMCore /build/WMCore
+
+RUN wmcore_repo="$(grep -v '^\s*#' wmcore_requirements.txt | cut -d' ' -f1)" \
+    && wmcore_version="$(grep -v '^\s*#' wmcore_requirements.txt | cut -d' ' -f2)" \
+    && git clone  --depth 1 ${wmcore_repo} -b "${wmcore_version}" /build/WMCore \
+    && ( cd /build/WMCore; git status )
 RUN WMCOREDIR=./WMCore \
     CRABSERVERDIR=./ \
     DATAFILES_WORKDIR=./data_files\
@@ -46,6 +41,10 @@ SHELL ["/bin/bash", "-c"]
 ENV USER=crab3
 ENV WDIR=/data
 
+# add new user
+RUN useradd -m ${USER} \
+    && install -o ${USER} -d ${WDIR}
+
 # install gfal
 # symlink to workaround calling gfal from absolute path
 COPY --chown=${USER}:${USER} --from=wmcore-gfal ${WDIR}/miniconda ${WDIR}/miniconda/
@@ -68,21 +67,29 @@ RUN mkdir /build
 WORKDIR /build
 
 # install dependencies
-COPY --chown=${USER}:${USER} --from=wmcore-src /wmcore_version ./
-COPY --chown=${USER}:${USER} cicd/crabtaskworker_pypi/requirements.txt ./
+COPY cicd/crabtaskworker_pypi/requirements.txt ./
 RUN pip install -r requirements.txt \
-    && pip install --no-deps wmcore==$(cat wmcore_version) \
     && pip cache purge
+
+# create install dir
+RUN install -d -o ${USER} -g ${USER} ${WDIR}/srv/current/lib/python/site-packages
+
+# install wmcore
+COPY cicd/crabserver_pypi/wmcore_requirements.txt \
+     cicd/crabserver_pypi/installWMCore.sh \
+     ./
+RUN ./installWMCore.sh wmcore_requirements.txt ${WDIR}/srv/current/lib/python/site-packages
+
+# install crabserver
+# will replace with pip later
+COPY --chown=${USER}:${USER} src/python/ ${WDIR}/srv/current/lib/python/site-packages
+
+# copy TaskManagerRun.tar.gz
+COPY --chown=${USER}:${USER} --from=build-data /build/data_files/data ${WDIR}/srv/current/lib/python/site-packages/data/
 
 # copy htcondor config
 RUN mkdir /etc/condor
 COPY --chown=${USER}:${USER} cicd/crabtaskworker_pypi/condor_config /etc/condor/
-
-# install crabserver
-# will replace with pip later
-COPY --chown=${USER}:${USER} src/python/ ${WDIR}/srv/current/lib/python/site-packages/
-# copy TaskManagerRun.tar.gz
-COPY --chown=${USER}:${USER} --from=build-data /build/data_files/data ${WDIR}/srv/current/lib/python/site-packages/data/
 
 # copy cern openldap config
 COPY --chown=${USER}:${USER} --from=cern-cc7 /etc/openldap /etc/openldap/
@@ -98,10 +105,6 @@ RUN bash addGH.sh
 # clean up
 WORKDIR ${WDIR}
 RUN rm -rf /build
-
-# add new user and switch to user
-RUN useradd -m ${USER} \
-    && install -o ${USER} -d ${WDIR}
 
 # create working directory
 RUN install -d -o ${USER} -g ${USER} ${WDIR}/srv/tmp


### PR DESCRIPTION
Fix https://github.com/dmwm/CRABServer/issues/8582

In summary, put the conditional check into a new `installWMCore.sh` script. 
If repository specify in [wmcore_requirements.txt](https://github.com/dmwm/CRABServer/blob/f5687adbf5fddeb21526c33b623b2f5025e17945/cicd/crabserver_pypi/wmcore_requirements.txt) is `dmwm/WMCore`, always install wmcore from PyPI packages. 
Otherwise, clone it and copy whole `src/python` to install directory.