### PR TITLE
fix the X509_USER_CERT path, and also add X509_USER_PROXY here,

### DIFF
--- a/cicd/crabserver_pypi/manage.sh
+++ b/cicd/crabserver_pypi/manage.sh
@@ -14,16 +14,27 @@ if [[ -z ${COMMAND+x} || -z ${MODE+x} || -z ${DEBUG+x} || -z ${SERVICE+x} ]]; th
 fi
 
 script_env() {
-    ## app path
+    # app path
     PYTHONPATH=${PYTHONPATH:-/data/srv/current/lib/python/site-packages}
-    ## secrets
+    # secrets
     PYTHONPATH=/data/srv/current/auth/crabserver:${PYTHONPATH}
-    # finally export PYTHONPATH
+    # export PYTHONPATH
     export PYTHONPATH
 
-    ## service creds
-    export X509_USER_CERT=${X509_USER_CERT:-/data/srv/current/auth/dmwm-service-cert.pem}
-    export X509_USER_KEY=${X509_USER_KEY:-/data/srv/current/auth/dmwm-service-key.pem}
+    # cert and proxy
+    # Wa: I am not 100% sure between X509_USER_PROXY (mount to /etc/proxy/proxy)
+    # and X509_USER_CERT (mount to /data/srv/current/auth/crabserver/dmwm-service-key.pem),
+    # which file REST should use. AFAIK, for current (v3.240809) prod, we use
+    # X509_USER_PROXY which export via https://github.com/dmwm/CRABServer/blob/f5687adbf5fddeb21526c33b623b2f5025e17945/cicd/crabserver_pypi/entrypoint.sh#L28
+    # This is confirmed by put a wrong X509_USER_CERT path and unset
+    # X509_USER_PROXY which make REST unable to start.
+    # If REST really use X509_USER_PROXY, I need to confirmed that somehow
+    # WMCore keep reread the file when it use.
+    #
+    # X509_USER_PROXY already set in setup.sh, the script that run before execute this file
+    export X509_USER_PROXY=${X509_USER_PROXY:-/etc/proxy/proxy}
+    export X509_USER_CERT=${X509_USER_CERT:-/data/srv/current/auth/crabserver/dmwm-service-cert.pem}
+    export X509_USER_KEY=${X509_USER_KEY:-/data/srv/current/auth/crabserver/dmwm-service-key.pem}
 
     if [[ "${DEBUG:-}" == true ]]; then
         # this will direct WMCore/REST/Main.py to run in the foreground rather than as a demon
@@ -32,6 +43,7 @@ script_env() {
         # this will start crabserver with only one thread (default is 25) to make it easier to run pdb
         export CRABSERVER_THREAD_POOL=1
     fi
+
     # non exported vars
     CFGFILE=/data/srv/current/config/crabserver/config.py
     STATEDIR=/data/srv/state/crabserver

--- a/cicd/crabserver_pypi/manage.sh
+++ b/cicd/crabserver_pypi/manage.sh
@@ -31,7 +31,8 @@ script_env() {
     # If REST really use X509_USER_PROXY, I need to confirmed that somehow
     # WMCore keep reread the file when it use.
     #
-    # X509_USER_PROXY already set in setup.sh, the script that run before execute this file
+    # X509_USER_PROXY already set in entrypoint.sh, the script that run before
+    # execute this file
     export X509_USER_PROXY=${X509_USER_PROXY:-/etc/proxy/proxy}
     export X509_USER_CERT=${X509_USER_CERT:-/data/srv/current/auth/crabserver/dmwm-service-cert.pem}
     export X509_USER_KEY=${X509_USER_KEY:-/data/srv/current/auth/crabserver/dmwm-service-key.pem}


### PR DESCRIPTION
which already overridden by entrypoint.sh/setup.sh