### PR TITLE
Various fix for process controller scripts (manage.sh/manage.py/etc.)

### DIFF
--- a/cicd/crabserver_pypi/env.sh
+++ b/cicd/crabserver_pypi/env.sh
@@ -11,7 +11,10 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 if [[ ${1} == '-g' ]]; then
-    eval "$("${SCRIPT_DIR}"/manage.py env -g)"
+    out="$("${SCRIPT_DIR}"/manage.py env -g)"
 else
-    eval "$("${SCRIPT_DIR}"/manage.py env -c)"
+    out="$("${SCRIPT_DIR}"/manage.py env -c)"
 fi
+echo "will source these variables: "
+echo "${out}"
+eval "${out}"

--- a/cicd/crabserver_pypi/manage.py
+++ b/cicd/crabserver_pypi/manage.py
@@ -5,8 +5,9 @@ We can even convert shell script in to python to increase code maintainability.
 """
 import argparse
 import os
+from pathlib import Path
 
-MANAGE_SH_PATH = os.path.join(__file__, 'manage.sh')
+MANAGE_SH_PATH = Path(__file__).parent / Path('manage.sh')
 
 class EnvDefault(argparse.Action): # pylint: disable=too-few-public-methods
     """

--- a/cicd/crabserver_pypi/manage.py
+++ b/cicd/crabserver_pypi/manage.py
@@ -6,6 +6,7 @@ We can even convert shell script in to python to increase code maintainability.
 import argparse
 import os
 
+MANAGE_SH_PATH = os.path.join(__file__, 'manage.sh')
 
 class EnvDefault(argparse.Action): # pylint: disable=too-few-public-methods
     """
@@ -71,4 +72,9 @@ env['SERVICE'] = args.service if hasattr(args, 'service') else ''
 
 # re exec the ./manage.sh, equivalent to `exec ./manage.sh` in shell script
 # os.execle(filepath, arg0, arg1, ..., argN, env_dict)
-os.execle('./manage.sh','./manage.sh', env)
+# arg0 is usually the exec path or simply the exec name. For example,
+# The path to the Python interpreter
+#   path = "/usr/bin/python3"
+# Arguments: the first is `arg0`, the rest are passed to the new program
+# os.execle(path, "python3", "-c", "print('CRAB!')", {"HOME": "/home/run"})
+os.execle(MANAGE_SH_PATH, MANAGE_SH_PATH, env)

--- a/cicd/crabserver_pypi/manage.py
+++ b/cicd/crabserver_pypi/manage.py
@@ -70,11 +70,9 @@ env['SERVICE'] = args.service if hasattr(args, 'service') else ''
 #import sys
 #sys.exit(0)
 
-# re exec the ./manage.sh, equivalent to `exec ./manage.sh` in shell script
+# re exec the ./manage.sh, equivalent to `exec ./manage.sh` in shell script.
 # os.execle(filepath, arg0, arg1, ..., argN, env_dict)
 # arg0 is usually the exec path or simply the exec name. For example,
-# The path to the Python interpreter
 #   path = "/usr/bin/python3"
-# Arguments: the first is `arg0`, the rest are passed to the new program
-# os.execle(path, "python3", "-c", "print('CRAB!')", {"HOME": "/home/run"})
+#   os.execle(path, "python3", "-c", "print('CRAB!')", {"HOME": "/home/run"})
 os.execle(MANAGE_SH_PATH, MANAGE_SH_PATH, env)

--- a/cicd/crabserver_pypi/manage.py
+++ b/cicd/crabserver_pypi/manage.py
@@ -26,8 +26,13 @@ class EnvDefault(argparse.Action): # pylint: disable=too-few-public-methods
         setattr(namespace, self.dest, values)
 
 myparser = argparse.ArgumentParser(description='crab service process controller')
+# SERVICE, for taskworker
+myparser.add_argument('-s', dest='service', action=EnvDefault, envvar='SERVICE',
+                         default='',
+                         help='Name of the service to run. Only use in Publisher (Publisher_schedd, Publisher_rucio)')
 
 subparsers = myparser.add_subparsers(dest='command', required=True, help='command to run')
+
 parserStart = subparsers.add_parser('start',
                                     help='start the service')
 groupModeStart = parserStart.add_mutually_exclusive_group(required=True)
@@ -38,14 +43,10 @@ groupModeStart.add_argument('-g', dest='mode', action='store_const', const='from
 parserStart.add_argument('-d', dest='debug', action='store_const', const='t',
                          default='',
                          help='Enable debug mode (foreground)')
-# env $SERVICE
-parserStart.add_argument('-s', dest='service', action=EnvDefault, envvar='SERVICE',
-                         default='',
-                         help='Name of the service to run. Only use in Publisher (Publisher_schedd, Publisher_rucio)')
 parserStop = subparsers.add_parser('stop',
                                    help='show service status (exit non-zero if service does not start)')
 parserStatus = subparsers.add_parser('status',
-                                    help='start the service')
+                                    help='status of the service (pid, value of PYTHONPATH)')
 parserEnv = subparsers.add_parser('env',
                                   help='print environment variable for sourcing it locally.')
 # Wa: it actually the same as groupModeStart but I do not know how to reuse it

--- a/cicd/crabserver_pypi/manage.sh
+++ b/cicd/crabserver_pypi/manage.sh
@@ -90,8 +90,6 @@ env_eval() {
     echo "export PYTHONPATH=${PYTHONPATH}"
     echo "export X509_USER_CERT=${X509_USER_CERT}"
     echo "export X509_USER_KEY=${X509_USER_KEY}"
-    echo "DONT_DAEMONIZE_REST=${DONT_DAEMONIZE_REST:-False}"
-    echo "CRABSERVER_THREAD_POOL=${CRABSERVER_THREAD_POOL:-1}"
 }
 
 # Main routine, perform action requested on command line.

--- a/cicd/crabserver_pypi/manage.sh
+++ b/cicd/crabserver_pypi/manage.sh
@@ -68,9 +68,12 @@ stop_srv() {
 }
 
 status_srv() {
+    # The `wmc-httpd -s` output when there is process running,
+    #   crabserver is RUNNING, PID 85298
+    # Otherwise (with exit 1)
+    #   crabserver is NOT RUNNING
+    # Note that PID is actually PGID.
     script_env
-    # 'crabserver is NOT RUNNING'
-    # 'crabserver is NOT RUNNING'
     rc=0
     out="$(wmc-httpd -s -d $STATEDIR $CFGFILE)" || rc=$?
     echo "${out}"

--- a/cicd/crabserver_pypi/manage.sh
+++ b/cicd/crabserver_pypi/manage.sh
@@ -37,7 +37,7 @@ script_env() {
     export X509_USER_CERT=${X509_USER_CERT:-/data/srv/current/auth/crabserver/dmwm-service-cert.pem}
     export X509_USER_KEY=${X509_USER_KEY:-/data/srv/current/auth/crabserver/dmwm-service-key.pem}
 
-    if [[ "${DEBUG:-}" == true ]]; then
+    if [[ -n "${DEBUG:-}" ]]; then
         # this will direct WMCore/REST/Main.py to run in the foreground rather than as a demon
         # allowing among other things to insert pdb calls in the crabserver code and debug interactively
         export DONT_DAEMONIZE_REST=True

--- a/cicd/crabtaskworker_pypi/Publisher/manage.sh
+++ b/cicd/crabtaskworker_pypi/Publisher/manage.sh
@@ -81,11 +81,16 @@ start_srv() {
 
 stop_srv() {
   nIter=1
+  maxIter=60 # 600 secs => 10 mins
   # check if publisher is still processing by look at the pb logs
   while _isPublisherBusy;  do
       # exit loop if publisher process is gone
       if [[ -z $(_getPublisherPid) ]]; then
          break;
+      elif [[ $nIter -gt $maxIter ]]; then
+          echo "Error: execeed maximum waiting time (10 mins)"
+          echo "crab-publisher is still running ${stillrunpid}"
+          exit 1
       fi
       [[ $nIter = 1 ]] && echo "Waiting for MasterPublisher to complete cycle: ."
       nIter=$((nIter+1))
@@ -110,7 +115,7 @@ stop_srv() {
 }
 
 status_srv() {
-    pid=$(_getMasterWorkerPid)
+    pid=$(_getPublisherPid)
     if [[ -z ${pid} ]]; then
         echo "Publisher's Master process is not running."
         exit 1

--- a/cicd/crabtaskworker_pypi/Publisher/manage.sh
+++ b/cicd/crabtaskworker_pypi/Publisher/manage.sh
@@ -110,8 +110,14 @@ stop_srv() {
 }
 
 status_srv() {
-    >&2 echo "Error: Not implemented."
-    exit 1
+    pid=$(_getMasterWorkerPid)
+    if [[ -z ${pid} ]]; then
+        echo "Publisher's Master process is not running."
+        exit 1
+    fi
+    echo "Publisher's Master process is running with PID ${pid}"
+    cat /proc/"${pid}"/environ | tr '\0' '\n' | grep PYTHONPATH
+    exit 0
 }
 
 

--- a/cicd/crabtaskworker_pypi/TaskWorker/manage.sh
+++ b/cicd/crabtaskworker_pypi/TaskWorker/manage.sh
@@ -96,8 +96,14 @@ stop_srv() {
 }
 
 status_srv() {
-    >&2 echo "Error: Not implemented."
-    exit 1
+    pid=$(_getMasterWorkerPid)
+    if [[ -z ${pid} ]]; then
+        echo "TaskWorker's Master process is not running."
+        exit 1
+    fi
+    echo "TaskWorker's Master process is running with PID ${pid}"
+    cat /proc/"${pid}"/environ | tr '\0' '\n' | grep PYTHONPATH
+    exit 0
 }
 
 env_eval() {


### PR DESCRIPTION
- Fix debug mode in crabserver image, check if var is set instead of boolean.
- Fix manage.sh for crabserver where `-g` does not work.
- Fix manage.py to execute manage.sh path in the same directory
- Fix manage.py `-s SERVICE` by moving to top-level, require by Publisher's manage.sh, and compatibility with other service.
- Print variables will be sourced in env.sh
- Add `./manage.py status` for all services, also print PYTHONPATH, partial fix https://github.com/dmwm/CRABServer/issues/8707
- Fix manage.sh waiting forever in Publisher https://github.com/dmwm/CRABServer/issues/8442

All tested except the last bullet.