### PR TITLE
Enable new code in cache status

### DIFF
--- a/scripts/task_process/cache_status.py
+++ b/scripts/task_process/cache_status.py
@@ -555,6 +555,26 @@ def summarizeFjrParseResults(checkpoint):
         return errDict, newCheckpoint
     return None, 0
 
+def reportDagStatusToDB(status):
+    """
+    argument
+    status : int: status of the DAG as per
+    https://htcondor.readthedocs.io/en/latest/automated-workflows/dagman-information-files.html#current-node-status-file
+    Most status values in there are only relevant for nodes.
+    For the DAG we usually expect to find 3 or 5 only
+    0 (STATUS_NOT_READY): At least one parent has not yet finished or the node is a FINAL node.
+    1 (STATUS_READY): All parents have finished, but the node is not yet running.
+    2 (STATUS_PRERUN): The node’s PRE script is running.
+    3 (STATUS_SUBMITTED): The node’s HTCondor job(s) are in the queue.
+    4 (STATUS_POSTRUN): The node’s POST script is running.
+    5 (STATUS_DONE): The node has completed successfully.
+    6 (STATUS_ERROR): The node has failed.
+    7 (STATUS_FUTILE): The node will never run because an ancestor node failed.
+    """
+
+    # to be implemented
+    return
+
 def main():
     """
     parse condor job_log from last checkpoint until now and write summary in status_cache files
@@ -573,6 +593,8 @@ def main():
         # to keep the txt file locally, useful for debugging, when we remove the old code:
         storeNodesInfoInTxtFile(updatedInfo)
         storeNodesInfoInJSONFile(updatedInfo)
+
+        reportDagStatusToDB(updatedInfo['nodes']['DagStatus'])
 
     except Exception:  # pylint: disable=broad-except
         logging.exception("error during main loop")


### PR DESCRIPTION
this enables "new" code in cache-status.py which aimed to be simply a reformatting for "readibility". This step should have been done about 3 years ago, but somehow fell into a crack.
I would like to have this consolidated before progressing with reporting DAG status to DB. Since new code is easier to deal with.
But since cache_status is critical, we need to check very well.

Initial test is in https://gitlab.cern.ch/crab3/CRABServer/-/pipelines/10996720 - OK
Adding Status Tracking https://gitlab.cern.ch/crab3/CRABServer/-/pipelines/10996905 - OK