### PR TITLE
adding dryrun option for task scheduling

### DIFF
--- a/src/python/TaskWorker/Main.py
+++ b/src/python/TaskWorker/Main.py
@@ -71,9 +71,7 @@ def main():
         raise ConfigException("Configuration not found")
 
     configuration = loadConfigurationFile(os.path.abspath(options.config))
-    configuration.section_('TaskScheduling')
-    configuration.TaskScheduling.selection_limit = 10
-    configuration.TaskScheduling.dry_run= True
+
     status, msg = validateConfig(configuration)
     if not status:
         raise ConfigException(msg)

--- a/src/python/TaskWorker/MasterWorker.py
+++ b/src/python/TaskWorker/MasterWorker.py
@@ -313,10 +313,10 @@ class MasterWorker(object):
             # Log the formatted table
             self.logger.info('\n%s', table)
 
-            if self.config.TaskScheduling.dry_run:
-                return selected_tasks #dry_run True (with Task Scheduling)
+            if self.config.TaskWorker.task_scheduling_dry_run:
+                return waiting_tasks 
             else:
-                return waiting_tasks  #dry_run False (without Task Scheduling)
+                return selected_tasks
 
         except Exception as e:
             self.logger.exception("Exception occurred during external scheduling: %s", str(e))
@@ -519,7 +519,7 @@ class MasterWorker(object):
         self.restartQueuedTasks()
         self.logger.debug("Master Worker Starting Main Cycle.")
         while not self.STOP:
-            selection_limit = self.config.TaskScheduling.selection_limit
+            selection_limit = self.config.TaskWorker.task_scheduling_limit
             if not self._selectWork(limit=selection_limit):
                 self.logger.warning("Selection of work failed.")
             else:

--- a/src/python/TaskWorker/MasterWorker.py
+++ b/src/python/TaskWorker/MasterWorker.py
@@ -319,7 +319,7 @@ class MasterWorker(object):
             except:
                 return selected_tasks
 
-        except Exception as e:
+        except Exception as e: # pylint: disable=W0718
             self.logger.exception("Exception occurred during external scheduling: %s", str(e))
             return []
 

--- a/src/python/TaskWorker/MasterWorker.py
+++ b/src/python/TaskWorker/MasterWorker.py
@@ -313,9 +313,10 @@ class MasterWorker(object):
             # Log the formatted table
             self.logger.info('\n%s', table)
 
-            if self.config.TaskWorker.task_scheduling_dry_run:
-                return waiting_tasks 
-            else:
+            try:
+                if self.config.TaskWorker.task_scheduling_dry_run:
+                    return waiting_tasks
+            except:
                 return selected_tasks
 
         except Exception as e:


### PR DESCRIPTION
Added taskscheduling under TaskWorker section in https://gitlab.cern.ch/ai/it-puppet-hostgroup-vocmsglidein/-/merge_requests/272 instead of as a separate section. Fixing dry run logic.