### PR TITLE
DagmanCreator updates num_jobs in taks. Fix #7766

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -19,9 +19,10 @@ import tarfile
 import hashlib
 import tempfile
 from ast import literal_eval
+from urllib.parse import urlencode
 
 from ServerUtilities import MAX_DISK_SPACE, MAX_IDLE_JOBS, MAX_POST_JOBS, TASKLIFETIME
-from ServerUtilities import getLock, checkS3Object, pythonListToClassAdExprTree
+from ServerUtilities import getLock, checkS3Object, getColumn, pythonListToClassAdExprTree
 
 import TaskWorker.DataObjects.Result
 from TaskWorker.Actions.TaskAction import TaskAction
@@ -1255,6 +1256,19 @@ class DagmanCreator(TaskAction):
         filesForSched.append('splitting-summary.json')
 
         self.prepareTarballForSched(filesForSched, subdags)
+
+        # update numner of jobs in this task in task table.
+        # add to current value to properly deal with automatic splitting
+        numJobsHere =kw['task']['jobcount']
+        # fetch previous value from DB
+        data = {'subresource': 'search', 'workflow': taskname}
+        try:
+            taskDict, _, _ = self.crabserver.get(api='task', data=data)
+        previousNumJobs = int(getColumn(taskDict, 'tm_num_jobs'))
+        numJobs = previousNumJobs + numJobsHere
+        data = {'subresource': 'edit', 'column': 'tm_num_jobs',
+                'value': numJobs, 'workflow': taskname}
+        self.crabserver.post(api='task', data=urlencode(data))
 
         return jobSubmit, params, ["InputFiles.tar.gz"], splitterResult
 

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -1262,8 +1262,7 @@ class DagmanCreator(TaskAction):
         numJobsHere =kw['task']['jobcount']
         # fetch previous value from DB
         data = {'subresource': 'search', 'workflow': taskname}
-        try:
-            taskDict, _, _ = self.crabserver.get(api='task', data=data)
+        taskDict, _, _ = self.crabserver.get(api='task', data=data)
         previousNumJobs = int(getColumn(taskDict, 'tm_num_jobs'))
         numJobs = previousNumJobs + numJobsHere
         data = {'subresource': 'edit', 'column': 'tm_num_jobs',


### PR DESCRIPTION
a bit ugly for my test. Pisses me off that we have a `task` dictionary which does not have all columns from DB. But let's make sure it work first, and beautify later.

**Note: needs a REST built with changes from https://github.com/dmwm/CRABServer/pull/8978**