### PR TITLE
clear PYTHONPATH before executing payload. Fix #8805

### DIFF
--- a/scripts/CMSRunAnalysis.py
+++ b/scripts/CMSRunAnalysis.py
@@ -682,7 +682,7 @@ if __name__ == "__main__":
         jobExitCode = None
         applicationName = 'CMSSW JOB' if not options.scriptExe else 'ScriptEXE'
         print(f"==== {applicationName} Execution started at {UTCNow()} ====")
-        command = "stdbuf -oL -eL "
+        command = "unset PYTHONPATH; stdbuf -oL -eL "  # make sure COMP python does not leak to CMSSW #8805
         if not options.scriptExe:
             command += 'cmsRun -j FrameworkJobReport.xml PSet.py'
         else:


### PR DESCRIPTION
with this the job stdout has
```
==== Will execute unset PYTHONPATH; stdbuf -oL -eL cmsRun -j FrameworkJobReport.xml PSet.py > cmsRun-stdout.log.tmp 2>&1
```
and jobs submitted with /CMSSW_14_2_PY312_X_2024-11-20-2300 (via client v3.241125) work 
