### PR TITLE
Fix8913

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -360,7 +360,8 @@ client_configuration_validation:
 
 check_status_tracking:
   rules:
-    - if: '$STATUS_TRACKING == "true" || $CLIENT_VALIDATION == "true" || $CLIENT_CONFIGURATION_VALIDATION == "true"'
+    - if: '$STATUS_TRACKING == "false"'
+      when: never
     - !reference [.default_rules, skip_check]
     - !reference [.default_rules, skip_submit]
     - !reference [.default_rules, default]

--- a/cicd/gitlab/st/statusTracking.py
+++ b/cicd/gitlab/st/statusTracking.py
@@ -70,11 +70,9 @@ def parse_result(listOfTasks, checkPublication=False):
                 else:
                     needToResubmit = True
                 if checkPublication and 'nopublication' not in task['taskName']:
-                    # remove probe jobs (job id of X-Y kind) if any from count
-                    jobsToPublish = total_jobs
-                    for job in task['jobs'].keys():
-                        if '-' in job:
-                            jobsToPublish -= 1
+                    # Remove probe jobs (job id of X-Y kind) from count
+                    probe_jobs_count = sum(1 for job in task['jobs'].keys() if '-' in job)
+                    jobsToPublish = total_jobs - probe_jobs_count
                     if published_in_transfersdb == jobsToPublish and published_in_dbs == jobsToPublish:
                         result = 'TestPassed'
                     elif failedPublications:

--- a/cicd/gitlab/st/statusTracking.py
+++ b/cicd/gitlab/st/statusTracking.py
@@ -65,21 +65,18 @@ def parse_result(listOfTasks, checkPublication=False):
             task['pubSummary'] = '%d/%d/%d' % (failedPublications, published_in_transfersdb, published_in_dbs)
 
             if total_jobs > 0 and ('finished', total_jobs) in task['jobsPerStatus'].items():
+                if task['status'] == 'COMPLETED':
+                    result = 'TestPassed'
+                else:
+                    needToResubmit = True
                 if checkPublication and 'nopublication' not in task['taskName']:
-                    # Remove probe jobs (job id of X-Y kind) from count
-                    probe_jobs_count = sum(1 for job in task['jobs'].keys() if '-' in job)
-                    jobsToPublish = total_jobs - probe_jobs_count
-                    if published_in_transfersdb == jobsToPublish and published_in_dbs == jobsToPublish:
+                    if published_in_transfersdb == total_jobs and published_in_dbs == total_jobs:
                         result = 'TestPassed'
                     elif failedPublications:
                         #result = 'TestFailed'
                         needToResubmitPublication = True
                     else:
                         result = 'TestRunning'
-                if task['status'] == 'COMPLETED':
-                    result = 'TestPassed'
-                else:
-                    needToResubmit = True
             elif any(k in task['jobsPerStatus'] for k in ('failed', 'held')):
                 needToResubmit = True
             else:

--- a/cicd/gitlab/st/statusTracking.py
+++ b/cicd/gitlab/st/statusTracking.py
@@ -65,10 +65,6 @@ def parse_result(listOfTasks, checkPublication=False):
             task['pubSummary'] = '%d/%d/%d' % (failedPublications, published_in_transfersdb, published_in_dbs)
 
             if total_jobs > 0 and ('finished', total_jobs) in task['jobsPerStatus'].items():
-                if task['status'] == 'COMPLETED':
-                    result = 'TestPassed'
-                else:
-                    needToResubmit = True
                 if checkPublication and 'nopublication' not in task['taskName']:
                     # Remove probe jobs (job id of X-Y kind) from count
                     probe_jobs_count = sum(1 for job in task['jobs'].keys() if '-' in job)
@@ -80,6 +76,10 @@ def parse_result(listOfTasks, checkPublication=False):
                         needToResubmitPublication = True
                     else:
                         result = 'TestRunning'
+                if task['status'] == 'COMPLETED':
+                    result = 'TestPassed'
+                else:
+                    needToResubmit = True
             elif any(k in task['jobsPerStatus'] for k in ('failed', 'held')):
                 needToResubmit = True
             else:


### PR DESCRIPTION
See Issue https://github.com/dmwm/CRABServer/issues/8913
The check for task['status'] == Completed should happen after the checkpublication condition
Tested ```{'TN': '250206_133625:crabint1_crab_20250206_143624', 'testResult': 'TestPassed', 'dbStatus': 'SUBMITTED', 'combinedStatus': 'COMPLETED', 'jobsPerStatus': {'finished': 1, 'probe': 5, 'rescheduled': 0}, 'publication (fail/tdb/DBS)': '0/0/0'}```