### PR TITLE
removing sleep in pendingwork if else

### DIFF
--- a/src/python/TaskWorker/MasterWorker.py
+++ b/src/python/TaskWorker/MasterWorker.py
@@ -586,8 +586,6 @@ class MasterWorker(object):
                 tasksInfo = [{k:v for k, v in task.items() if k in keys} for task in pendingwork]
                 self.logger.info("Retrieved a total of %d works", len(pendingwork))
                 self.logger.debug("Retrieved the following works: \n%s", str(tasksInfo))
-            else:
-                time.sleep(self.config.TaskWorker.polling)
 
             toInject = []
             for task in pendingwork:


### PR DESCRIPTION
Polling in [here](https://github.com/aspiringmind-code/CRABServer/blob/ddd6ce1ded4d1b49cf92406b39d9a47321bd6776/src/python/TaskWorker/MasterWorker.py#L618) works for both canary and master. No need for pending-else polling.