### PR TITLE
CCV and TS testsuites fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ stages:
   - submit_testsuite
   - run_testsuite_CV
   - run_testsuite_CCV
-  - check_testsuite
+  - run_testsuite_TS
   - tagging_release
 
 get_env:
@@ -358,14 +358,14 @@ client_configuration_validation:
         - workdir/submitted_tasks_CCV
       policy: pull
 
-check_test_result:
+check_status_tracking:
   rules:
     - if: '$STATUS_TRACKING == "true" || $CLIENT_VALIDATION == "true" || $CLIENT_CONFIGURATION_VALIDATION == "true"'
     - !reference [.default_rules, skip_check]
     - !reference [.default_rules, skip_submit]
     - !reference [.default_rules, default]
     - !reference [.default_rules, release]
-  stage: check_testsuite
+  stage: run_testsuite_TS
   tags:
     - crab3-shell
   script:
@@ -377,24 +377,15 @@ check_test_result:
     - export CMSSW_release=CMSSW_13_0_2
     - export SCRAM_ARCH=el8_amd64_gcc11
     - export Check_Publication_Status=Yes
-    - echo ${MANUAL_CI_PIPELINE_ID}
-    # manual task name
-    - |
-        if [[ -n "${MANUAL_TASKNAME:-}" ]]; then
-            echo "${MANUAL_TASKNAME}" > workdir/submitted_tasks_TS
-            echo "${MANUAL_TASKNAME}" > workdir/submitted_tasks_CV
-            echo "${MANUAL_TASKNAME}" > workdir/submitted_tasks_CCV
-        fi
     - bash cicd/gitlab/retry.sh bash -x cicd/gitlab/executeStatusTracking.sh
   cache:
-    - key: $MANUAL_CI_PIPELINE_ID
-      fallback_keys:
-        - $CI_PIPELINE_ID
-        - submitted_tasks_TS_latest
-        - submitted_tasks_CCV_latest
-        - submitted_tasks_CV_latest
+    - key: $CI_PIPELINE_ID
       paths:
-        - workdir
+        - workdir/submitted_tasks_TS
+      policy: pull
+    - key: submitted_tasks_TS_latest
+      paths:
+        - workdir/submitted_tasks_TS
       policy: pull
 
 # if test is pass, retag with `*-stable`

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -347,7 +347,7 @@ client_configuration_validation:
     - export CMSSW_release=CMSSW_13_0_2
     - export Client_Configuration_Validation=true
     - ls workdir/submitted_tasks_CCV
-    - cicd/gitlab/retry.sh bash -x cicd/gitlab/CCV_config.sh
+    - bash cicd/gitlab/retry.sh bash -x cicd/gitlab/CCV_config.sh
   cache:
     - key: $CI_PIPELINE_ID
       paths:
@@ -385,7 +385,7 @@ check_test_result:
             echo "${MANUAL_TASKNAME}" > workdir/submitted_tasks_CV
             echo "${MANUAL_TASKNAME}" > workdir/submitted_tasks_CCV
         fi
-    - cicd/gitlab/retry.sh bash -x cicd/gitlab/executeStatusTracking.sh
+    - bash cicd/gitlab/retry.sh bash -x cicd/gitlab/executeStatusTracking.sh
   cache:
     - key: $MANUAL_CI_PIPELINE_ID
       fallback_keys:

--- a/cicd/gitlab/CCV_config.sh
+++ b/cicd/gitlab/CCV_config.sh
@@ -52,12 +52,6 @@ MESSAGE='Test failed. Investigate manually'
 # Define an associative array to hold the test results
 declare -A results=( ["SUCCESSFUL"]="successful_tests" ["FAILED"]="failed_tests" ["RETRY"]="retry_tests" )
 
-# Check if the tests passed or failed
-if [ -s "successful_tests" ] && { [ ! -e "failed_tests" ] || [[ $(<failed_tests) == *none* ]]; }; then
-    TEST_RESULT='SUCCEEDED'
-    MESSAGE='Test is done.'
-fi
-
 for result in "${!results[@]}"; do
 	if [ -s "${results[$result]}" ]; then
 		test_result=$(cat "${results[$result]}")
@@ -76,6 +70,15 @@ for result in "${!results[@]}"; do
 		echo -e "\n${result} TESTS:\n none" >> message_CCVResult_interim
 	fi
 done
+
+# Check if the tests passed or failed
+if [ -s "successful_tests" ] && { 
+    { [ ! -e "failed_tests" ] || [[ $(<failed_tests) == *none* ]]; }; 
+    && { [ ! -e "retry_tests" ] || [[ $(<retry_tests) == *none* ]]; };
+}; then
+    TEST_RESULT='SUCCEEDED'
+    MESSAGE='Test is done.'
+fi
 
 # Create the final result message
 echo -e "**Test:** Client configuration validation\n\

--- a/cicd/gitlab/CCV_config.sh
+++ b/cicd/gitlab/CCV_config.sh
@@ -35,7 +35,8 @@ if [ "X${singularity}" == X6 ] || [ "X${singularity}" == X7 ] || [ "X${singulari
     if [ "X${singularity}" == X7 ]; then scramprefix=el${singularity}; fi
     if [ "X${singularity}" == X8 ]; then scramprefix=el${singularity}; fi
     ERR=false;
-    /cvmfs/cms.cern.ch/common/cmssw-${scramprefix} -- "${ROOT_DIR}/cicd/gitlab/clientConfigurationValidation.sh" || ERR=true
+    /cvmfs/cms.cern.ch/common/cmssw-${scramprefix} -- "${ROOT_DIR}/cicd/gitlab/clientConfigurationValidation.sh"
+    ERR=$([[ $? -eq 0 || $? -eq 2 ]] && echo "false" || echo "true") #ERR is true if return is other than 0 or 2
 else
     echo "!!! I am not prepared to run for slc${singularity}."
     exit 1

--- a/cicd/gitlab/CCV_config.sh
+++ b/cicd/gitlab/CCV_config.sh
@@ -41,6 +41,10 @@ else
     exit 1
 fi
 
+if [ "$ERR" == true ]; then
+    echo "clientConfigurationValidation.sh script failed to run properly."
+    exit 1
+fi
 # Change to the working directory
 # cd ${WORK_DIR}
 
@@ -75,12 +79,14 @@ for result in "${!results[@]}"; do
 done
 
 # Check if the tests passed or failed
-# Check if the tests passed or failed
-if [ -s "successful_tests" ] && { [ ! -e "failed_tests" ] || [[ $(<failed_tests) == *none* ]]; } && { [ ! -e "retry_tests" ] || [[ $(<retry_tests) == *none* ]]; }; then
+if [ -s "failed_tests" ]; then
+    TEST_RESULT='FAILED'
+elif [ -s "retry_tests" ]; then
+    TEST_RESULT='FULL-STATUS-UNKNOWN'
+elif [ -s "successful_tests" ]; then
     TEST_RESULT='SUCCEEDED'
     MESSAGE='Test is done.'
 fi
-
 
 # Create the final result message
 echo -e "**Test:** Client configuration validation\n\

--- a/cicd/gitlab/clientConfigurationValidation.sh
+++ b/cicd/gitlab/clientConfigurationValidation.sh
@@ -14,25 +14,44 @@ echo "(debug) X509_USER_PROXY=${X509_USER_PROXY}"
 # 3. failed_tests: tests that returned exit code not equal to 0 or 2, i.e. test failed.
 #Script is used in Jenkins job CRABServer_ClientConfigurationValidation.
 
-#setup CRABClient
+# Setup CRABClient
 source "${ROOT_DIR}/cicd/gitlab/setupCRABClient.sh"
 python ${ROOT_DIR}/test/makeTests.py
 
-if [ -f "${WORK_DIR}/submitted_tasks_CCV" ]; then
-  while read task ; do
-    echo "$task"
-    test_to_execute=`echo "${task}" | grep -oP '(?<=_crab_).*(?=)'`
-    bash -x ${test_to_execute}-check.sh ${task}
+# Ensure the log files exist (creating successful_tests and error.log, and deleting/recreating retry_tests and failed_tests)
+touch ${WORK_DIR}/successful_tests ${WORK_DIR}/error.log
 
-    retVal=$?
-    if [ $retVal -eq 0 ]; then
+# Delete and recreate retry_tests and failed_tests (if they exist)
+rm -f ${WORK_DIR}/retry_tests ${WORK_DIR}/failed_tests
+touch ${WORK_DIR}/retry_tests ${WORK_DIR}/failed_tests
+
+if [ -f "${WORK_DIR}/submitted_tasks_CCV" ]; then
+  while read task; do
+    echo "Processing task: $task"
+
+    # Extract the test name from the task
+    test_to_execute=$(echo "${task}" | grep -oP '(?<=_crab_).*(?=)')
+    echo "Test to execute: ${test_to_execute}"
+
+    # Ensure the test script exists and is executable
+    if [ -x "${test_to_execute}-check.sh" ]; then
+      bash -x ${test_to_execute}-check.sh ${task}
+      retVal=$?
+      echo "Exit Code: $retVal"
+
+      if [ $retVal -eq 0 ]; then
         echo ${test_to_execute}-check.sh ${task} - $retVal >> ${WORK_DIR}/successful_tests
-    elif [ $retVal -eq 2 ]; then
+      elif [ $retVal -eq 2 ]; then
         echo ${test_to_execute}-check.sh ${task} - $retVal >> ${WORK_DIR}/retry_tests
-    else
+      else
         echo ${test_to_execute}-check.sh ${task} - $retVal >> ${WORK_DIR}/failed_tests
+      fi
+    else
+      echo "Error: ${test_to_execute}-check.sh not found or not executable" >> ${WORK_DIR}/error.log
     fi
-  done <"${WORK_DIR}/submitted_tasks_CCV"
-else echo "Error: ${WORK_DIR}/submitted_tasks_CCV is not a file"
+  done < "${WORK_DIR}/submitted_tasks_CCV"
+else
+  echo "Error: ${WORK_DIR}/submitted_tasks_CCV is not a file" >> ${WORK_DIR}/error.log
   exit 1
 fi
+

--- a/cicd/gitlab/executeStatusTracking.sh
+++ b/cicd/gitlab/executeStatusTracking.sh
@@ -27,6 +27,11 @@ if [ "X${singularity}" == X8 ]; then scramprefix=el${singularity}; fi
 ERR=false
 /cvmfs/cms.cern.ch/common/cmssw-${scramprefix} -- bash -x "${ROOT_DIR}"/cicd/gitlab/st/statusTracking.sh || ERR=true
 
+if [ "$ERR" == true ]; then
+    echo "statusTracking.sh script failed to run properly."
+    exit 1
+fi
+
 #3. Update issue with submission results
 TEST_RESULT='FAILED'
 if [ ! -s "./result" ]; then

--- a/cicd/gitlab/setupCRABClient.sh
+++ b/cicd/gitlab/setupCRABClient.sh
@@ -21,7 +21,7 @@ cd ${CMSSW_release}/src
 eval "$(scramv1 runtime -sh)"
 scram build
 
-mkdir ../venv
+mkdir -p ../venv
 
 if echo ${CMSSW_release} | grep -q CMSSW_7; then
   # when using CMSSW_7, need to force latest curl

--- a/cicd/gitlab/st/statusTracking.py
+++ b/cicd/gitlab/st/statusTracking.py
@@ -86,7 +86,7 @@ def parse_result(listOfTasks, checkPublication=False):
                 needToResubmit = True
             else:
                 result = 'TestRunning'
-        elif task['dbStatus'] in ['HOLDING', 'QUEUED', 'NEW']:
+        elif task['dbStatus'] in ['HOLDING', 'QUEUED', 'NEW', 'WAITING']:
             result = 'TestRunning'
         else:
             needToResubmit = True
@@ -147,7 +147,7 @@ def main():
     # Read all tasks from the specified files into a single list
     tasks = [
     line 
-    for file_name in ['submitted_tasks_TS', 'submitted_tasks_CCV', 'submitted_tasks_CV']
+    for file_name in ['submitted_tasks_TS']
     if os.path.exists(f'{work_dir}/{file_name}')
     for line in open(f'{work_dir}/{file_name}').readlines()
     ]

--- a/test/container/testingScripts/setupCRABClient.sh
+++ b/test/container/testingScripts/setupCRABClient.sh
@@ -15,7 +15,7 @@ scram build
 
 # creates a venv folder to test sending it
 cd ..
-mkdir venv
+mkdir -p venv
 
 if echo $CMSSW_release | grep -q CMSSW_7
 then

--- a/test/makeTests.py
+++ b/test/makeTests.py
@@ -71,8 +71,8 @@ checkStatus ${taskName} COMPLETED
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
-lookFor "Retrieved job_out.1.*.txt" commandLog.txt
-lookFor "JOB AD: CRAB_TransferOutputs = 0" "${workDir}/results/job_out.1.*.txt"
+lookFor "Retrieved job_out.1.*.txt" commandLog.txt || echo "transferOutputs: Retrieval failure job_out.1.*.txt"
+lookFor "JOB AD: CRAB_TransferOutputs = 0" "${workDir}/results/job_out.1.*.txt" || echo "transferOutputs: Retrieval failure JOB AD"
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -88,8 +88,8 @@ checkStatus ${taskName} COMPLETED
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
-lookFor "Retrieved job_out.1.*.txt" commandLog.txt
-lookFor "JOB AD: CRAB_SaveLogsFlag = 1" "${workDir}/results/job_out.1.*.txt"
+lookFor "Retrieved job_out.1.*.txt" commandLog.txt || echo "transferLogs: Retrieval failure job_out.1.*.txt"
+lookFor "JOB AD: CRAB_SaveLogsFlag = 1" "${workDir}/results/job_out.1.*.txt" || echo "transferLogs: Retrieval failure JOB AD"
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -105,8 +105,8 @@ checkStatus ${taskName} COMPLETED
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
-lookFor "JOB AD: CMS_Type = \\"Test\\"" "${workDir}/results/job_out.1.*.txt"
-lookFor "JOB AD: CMS_TaskType = \\"hctestnew\\"" "${workDir}/results/job_out.1.*.txt"
+lookFor "JOB AD: CMS_Type = \\"Test\\"" "${workDir}/results/job_out.1.*.txt" || echo "activity: Retrieval failure JOB AD"
+lookFor "JOB AD: CMS_TaskType = \\"hctestnew\\"" "${workDir}/results/job_out.1.*.txt" || echo "activity: Retrieval failure JOB AD"
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -123,8 +123,8 @@ inFile2 = '/etc/centos-release'
 changeDict = {'param': name, 'section': 'JobType', 'value': [inFile1, inFile2]}
 confChangesList = [changeDict]
 testSubmitScript = """
-lookInTarFor "^hosts" ${workDir}/inputs/*default.tgz
-lookInTarFor "^centos-release" ${workDir}/inputs/*default.tgz
+lookInTarFor "^hosts" ${workDir}/inputs/*default.tgz || echo "inputFiles: Retrieval failure in Tarlookup of hosts"
+lookInTarFor "^centos-release" ${workDir}/inputs/*default.tgz || echo "inputFiles: Retrieval failure in Tarlookup of centos-release"
 """
 validationScript = """
 checkStatus ${taskName} SUBMITTED
@@ -145,8 +145,8 @@ checkStatus ${taskName} COMPLETED
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
-lookFor "Retrieved job_out.1.*.txt" commandLog.txt
-lookFor "^Output files.*: \$" "${workDir}/results/job_out.1.*.txt"
+lookFor "Retrieved job_out.1.*.txt" commandLog.txt || echo "disableAutomaticOutputCollection: Retrieval failure job_out.1.*.txt"
+lookFor "^Output files.*: \$" "${workDir}/results/job_out.1.*.txt" || echo "disableAutomaticOutputCollection: Retrieval failure Output files"
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -168,8 +168,8 @@ checkStatus ${taskName} COMPLETED
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getoutput "--jobids=1 --proxy=$PROXY"
-lookFor "Success in retrieving output_1.root " commandLog.txt
-lookFor "Success in retrieving My_output_1.txt " commandLog.txt
+lookFor "Success in retrieving output_1.root " commandLog.txt || echo "outputFiles: Reetrieval failure output_1.root"
+lookFor "Success in retrieving My_output_1.txt " commandLog.txt  || echo "outputFiles: Retrieval failure My_output_1.txt"
 """
 if SL6:  # skip: singularity, no gfal_copy, crab getoutput can't work
     validationScript = dummyTestScript
@@ -202,8 +202,8 @@ checkStatus ${taskName} COMPLETED
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
-lookFor "Retrieved job_out.1.*.txt" commandLog.txt
-lookFor "JOB AD: RequestMemory = 2500" "${workDir}/results/job_out.1.*.txt"
+lookFor "Retrieved job_out.1.*.txt" commandLog.txt || echo "maxMemoryMB: Retrieval failure job_out.1.*.txt"
+lookFor "JOB AD: RequestMemory = 2500" "${workDir}/results/job_out.1.*.txt" || echo "maxMemoryMB: Retrieval failure JOB AD"
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -219,8 +219,8 @@ checkStatus ${taskName} COMPLETED
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
-lookFor "Retrieved job_out.1.*.txt" commandLog.txt
-lookFor "JOB AD: MaxWallTimeMins_RAW = 100" "${workDir}/results/job_out.1.*.txt"
+lookFor "Retrieved job_out.1.*.txt" commandLog.txt || echo "maxJobRuntimeMin: Retrieval failure job_out.1.*.txt"
+lookFor "JOB AD: MaxWallTimeMins_RAW = 100" "${workDir}/results/job_out.1.*.txt" || echo "maxJobRuntimeMin: Retrieval failure JOB AD"
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -241,8 +241,8 @@ checkStatus ${taskName} COMPLETED
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
-lookFor "Retrieved job_out.1.*.txt" commandLog.txt
-lookFor "JOB AD: RequestCpus = 8" "${workDir}/results/job_out.1.*.txt"
+lookFor "Retrieved job_out.1.*.txt" commandLog.txt || echo "numCores: Retrieval failure job_out.1.*.txt"
+lookFor "JOB AD: RequestCpus = 8" "${workDir}/results/job_out.1.*.txt" || echo "numCores: Retrieval failure JOB AD"
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -253,16 +253,16 @@ name = 'scriptExe'
 changeDict = {'param': name, 'value': '"SIMPLE-SCRIPT.sh"', 'section': 'JobType'}
 confChangesList = [changeDict]
 testSubmitScript = """
-lookInTarFor "^SIMPLE-SCRIPT.sh" ${workDir}/inputs/*default.tgz
+lookInTarFor "^SIMPLE-SCRIPT.sh" ${workDir}/inputs/*default.tgz || echo "scriptExe: Tarlookup failure"
 """
 validationScript = """
 checkStatus ${taskName} COMPLETED
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
-lookFor "Retrieved job_out.1.*.txt" commandLog.txt
-lookFor "SB CMSRUN starting" "${workDir}/results/job_out.1.*.txt"
-lookFor "====== arg checking: \$1 = 1" "${workDir}/results/job_out.1.*.txt"
+lookFor "Retrieved job_out.1.*.txt" commandLog.txt || echo "scriptExe: Retrieval failure job_out.1.*.txt"
+lookFor "SB CMSRUN starting" "${workDir}/results/job_out.1.*.txt" || echo "scriptExe: Retrieval failure SB CMSRUN start"
+lookFor "====== arg checking: \$1 = 1" "${workDir}/results/job_out.1.*.txt" || echo "scriptExe: Retrieval failure arg checking"
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -276,18 +276,18 @@ confChangesList.append(changeDict)
 changeDict = {'param': name, 'value': ['exitCode=666', 'gotArgs=Yes'], 'section': 'JobType'}
 confChangesList.append(changeDict)
 testSubmitScript = """
-lookInTarFor "^SIMPLE-SCRIPT.sh" ${workDir}/inputs/*default.tgz
+lookInTarFor "^SIMPLE-SCRIPT.sh" ${workDir}/inputs/*default.tgz || echo "scriptArgs: Tarlookup failure"
 """
 validationScript = """
 checkStatus ${taskName} COMPLETED
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
-lookFor "Retrieved job_out.1.*.txt" commandLog.txt
-lookFor "SB CMSRUN starting" "${workDir}/results/job_out.1.*.txt"
-lookFor "====== arg checking: \$1 = 1" "${workDir}/results/job_out.1.*.txt"
-lookFor "====== arg checking: \$2 = exitCode=666" "${workDir}/results/job_out.1.*.txt"
-lookFor "====== arg checking: \$3 = gotArgs=Yes" "${workDir}/results/job_out.1.*.txt"
+lookFor "Retrieved job_out.1.*.txt" commandLog.txt || echo "scriptArgs: Retrieval failure job_out.1.*.txt"
+lookFor "SB CMSRUN starting" "${workDir}/results/job_out.1.*.txt" || echo "scriptArgs: Retrieval failure SB CMSRUN start"
+lookFor "====== arg checking: \$1 = 1" "${workDir}/results/job_out.1.*.txt" || echo "scriptArgs: Retrieval failure arg checking"
+lookFor "====== arg checking: \$2 = exitCode=666" "${workDir}/results/job_out.1.*.txt" || echo "scriptArgs: Retrieval failure arg checking"
+lookFor "====== arg checking: \$3 = gotArgs=Yes" "${workDir}/results/job_out.1.*.txt" || echo "scriptArgs: Retrieval failure arg checking"
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -298,7 +298,7 @@ name = 'sendVenvFolder'
 changeDict = {'param': name, 'value': 'True', 'section': 'JobType'}
 confChangesList = [changeDict]
 testSubmitScript = """
-lookInTarFor "^venv/" ${workDir}/inputs/*default.tgz
+lookInTarFor "^venv/" ${workDir}/inputs/*default.tgz || echo "sendVenvFolder: Tarlookup failure"
 """
 validationScript = """
 checkStatus ${taskName} SUBMITTED
@@ -315,7 +315,7 @@ name = 'sendExternalFolder'
 changeDict = {'param': name, 'value': 'True', 'section': 'JobType'}
 confChangesList = [changeDict]
 testSubmitScript = """
-lookInTarFor "^external/" ${workDir}/inputs/*default.tgz
+lookInTarFor "^external/" ${workDir}/inputs/*default.tgz || echo "sendExternalFolder: Tarlookup failure"
 """
 validationScript = """
 checkStatus ${taskName} SUBMITTED
@@ -361,8 +361,8 @@ checkStatus ${taskName} COMPFAIL
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
-lookFor "Retrieved job_out.1.*.txt" commandLog.txt
-lookFor "request to open.*GenericTTbar/GEN-SIM-RAW" "${workDir}/results/job_out.1.*.txt"
+lookFor "Retrieved job_out.1.*.txt" commandLog.txt || echo "useParent: Retrieval failure job_out.1.*.txt"
+lookFor "request to open.*GenericTTbar/GEN-SIM-RAW" "${workDir}/results/job_out.1.*.txt" || echo "useParent: Retrieval failure"
 """
 if CMSSW8:  # skip: needed parent dataset for the sample that we can read witn CMSSW_8 is not on disk
     validationScript = dummyTestScript
@@ -382,8 +382,8 @@ checkStatus ${taskName} COMPFAIL
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
-lookFor "Retrieved job_out.1.*.txt" commandLog.txt
-lookFor "request to open.*GenericTTbar/GEN-SIM-RAW" "${workDir}/results/job_out.1.*.txt"
+lookFor "Retrieved job_out.1.*.txt" commandLog.txt || echo "secondaryInputDataset: Retrieval failure job_out.1.*.txt"
+lookFor "request to open.*GenericTTbar/GEN-SIM-RAW" "${workDir}/results/job_out.1.*.txt" || echo "secondaryInputDataset: Retrieval failure"
 """
 if SL6:  # skip: primary input used for CMSSW_7 has different lumisection numbers from the dataset above
     validationScript = dummyTestScript
@@ -405,8 +405,8 @@ checkStatus ${taskName} COMPLETED
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
-lookFor "Retrieved job_out.1.*.txt" commandLog.txt
-lookFor "== JOB AD: CRAB_AlgoArgs.*1,10,20,25" "${workDir}/results/job_out.1.*.txt"
+lookFor "Retrieved job_out.1.*.txt" commandLog.txt || echo "lumiMask-File: Retrieval failure job_out.1.*.txt"
+lookFor "== JOB AD: CRAB_AlgoArgs.*1,10,20,25" "${workDir}/results/job_out.1.*.txt" || echo "lumiMask-File: Retrieval failure JOB AD"
 """
 if SL6:  # skip: our lumiMask does not work on the primary input used for CMSSW_7 tests
     validationScript = dummyTestScript
@@ -431,8 +431,8 @@ if not SL6:  # skip on SL6, can't fetch lumMask from URL inside singularity
     statusCode=$?
     ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
     crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
-    lookFor "Retrieved job_out.1.*.txt" commandLog.txt
-    lookFor "== JOB AD: CRAB_AlgoArgs.*273158" "${workDir}/results/job_out.1.*.txt"
+    lookFor "Retrieved job_out.1.*.txt" commandLog.txt || echo "lumiMask-URL: Retrieval failure job_out.1.*.txt"
+    lookFor "== JOB AD: CRAB_AlgoArgs.*273158" "${workDir}/results/job_out.1.*.txt" || echo "lumiMask-URL: Retrieval failure JOB AD"
     """
     writeConfigFile(testName=name, listOfDicts=confChangesList)
     writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -448,7 +448,7 @@ checkStatus ${taskName} COMPLETED
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getoutput "--dump --jobids=1 --proxy=$PROXY"
-lookFor "OLFNtest/Adir" commandLog.txt
+lookFor "OLFNtest/Adir" commandLog.txt || echo "outLFNDirBase: Retrieval failure"
 """
 if SL6:  # skip: singularity, no gfal_copy, crab getoutput can't work
     validationScript = dummyTestScript
@@ -472,8 +472,8 @@ checkStatus ${taskName} COMPLETED
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
-lookFor "Retrieved job_out.1.*.txt" commandLog.txt
-lookFor "== JOB AD: CRAB_AlgoArgs.*273150" "${workDir}/results/job_out.1.*.txt"
+lookFor "Retrieved job_out.1.*.txt" commandLog.txt || echo "runRange: Retrieval failure job_out.1.*.txt"
+lookFor "== JOB AD: CRAB_AlgoArgs.*273150" "${workDir}/results/job_out.1.*.txt"|| echo "runRange: Retrieval failure JOB AD"
 """
 if SL6:  # skip: our runRange does not work on the primary input used for CMSSW_7 tests
     validationScript = dummyTestScript
@@ -498,7 +498,7 @@ checkStatus ${taskName} COMPLETED
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand status "--long --proxy=$PROXY"
-lookFor "T2_CH_CERN" commandLog.txt
+lookFor "T2_CH_CERN" commandLog.txt || echo "ignoreLocality: Retrieval failure"
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -544,8 +544,8 @@ checkStatus ${taskName} COMPLETED
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
-lookFor "Retrieved job_out.1.*.txt" commandLog.txt
-lookFor "JOB AD: DESIRED_SITES = \\"T2_DE_DESY\\"" "${workDir}/results/job_out.1.*.txt"
+lookFor "Retrieved job_out.1.*.txt" commandLog.txt || echo "whitelist: Retrieval failure job_out.1.*.txt"
+lookFor "JOB AD: DESIRED_SITES = \\"T2_DE_DESY\\"" "${workDir}/results/job_out.1.*.txt" || echo "whitelist: Retrieval failure JOB AD"
 """
 if SL6:  # skip: old dataset for CMSSW_7 has not enough locations to test this
     validationScript = dummyTestScript
@@ -569,8 +569,8 @@ checkStatus ${taskName} COMPLETED
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
-lookFor "Retrieved job_out.1.*.txt" commandLog.txt
-lookFor "JOB AD: JOB_CMSSite = \\"T1_US_FNAL\\"" "${workDir}/results/job_out.1.*.txt"
+lookFor "Retrieved job_out.1.*.txt" commandLog.txt || echo "blacklist: Retrieval failure job_out.1.*.txt"
+lookFor "JOB AD: JOB_CMSSite = \\"T1_US_FNAL\\"" "${workDir}/results/job_out.1.*.txt" || echo "blacklist: Retrieval failure JOB AD"
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -608,9 +608,9 @@ checkStatus ${taskName} COMPLETED
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
-lookFor "Retrieved job_out.1.*.txt" commandLog.txt
-lookFor "JOB AD: CRAB_UserRole = \\"production\\"" "${workDir}/results/job_out.1.*.txt"
-lookFor "attribute : /cms/Role=production/Capability=NULL" "${workDir}/results/job_out.1.*.txt"
+lookFor "Retrieved job_out.1.*.txt" commandLog.txt || echo "voRole: Retrieval failure job_out.1.*.txt"
+lookFor "JOB AD: CRAB_UserRole = \\"production\\"" "${workDir}/results/job_out.1.*.txt" || echo "voRole: Retrieval failure JOB AD"
+lookFor "attribute : /cms/Role=production/Capability=NULL" "${workDir}/results/job_out.1.*.txt" || echo "voRole: Retrieval failure attribute"
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -629,9 +629,9 @@ writeValidationScript(testName=name, validationScript=validationScript)
 #statusCode=$?
 #([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 #crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
-#lookFor "Retrieved job_out.1.*.txt" commandLog.txt
-#lookFor "JOB AD: CRAB_UserGroup = \\"itcms\\"" "${workDir}/results/job_out.1.*.txt"
-#lookFor "attribute : /cms/itcms/Role=NULL/Capability=NULL" "${workDir}/results/job_out.1.*.txt"
+#lookFor "Retrieved job_out.1.*.txt" commandLog.txt || echo "voGroup: Retrieval failure job_out.1.*.txt"
+#lookFor "JOB AD: CRAB_UserGroup = \\"itcms\\"" "${workDir}/results/job_out.1.*.txt" || echo "voGroup: Retrieval failure JOB AD"
+#lookFor "attribute : /cms/itcms/Role=NULL/Capability=NULL" "${workDir}/results/job_out.1.*.txt" || echo "voGroup: Retrieval failure attribute"
 ## now that condor does not fill x509UserProxyFirstFQAN anymore we lack a good way to check the FirstFQAN
 ##lookFor "JOB AD: x509UserProxyFirstFQAN = \\"/cms/itcms/Role=NULL/Capability=NULL\\"" "${workDir}/results/job_out.1.*.txt"
 #"""
@@ -653,7 +653,7 @@ validationScript = """
 checkStatus ${taskName} SUBMITTED
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
-lookFor "crab3@vocms059.cern.ch" statusLog.txt
+lookFor "crab3@vocms059.cern.ch" statusLog.txt || echo "scheddName: Retrieval failure"
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -686,9 +686,9 @@ checkStatus ${taskName} COMPLETED
 statusCode=$?
 ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
-lookFor "Retrieved job_out.1.*.txt" commandLog.txt
-lookFor "JOB AD: CMS_ALLOW_OVERFLOW = false" "${workDir}/results/job_out.1.*.txt"
-lookFor "JOB AD: CRAB_StageoutPolicy = \\"remote\\"" "${workDir}/results/job_out.1.*.txt"
+lookFor "Retrieved job_out.1.*.txt" commandLog.txt || echo "extraJDL: Retrieval failure job_out.1.*.txt"
+lookFor "JOB AD: CMS_ALLOW_OVERFLOW = false" "${workDir}/results/job_out.1.*.txt" || echo "extraJDL: Retrieval failure JOB AD"
+lookFor "JOB AD: CRAB_StageoutPolicy = \\"remote\\"" "${workDir}/results/job_out.1.*.txt" || echo "extraJDL: Retrieval failure JOB AD"
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)

--- a/test/makeTests.py
+++ b/test/makeTests.py
@@ -68,7 +68,8 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "JOB AD: CRAB_TransferOutputs = 0" "${workDir}/results/job_out.1.*.txt"
@@ -84,7 +85,8 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "JOB AD: CRAB_SaveLogsFlag = 1" "${workDir}/results/job_out.1.*.txt"
@@ -100,7 +102,8 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "JOB AD: CMS_Type = \\"Test\\"" "${workDir}/results/job_out.1.*.txt"
 lookFor "JOB AD: CMS_TaskType = \\"hctestnew\\"" "${workDir}/results/job_out.1.*.txt"
@@ -125,7 +128,8 @@ lookInTarFor "^centos-release" ${workDir}/inputs/*default.tgz
 """
 validationScript = """
 checkStatus ${taskName} SUBMITTED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -138,7 +142,8 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "^Output files.*: \$" "${workDir}/results/job_out.1.*.txt"
@@ -160,7 +165,8 @@ confChangesList.append(changeDict)
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getoutput "--jobids=1 --proxy=$PROXY"
 lookFor "Success in retrieving output_1.root " commandLog.txt
 lookFor "Success in retrieving My_output_1.txt " commandLog.txt
@@ -179,7 +185,8 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} SUBMITTED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -192,7 +199,8 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "JOB AD: RequestMemory = 2500" "${workDir}/results/job_out.1.*.txt"
@@ -208,7 +216,8 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "JOB AD: MaxWallTimeMins_RAW = 100" "${workDir}/results/job_out.1.*.txt"
@@ -229,7 +238,8 @@ confChangesList.append(changeDict)
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "JOB AD: RequestCpus = 8" "${workDir}/results/job_out.1.*.txt"
@@ -247,7 +257,8 @@ lookInTarFor "^SIMPLE-SCRIPT.sh" ${workDir}/inputs/*default.tgz
 """
 validationScript = """
 checkStatus ${taskName} COMPLETED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "SB CMSRUN starting" "${workDir}/results/job_out.1.*.txt"
@@ -269,7 +280,8 @@ lookInTarFor "^SIMPLE-SCRIPT.sh" ${workDir}/inputs/*default.tgz
 """
 validationScript = """
 checkStatus ${taskName} COMPLETED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "SB CMSRUN starting" "${workDir}/results/job_out.1.*.txt"
@@ -290,7 +302,8 @@ lookInTarFor "^venv/" ${workDir}/inputs/*default.tgz
 """
 validationScript = """
 checkStatus ${taskName} SUBMITTED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -306,7 +319,8 @@ lookInTarFor "^external/" ${workDir}/inputs/*default.tgz
 """
 validationScript = """
 checkStatus ${taskName} SUBMITTED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -329,7 +343,8 @@ testSubmitScript = dummyTestScript
 # but if it was sumitted, it means that DBS lookup was OK
 validationScript = """
 checkStatus ${taskName} SUBMITTED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -343,7 +358,8 @@ testSubmitScript = dummyTestScript
 # make sure that parents were really read by cmsRun
 validationScript = """
 checkStatus ${taskName} COMPFAIL
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "request to open.*GenericTTbar/GEN-SIM-RAW" "${workDir}/results/job_out.1.*.txt"
@@ -363,7 +379,8 @@ testSubmitScript = dummyTestScript
 # make sure that the secondary dataset was really used in cmsRun
 validationScript = """
 checkStatus ${taskName} COMPFAIL
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "request to open.*GenericTTbar/GEN-SIM-RAW" "${workDir}/results/job_out.1.*.txt"
@@ -385,7 +402,8 @@ testSubmitScript = dummyTestScript
 # make sure that the lumimask was really applied
 validationScript = """
 checkStatus ${taskName} COMPLETED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "== JOB AD: CRAB_AlgoArgs.*1,10,20,25" "${workDir}/results/job_out.1.*.txt"
@@ -410,7 +428,8 @@ if not SL6:  # skip on SL6, can't fetch lumMask from URL inside singularity
     # make sure that the lumimask was really applied
     validationScript = """
     checkStatus ${taskName} COMPLETED
-    [ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+    statusCode=$?
+    ([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
     crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
     lookFor "Retrieved job_out.1.*.txt" commandLog.txt
     lookFor "== JOB AD: CRAB_AlgoArgs.*273158" "${workDir}/results/job_out.1.*.txt"
@@ -426,7 +445,8 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getoutput "--dump --jobids=1 --proxy=$PROXY"
 lookFor "OLFNtest/Adir" commandLog.txt
 """
@@ -449,7 +469,8 @@ testSubmitScript = dummyTestScript
 # make sure that the run range was really applied
 validationScript = """
 checkStatus ${taskName} COMPLETED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "== JOB AD: CRAB_AlgoArgs.*273150" "${workDir}/results/job_out.1.*.txt"
@@ -474,7 +495,8 @@ confChangesList.append(changeDict)
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand status "--long --proxy=$PROXY"
 lookFor "T2_CH_CERN" commandLog.txt
 """
@@ -496,7 +518,8 @@ confChangesList.append(changeDict)
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 """
 if SL6:  # skip: those input files can't be read with CMSSW_7
     validationScript = dummyTestScript
@@ -518,7 +541,8 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "JOB AD: DESIRED_SITES = \\"T2_DE_DESY\\"" "${workDir}/results/job_out.1.*.txt"
@@ -542,7 +566,8 @@ confChangesList.append(changeDict)
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "JOB AD: JOB_CMSSite = \\"T1_US_FNAL\\"" "${workDir}/results/job_out.1.*.txt"
@@ -562,7 +587,8 @@ testSubmitScript = dummyTestScript
 # let's simply make sure that task completes
 validationScript = """
 checkStatus ${taskName} COMPLETED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -579,7 +605,8 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "JOB AD: CRAB_UserRole = \\"production\\"" "${workDir}/results/job_out.1.*.txt"
@@ -599,7 +626,8 @@ writeValidationScript(testName=name, validationScript=validationScript)
 #testSubmitScript = dummyTestScript
 #validationScript = """
 #checkStatus ${taskName} COMPLETED
-#[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+#statusCode=$?
+#([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 #crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 #lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 #lookFor "JOB AD: CRAB_UserGroup = \\"itcms\\"" "${workDir}/results/job_out.1.*.txt"
@@ -623,7 +651,8 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} SUBMITTED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 lookFor "crab3@vocms059.cern.ch" statusLog.txt
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
@@ -640,7 +669,8 @@ confChangesList.append(changeDict)
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} SUBMITTED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -653,7 +683,8 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
-[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
+statusCode=$?
+([ $statusCode -eq 0 ] || [ $statusCode -eq 2 ]) || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "JOB AD: CMS_ALLOW_OVERFLOW = false" "${workDir}/results/job_out.1.*.txt"

--- a/test/makeTests.py
+++ b/test/makeTests.py
@@ -68,6 +68,7 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "JOB AD: CRAB_TransferOutputs = 0" "${workDir}/results/job_out.1.*.txt"
@@ -83,6 +84,7 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "JOB AD: CRAB_SaveLogsFlag = 1" "${workDir}/results/job_out.1.*.txt"
@@ -98,6 +100,7 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "JOB AD: CMS_Type = \\"Test\\"" "${workDir}/results/job_out.1.*.txt"
 lookFor "JOB AD: CMS_TaskType = \\"hctestnew\\"" "${workDir}/results/job_out.1.*.txt"
@@ -122,6 +125,7 @@ lookInTarFor "^centos-release" ${workDir}/inputs/*default.tgz
 """
 validationScript = """
 checkStatus ${taskName} SUBMITTED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -134,6 +138,7 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "^Output files.*: \$" "${workDir}/results/job_out.1.*.txt"
@@ -155,6 +160,7 @@ confChangesList.append(changeDict)
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 crabCommand getoutput "--jobids=1 --proxy=$PROXY"
 lookFor "Success in retrieving output_1.root " commandLog.txt
 lookFor "Success in retrieving My_output_1.txt " commandLog.txt
@@ -173,6 +179,7 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} SUBMITTED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -185,6 +192,7 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "JOB AD: RequestMemory = 2500" "${workDir}/results/job_out.1.*.txt"
@@ -200,6 +208,7 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "JOB AD: MaxWallTimeMins_RAW = 100" "${workDir}/results/job_out.1.*.txt"
@@ -220,6 +229,7 @@ confChangesList.append(changeDict)
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "JOB AD: RequestCpus = 8" "${workDir}/results/job_out.1.*.txt"
@@ -237,6 +247,7 @@ lookInTarFor "^SIMPLE-SCRIPT.sh" ${workDir}/inputs/*default.tgz
 """
 validationScript = """
 checkStatus ${taskName} COMPLETED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "SB CMSRUN starting" "${workDir}/results/job_out.1.*.txt"
@@ -258,6 +269,7 @@ lookInTarFor "^SIMPLE-SCRIPT.sh" ${workDir}/inputs/*default.tgz
 """
 validationScript = """
 checkStatus ${taskName} COMPLETED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "SB CMSRUN starting" "${workDir}/results/job_out.1.*.txt"
@@ -278,6 +290,7 @@ lookInTarFor "^venv/" ${workDir}/inputs/*default.tgz
 """
 validationScript = """
 checkStatus ${taskName} SUBMITTED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -293,6 +306,7 @@ lookInTarFor "^external/" ${workDir}/inputs/*default.tgz
 """
 validationScript = """
 checkStatus ${taskName} SUBMITTED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -315,6 +329,7 @@ testSubmitScript = dummyTestScript
 # but if it was sumitted, it means that DBS lookup was OK
 validationScript = """
 checkStatus ${taskName} SUBMITTED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -328,6 +343,7 @@ testSubmitScript = dummyTestScript
 # make sure that parents were really read by cmsRun
 validationScript = """
 checkStatus ${taskName} COMPFAIL
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "request to open.*GenericTTbar/GEN-SIM-RAW" "${workDir}/results/job_out.1.*.txt"
@@ -347,6 +363,7 @@ testSubmitScript = dummyTestScript
 # make sure that the secondary dataset was really used in cmsRun
 validationScript = """
 checkStatus ${taskName} COMPFAIL
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "request to open.*GenericTTbar/GEN-SIM-RAW" "${workDir}/results/job_out.1.*.txt"
@@ -368,6 +385,7 @@ testSubmitScript = dummyTestScript
 # make sure that the lumimask was really applied
 validationScript = """
 checkStatus ${taskName} COMPLETED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "== JOB AD: CRAB_AlgoArgs.*1,10,20,25" "${workDir}/results/job_out.1.*.txt"
@@ -392,6 +410,7 @@ if not SL6:  # skip on SL6, can't fetch lumMask from URL inside singularity
     # make sure that the lumimask was really applied
     validationScript = """
     checkStatus ${taskName} COMPLETED
+    [ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
     crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
     lookFor "Retrieved job_out.1.*.txt" commandLog.txt
     lookFor "== JOB AD: CRAB_AlgoArgs.*273158" "${workDir}/results/job_out.1.*.txt"
@@ -407,6 +426,7 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 crabCommand getoutput "--dump --jobids=1 --proxy=$PROXY"
 lookFor "OLFNtest/Adir" commandLog.txt
 """
@@ -429,6 +449,7 @@ testSubmitScript = dummyTestScript
 # make sure that the run range was really applied
 validationScript = """
 checkStatus ${taskName} COMPLETED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "== JOB AD: CRAB_AlgoArgs.*273150" "${workDir}/results/job_out.1.*.txt"
@@ -453,6 +474,7 @@ confChangesList.append(changeDict)
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 crabCommand status "--long --proxy=$PROXY"
 lookFor "T2_CH_CERN" commandLog.txt
 """
@@ -474,6 +496,7 @@ confChangesList.append(changeDict)
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 """
 if SL6:  # skip: those input files can't be read with CMSSW_7
     validationScript = dummyTestScript
@@ -495,6 +518,7 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "JOB AD: DESIRED_SITES = \\"T2_DE_DESY\\"" "${workDir}/results/job_out.1.*.txt"
@@ -518,6 +542,7 @@ confChangesList.append(changeDict)
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "JOB AD: JOB_CMSSite = \\"T1_US_FNAL\\"" "${workDir}/results/job_out.1.*.txt"
@@ -537,6 +562,7 @@ testSubmitScript = dummyTestScript
 # let's simply make sure that task completes
 validationScript = """
 checkStatus ${taskName} COMPLETED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -553,6 +579,7 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "JOB AD: CRAB_UserRole = \\"production\\"" "${workDir}/results/job_out.1.*.txt"
@@ -572,6 +599,7 @@ writeValidationScript(testName=name, validationScript=validationScript)
 #testSubmitScript = dummyTestScript
 #validationScript = """
 #checkStatus ${taskName} COMPLETED
+#[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 #crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 #lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 #lookFor "JOB AD: CRAB_UserGroup = \\"itcms\\"" "${workDir}/results/job_out.1.*.txt"
@@ -595,6 +623,7 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} SUBMITTED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 lookFor "crab3@vocms059.cern.ch" statusLog.txt
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
@@ -611,6 +640,7 @@ confChangesList.append(changeDict)
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} SUBMITTED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 """
 writeConfigFile(testName=name, listOfDicts=confChangesList)
 writeTestSubmitScript(testName=name, testSubmitScript=testSubmitScript)
@@ -623,6 +653,7 @@ confChangesList = [changeDict]
 testSubmitScript = dummyTestScript
 validationScript = """
 checkStatus ${taskName} COMPLETED
+[ $? -eq 0 ] || [ $? -eq 2 ] || exit 1
 crabCommand getlog "--short --jobids=1 --proxy=$PROXY"
 lookFor "Retrieved job_out.1.*.txt" commandLog.txt
 lookFor "JOB AD: CMS_ALLOW_OVERFLOW = false" "${workDir}/results/job_out.1.*.txt"

--- a/test/testUtils.py
+++ b/test/testUtils.py
@@ -40,11 +40,11 @@ function checkStatus {
       [ ${isSub} -eq 0 ] && [ ${isDone} -eq 0 ] && [ ${isFailed} -eq 0 ] && exit 1
       ;;
     COMPLETED)
-      [ ${isSub} -eq 1 ] && exit 2  # ask for a check later on
+      [ ${isSub} -eq 1 ] && return 2  # ask for a check later on
       [ ${isDone} -eq 0 ] && exit 1
       ;;
     COMPFAIL)
-      [ ${isSub} -eq 1 ] && exit 2  # ask for a check later on
+      [ ${isSub} -eq 1 ] && return 2  # ask for a check later on
       [ ${isDone} -eq 0 ] && [ ${isFailed} -eq 0 ] && exit 1
   esac
   return 0

--- a/test/testUtils.py
+++ b/test/testUtils.py
@@ -55,7 +55,7 @@ function lookFor {
   local string="$1"
   local file="$2"
   grep -q "${string}" ${file}
-  [ $? -ne 0 ] && exit 1
+  [ $? -ne 0 ] && return 1
   return 0
 }
 
@@ -64,7 +64,7 @@ function lookInTarFor {
   local file="$1"
   local tarball="$2"
   tar tf ${tarball} | grep -q ${file}
-  [ $? -ne 0 ] && exit 1
+  [ $? -ne 0 ] && return 1
   return 0
 }
 


### PR DESCRIPTION
Major changes include:
- Handling of return status 2 instead of exit in CCV
- Separating TS testing from CV and CCV
- Usage of return values from checkStatus function