### PR TITLE
Fix #8809

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ variables:
     if [ "$SUBMIT_STATUS_TRACKING" == "false" ] && 
        [ "$CLIENT_CONFIGURATION_VALIDATION" == "false" ] && 
        [ "$CLIENT_VALIDATION_SUITE" == "false" ]; 
-    then echo "false"; else echo "false"; fi
+    then echo "true"; else echo "false"; fi
 
 # This key define variables which are later used in `!reference` tag in `rules`.
 # Ref https://docs.gitlab.com/ee/ci/jobs/index.html#hide-jobs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,11 +18,7 @@ variables:
   CLIENT_VALIDATION_SUITE: "true"
   SKIP_BUILD: "false"
   SKIP_DEPLOY: "false"
-  SKIP_SUBMIT: >
-    if [ "$SUBMIT_STATUS_TRACKING" == "false" ] && 
-       [ "$CLIENT_CONFIGURATION_VALIDATION" == "false" ] && 
-       [ "$CLIENT_VALIDATION_SUITE" == "false" ]; 
-    then echo "true"; else echo "false"; fi
+  SKIP_SUBMIT: "false"
 
 # This key define variables which are later used in `!reference` tag in `rules`.
 # Ref https://docs.gitlab.com/ee/ci/jobs/index.html#hide-jobs
@@ -260,6 +256,8 @@ deploy_publisher_rucio:
 task_submission:
   rules:
     - if: '$SUBMIT_STATUS_TRACKING == "true" || $CLIENT_VALIDATION_SUITE == "true" || $CLIENT_CONFIGURATION_VALIDATION == "true"'
+    - if: '$SUBMIT_STATUS_TRACKING == "false" && $CLIENT_VALIDATION_SUITE == "false" && $CLIENT_CONFIGURATION_VALIDATION == "false"'
+      when: never
     - !reference [.default_rules, skip_submit]
     - !reference [.default_rules, default]
     - !reference [.default_rules, release]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -256,8 +256,7 @@ deploy_publisher_rucio:
 task_submission:
   rules:
     - if: '$SUBMIT_STATUS_TRACKING == "true" || $CLIENT_VALIDATION_SUITE == "true" || $CLIENT_CONFIGURATION_VALIDATION == "true"'
-    - if: '$SUBMIT_STATUS_TRACKING == "false" && $CLIENT_VALIDATION_SUITE == "false" && $CLIENT_CONFIGURATION_VALIDATION == "false"'
-      when: never
+    - !reference [.default_rules, skip_check]
     - !reference [.default_rules, skip_submit]
     - !reference [.default_rules, default]
     - !reference [.default_rules, release]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,6 +36,9 @@ variables:
       when: never 
   skip_submit:
     - if: '$SKIP_SUBMIT == "true"'
+      when: never
+  skip_check:
+    - if: '$SUBMIT_STATUS_TRACKING == "false" && $CLIENT_CONFIGURATION_VALIDATION == "false" && $CLIENT_VALIDATION_SUITE == "false"'
       when: never 
 
 stages:
@@ -355,7 +358,7 @@ client_configuration_validation:
 check_test_result:
   rules:
     - if: '$SUBMIT_STATUS_TRACKING == "true" || $CLIENT_VALIDATION_SUITE == "true" || $CLIENT_CONFIGURATION_VALIDATION == "true"'
-    - !reference [.default_rules, skip_submit]
+    - !reference [.default_rules, skip_check]
     - !reference [.default_rules, default]
     - !reference [.default_rules, release]
   stage: check_testsuite

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -298,6 +298,7 @@ client_validation_suite:
   rules:
     - if: '$CLIENT_VALIDATION_SUITE == "false"'
       when: never
+    - !reference [.default_rules, skip_submit]
     - !reference [.default_rules, default]
     - !reference [.default_rules, release]
   stage: run_testsuite_CV
@@ -329,6 +330,7 @@ client_configuration_validation:
   rules:
     - if: '$CLIENT_CONFIGURATION_VALIDATION == "false"'
       when: never
+    - !reference [.default_rules, skip_submit]
     - !reference [.default_rules, default]
     - !reference [.default_rules, release]
   stage: run_testsuite_CCV
@@ -360,6 +362,7 @@ check_test_result:
   rules:
     - if: '$SUBMIT_STATUS_TRACKING == "true" || $CLIENT_VALIDATION_SUITE == "true" || $CLIENT_CONFIGURATION_VALIDATION == "true"'
     - !reference [.default_rules, skip_check]
+    - !reference [.default_rules, skip_submit]
     - !reference [.default_rules, default]
     - !reference [.default_rules, release]
   stage: check_testsuite

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,11 @@ variables:
   CLIENT_VALIDATION_SUITE: "true"
   SKIP_BUILD: "false"
   SKIP_DEPLOY: "false"
-  SKIP_SUBMIT: "false" 
+  SKIP_SUBMIT: >
+    if [ "$SUBMIT_STATUS_TRACKING" == "false" ] && 
+       [ "$CLIENT_CONFIGURATION_VALIDATION" == "false" ] && 
+       [ "$CLIENT_VALIDATION_SUITE" == "false" ]; 
+    then echo "false"; else echo "false"; fi
 
 # This key define variables which are later used in `!reference` tag in `rules`.
 # Ref https://docs.gitlab.com/ee/ci/jobs/index.html#hide-jobs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,6 @@ variables:
   # https://docs.docker.com/build/cache/backends/
   DOCKER_TLS_CERTDIR: "/certs"
   DOCKER_BUILDKIT: 1
-  CHECK_TEST_RESULT: "false"
   SUBMIT_STATUS_TRACKING: "true"
   CLIENT_CONFIGURATION_VALIDATION: "true"
   CLIENT_VALIDATION_SUITE: "true"
@@ -355,8 +354,8 @@ client_configuration_validation:
 
 check_test_result:
   rules:
-    - if: '$CHECK_TEST_RESULT == "false"'
-      when: never
+    - if: '$SUBMIT_STATUS_TRACKING == "true" || $CLIENT_VALIDATION_SUITE == "true" || $CLIENT_CONFIGURATION_VALIDATION == "true"'
+    - !reference [.default_rules, skip_submit]
     - !reference [.default_rules, default]
     - !reference [.default_rules, release]
   stage: check_testsuite

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,9 +13,9 @@ variables:
   # https://docs.docker.com/build/cache/backends/
   DOCKER_TLS_CERTDIR: "/certs"
   DOCKER_BUILDKIT: 1
-  SUBMIT_STATUS_TRACKING: "true"
+  STATUS_TRACKING: "true"
   CLIENT_CONFIGURATION_VALIDATION: "true"
-  CLIENT_VALIDATION_SUITE: "true"
+  CLIENT_VALIDATION: "true"
   SKIP_BUILD: "false"
   SKIP_DEPLOY: "false"
   SKIP_SUBMIT: "false"
@@ -38,7 +38,7 @@ variables:
     - if: '$SKIP_SUBMIT == "true"'
       when: never
   skip_check:
-    - if: '$SUBMIT_STATUS_TRACKING == "false" && $CLIENT_CONFIGURATION_VALIDATION == "false" && $CLIENT_VALIDATION_SUITE == "false"'
+    - if: '$STATUS_TRACKING == "false" && $CLIENT_CONFIGURATION_VALIDATION == "false" && $CLIENT_VALIDATION == "false"'
       when: never 
 
 stages:
@@ -255,7 +255,7 @@ deploy_publisher_rucio:
 
 task_submission:
   rules:
-    - if: '$SUBMIT_STATUS_TRACKING == "true" || $CLIENT_VALIDATION_SUITE == "true" || $CLIENT_CONFIGURATION_VALIDATION == "true"'
+    - if: '$STATUS_TRACKING == "true" || $CLIENT_VALIDATION == "true" || $CLIENT_CONFIGURATION_VALIDATION == "true"'
     - !reference [.default_rules, skip_check]
     - !reference [.default_rules, skip_submit]
     - !reference [.default_rules, default]
@@ -270,9 +270,9 @@ task_submission:
     - export REST_Instance  # from .env
     - export ROOT_DIR
     - export CMSSW_release=CMSSW_13_0_2
-    - export Task_Submission_Status_Tracking=$SUBMIT_STATUS_TRACKING
+    - export Task_Submission_Status_Tracking=$STATUS_TRACKING
     - export Client_Configuration_Validation=$CLIENT_CONFIGURATION_VALIDATION
-    - export Client_Validation_Suite=$CLIENT_VALIDATION_SUITE
+    - export Client_Validation_Suite=$CLIENT_VALIDATION
     - bash -x cicd/gitlab/executeTests.sh
   cache:
     - key: $CI_PIPELINE_ID
@@ -296,7 +296,7 @@ task_submission:
 
 client_validation_suite:
   rules:
-    - if: '$CLIENT_VALIDATION_SUITE == "false"'
+    - if: '$CLIENT_VALIDATION == "false"'
       when: never
     - !reference [.default_rules, skip_submit]
     - !reference [.default_rules, default]
@@ -360,7 +360,7 @@ client_configuration_validation:
 
 check_test_result:
   rules:
-    - if: '$SUBMIT_STATUS_TRACKING == "true" || $CLIENT_VALIDATION_SUITE == "true" || $CLIENT_CONFIGURATION_VALIDATION == "true"'
+    - if: '$STATUS_TRACKING == "true" || $CLIENT_VALIDATION == "true" || $CLIENT_CONFIGURATION_VALIDATION == "true"'
     - !reference [.default_rules, skip_check]
     - !reference [.default_rules, skip_submit]
     - !reference [.default_rules, default]


### PR DESCRIPTION
See https://github.com/dmwm/CRABServer/issues/8809

- Remove CHECK_TEST_RESULT variable to make it easier to understand and streamlining
- Make the pipeline more robust using rules like skip_check and skip_submit
- Now we only need to set three variables: SUBMIT_STATUS_TRACKING, CLIENT_CONFIGURATION_VALIDATION and CLIENT_VALIDATION_SUITE for both task submission and checking of their respective actions. By default, they are all set to true.
- We additionally have three skip variables SKIP_BUILD, SKIP_DEPLOY and SKIP_SUBMIT which can be used if so desired. By default they are all set to false.