### PR TITLE
add logging of slaves queue. Fix #9022

### DIFF
--- a/src/python/TaskWorker/Actions/Recurring/BaseRecurringAction.py
+++ b/src/python/TaskWorker/Actions/Recurring/BaseRecurringAction.py
@@ -1,3 +1,4 @@
+""" Need a doc string here """
 import time
 import logging
 import os
@@ -5,12 +6,14 @@ import os
 from TaskWorker.DataObjects.Result import Result
 
 def handleRecurring(resthost, dbInstance, config, task, procnum, action):
+    """ hanldes recurring actions """
     actionClass = action.split('.')[-1]
     mod = __import__(action, fromlist=actionClass)
     result = getattr(mod, actionClass)(config.TaskWorker.logsDir).execute(resthost, dbInstance, config, task, procnum)
     return result
 
 class BaseRecurringAction:
+    """ base class for all recurring actions """
     def __init__(self, logsDir):
         self.lastExecution = 0
         # set the logger
@@ -25,17 +28,23 @@ class BaseRecurringAction:
         self.logger.setLevel(logging.DEBUG)
 
     def isTimeToGo(self):
+        """ True if it is time ro execute this action """
         timetogo = time.time() - self.lastExecution > self.pollingTime * 60
         if timetogo:
             self.lastExecution = time.time()
         return timetogo
 
-    def execute(self, resthost, dbinstance, config, task, procnum):
+    def execute(self, resthost, dbinstance, config, task, procnum):  # pylint: disable=unused-argument
+        """
+        runs a recurring action
+        All classes inheriting from this Base class must define the _execute() method
+        (note the underscore character in front ! )
+        """
         try:
             self.logger.info("Executing %s", task)
             self._execute(config, task)
             return Result(task=task, result="OK")
-        except Exception as ex:
+        except Exception as ex:  # pylint: disable=broad-except
             self.logger.error("Error while runnig recurring action.")
             self.logger.exception(ex)
             return Result(task=task, err="RecurringAction FAILED")

--- a/src/python/TaskWorker/Actions/Recurring/BaseRecurringAction.py
+++ b/src/python/TaskWorker/Actions/Recurring/BaseRecurringAction.py
@@ -7,7 +7,8 @@ from TaskWorker.DataObjects.Result import Result
 def handleRecurring(resthost, dbInstance, config, task, procnum, action):
     actionClass = action.split('.')[-1]
     mod = __import__(action, fromlist=actionClass)
-    getattr(mod, actionClass)(config.TaskWorker.logsDir).execute(resthost, dbInstance, config, task, procnum)
+    result = getattr(mod, actionClass)(config.TaskWorker.logsDir).execute(resthost, dbInstance, config, task, procnum)
+    return result
 
 class BaseRecurringAction:
     def __init__(self, logsDir):
@@ -33,8 +34,8 @@ class BaseRecurringAction:
         try:
             self.logger.info("Executing %s", task)
             self._execute(config, task)
-            return Result(task=task['tm_taskname'], result="OK")
+            return Result(task=task, result="OK")
         except Exception as ex:
             self.logger.error("Error while runnig recurring action.")
             self.logger.exception(ex)
-            return Result(task=task['tm_taskname'], err="RecurringAction FAILED")
+            return Result(task=task, err="RecurringAction FAILED")

--- a/src/python/TaskWorker/MasterWorker.py
+++ b/src/python/TaskWorker/MasterWorker.py
@@ -604,12 +604,20 @@ class MasterWorker(object):
             for action in self.recurringActions:
                 if action.isTimeToGo():
                     #Maybe we should use new slaves and not reuse the ones used for the tasks
-                    self.logger.debug("Injecting recurring action: \n%s", (str(action.__module__)))
-                    self.slaves.injectWorks([(handleRecurring, {'tm_username': 'recurring', 'tm_taskname' : action.__module__}, 'FAILED', action.__module__)])
+                    # use an unique ID to track this action
+                    actionName = str(action.__module__).split('.')[-1]
+                    now = time.strftime("%y%m%d_%H%M%S", time.localtime())
+                    actionName += '.' + now
+                    self.logger.debug("Injecting recurring action: \n%s", actionName)
+                    self.slaves.injectWorks([(handleRecurring, {'tm_username': 'recurring', 'tm_taskname' : actionName}, 'FAILED', action.__module__)])
 
             self.logger.info('Master Worker status:')
             self.logger.info(' - free slaves: %d', self.slaves.freeSlaves())
             self.logger.info(' - acquired tasks: %d', self.slaves.queuedTasks())
+            if self.slaves.queuedTasks():
+                working = self.slaves.listWorks()
+                for wid, work in working.items():
+                    self.logger.info(f"      wid {wid} : {work['workflow']}")
             self.logger.info(' - tasks pending in queue: %d', self.slaves.pendingTasks())
 
             time.sleep(self.config.TaskWorker.polling)

--- a/src/python/TaskWorker/Worker.py
+++ b/src/python/TaskWorker/Worker.py
@@ -145,10 +145,13 @@ def processWorkerLoop(inputs, results, resthost, dbInstance, procnum, logger, lo
 
         removeTaskLogHandler(logger, taskhandler)
 
+        logger.debug("About to put out message in results queue for workid %s", workid)
+        logger.debug(" out.result: %s - out.task: %s ", outputs.result, outputs.task)
         results.put({
                      'workid': workid,
                      'out' : outputs
                     })
+        logger.debug("Done")
 
 
 def processWorker(inputs, results, resthost, dbInstance, logsDir, procnum):
@@ -284,7 +287,7 @@ class Worker(object):
                     self.logger.debug('Completed work %d on %s', workid, taskname)
                 else:
                     # recurring actions do not return a Result object
-                    self.logger.debug('Completed work %s', str(out))
+                    self.logger.debug('Completed work %d %s', workid, str(out))
 
                 if isinstance(out['out'], list):
                     allout.extend(out['out'])
@@ -306,6 +309,15 @@ class Worker(object):
 
         :return int: number of working slaves."""
         return len(self.working)
+
+    def listQueuedTasks(self):
+        """ list tasks being worked on """
+        tasks = [ v['workflow'] for v in self.working.values() ]
+        return tasks
+
+    def listWorks(self):
+        """ list what's being worked on"""
+        return self.working
 
     def queueableTasks(self):
         """Depending on the queue size limit

--- a/src/python/TaskWorker/Worker.py
+++ b/src/python/TaskWorker/Worker.py
@@ -140,7 +140,7 @@ def processWorkerLoop(inputs, results, resthost, dbInstance, procnum, logger, lo
             out, _, _ = executeCommand("ps u -p %s | awk '{sum=sum+$6}; END {print sum/1024}'" % os.getpid())
             msg = "RSS after finishing %s: %s MB" % (task['tm_taskname'], out.strip())
             logger.debug(msg)
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             logger.exception("Problem getting worker RSS:")
 
         removeTaskLogHandler(logger, taskhandler)


### PR DESCRIPTION
these are changes that I have been using in my [branch](https://github.com/belforte/CRABServer/tree/add-diagnostic-to-Worker), and which are running currently in canary.
In that branch I have also modified code so that `./start.sh -d` option runs only MasterWorker in debug mode, while keeping the subprocesses pool for the slaves, but adding another option for that seems too much complexity which we may never use, so have left it out and that's why I am not merging that branch.

I think the additional logging is good to have anyhow and allows us to progress with new code like the [add info to TaskTable](https://github.com/dmwm/CRABServer/tree/addInfoToTasks-03-25).

All in all since the problem in #9014 is not easily reproducible, we may want to  move to new code anyhow and simply investigate when it happens.
