### PR TITLE
report DAG status, NJob to DB. Fix #7766 Fix #8394

### DIFF
--- a/scripts/dag_bootstrap_startup.sh
+++ b/scripts/dag_bootstrap_startup.sh
@@ -214,25 +214,32 @@ else
     if [ ! -f task_process/task_process_running ];
     then
         echo "creating and executing task process daemon jdl"
+        # grepping from _CONDOR_JOB_AD give us double-quoted strings as needed for defining classAds in JDL
         TASKNAME=`grep '^CRAB_ReqName =' $_CONDOR_JOB_AD | awk '{print $NF;}'`
         USERNAME=`grep '^CRAB_UserHN =' $_CONDOR_JOB_AD | awk '{print $NF;}'`
+        RESTHOST=`grep '^CRAB_RestHost =' $_CONDOR_JOB_AD | awk '{print $NF;}'`
+        PROXYFILE=`grep '^x509userproxy =' $_CONDOR_JOB_AD | awk '{print $NF;}'`
+        DBINSTANCE=`grep '^CRAB_DbInstance =' $_CONDOR_JOB_AD | awk '{print $NF;}'`
         CMSTYPE=`grep '^CMS_Type =' $_CONDOR_JOB_AD | awk '{print $NF;}'`
         CMSWMTOOL=`grep '^CMS_WMTool =' $_CONDOR_JOB_AD | awk '{print $NF;}'`
         CMSTTASKYPE=`grep '^CMS_TaskType =' $_CONDOR_JOB_AD | awk '{print $NF;}'`
         CMSSUBMISSIONTOOL=`grep '^CMS_SubmissionTool =' $_CONDOR_JOB_AD | awk '{print $NF;}'`
 cat > task_process/daemon.jdl << EOF
-Universe      = local
-Executable    = task_process/task_proc_wrapper.sh
-Arguments     = $REQUEST_NAME
-Log           = task_process/daemon.PC.log
-Output        = task_process/daemon.out.\$(Cluster).\$(Process)
-Error         = task_process/daemon.err.\$(Cluster).\$(Process)
-+CRAB_ReqName = $TASKNAME
-+CRAB_UserHN  = $USERNAME
-+CMS_Type     = $CMSTYPE
-+CMS_WMTool   = $CMSWMTOOL
-+CMS_TaskType = $CMSTTASKYPE
-+CMS_SubmissionTool = $CMSSUBMISSIONTOOL
+Universe   = local
+Executable = task_process/task_proc_wrapper.sh
+Arguments  = $REQUEST_NAME
+Log        = task_process/daemon.PC.log
+Output     = task_process/daemon.out.\$(Cluster).\$(Process)
+Error      = task_process/daemon.err.\$(Cluster).\$(Process)
+MY.CRAB_ReqName     = $TASKNAME
+MY.CRAB_UserHN      = $USERNAME
+MY.CRAB_RestHost    = $RESTHOST
+MY.CRAB_DbInstance  = $DBINSTANCE
+MY.X509UserProxy    = $PROXYFILE
+MY.CMS_Type         = $CMSTYPE
+MY.CMS_WMTool       = $CMSWMTOOL
+MY.CMS_TaskType     = $CMSTTASKYPE
+MY.CMS_SubmissionTool = $CMSSUBMISSIONTOOL
 
 Queue 1
 EOF

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -19,9 +19,10 @@ import tarfile
 import hashlib
 import tempfile
 from ast import literal_eval
+from urllib.parse import urlencode
 
 from ServerUtilities import MAX_DISK_SPACE, MAX_IDLE_JOBS, MAX_POST_JOBS, TASKLIFETIME
-from ServerUtilities import getLock, checkS3Object, pythonListToClassAdExprTree
+from ServerUtilities import getLock, checkS3Object, getColumn, pythonListToClassAdExprTree
 
 import TaskWorker.DataObjects.Result
 from TaskWorker.Actions.TaskAction import TaskAction
@@ -36,7 +37,6 @@ from WMCore.WMRuntime.Tools.Scram import ARCH_TO_OS, SCRAM_TO_ARCH
 
 import htcondor2 as htcondor
 import classad2 as classad
-
 
 DAG_HEADER = """
 
@@ -768,6 +768,7 @@ class DagmanCreator(TaskAction):
 
         # SB should have a createDagSpects() methos to move away a lot of following code
 
+        task = kwargs['task']
         startjobid = kwargs.get('startjobid', 0)
         # parentDag below is only used during automatic splitting
         # possible values in each stage are:  probe: 0, tail: 1/2/3, processing: None
@@ -1160,6 +1161,9 @@ class DagmanCreator(TaskAction):
         elif int(jobSubmit['My.CRAB_FailedNodeLimit']) < 0:
             jobSubmit['My.CRAB_FailedNodeLimit'] = "-1"
 
+        # last thing, update number of jobs in this task in Task table
+        # using the numer of jobs in this (sub)DAGta
+        self.reportNumJobToDB(task, len(dagSpecs))
 
         return jobSubmit, splitterResult, subdags
 
@@ -1177,6 +1181,44 @@ class DagmanCreator(TaskAction):
             self.logger.error(msg)
             return []
         return highPrioUsers
+
+    def reportNumJobToDB(self, task, nJobs):
+        # update numner of jobs in this task in task table.
+        numJobsHere = nJobs
+        taskname = task['tm_taskname']
+        if self.runningInTW:
+            # things are easy
+            self.logger.info('Reporting numJobs from TW: %s', numJobsHere)
+            data = {'subresource': 'edit', 'column': 'tm_num_jobs',
+                    'value': numJobsHere, 'workflow': taskname}
+            self.crabserver.post(api='task', data=urlencode(data))
+        else:
+            # running in HTC AP host, i.e. automatic splitting, running inside PreDAG
+            # in the HTC AP there is no crabserver from "the TW slave process" so create one now
+            self.logger.info('Reporting numJobs from AP (preDag)')
+            with open(os.environ['_CONDOR_JOB_AD'], 'r', encoding='utf-8') as fd:
+                ad = classad.parseOne(fd)
+            host = ad['CRAB_RestHost']
+            dbInstance = ad['CRAB_DbInstance']
+            cert = ad['X509UserProxy']
+            reqname = ad['CRAB_Reqname']
+            self.logger.info(f"host {host} dbInstance {dbInstance} cert {cert}")
+            self.logger.info(f"taskname {taskname}  reqname {reqname}")
+            from RESTInteractions import CRABRest  # pylint: disable=import-outside-toplevel
+            crabserver = CRABRest(host, cert, cert, retry=3, userAgent='CRABSchedd')
+            crabserver.setDbInstance(dbInstance)
+            # fetch previous value from DB and  add to current value
+            data = {'subresource': 'search', 'workflow': taskname}
+            taskDict, _, _ = crabserver.get(api='task', data=data)
+            previousNumJobs = int(getColumn(taskDict, 'tm_num_jobs'))
+            self.logger.info(f"previousNumJobs {previousNumJobs}")
+            self.logger.info(f"numJobsHere {numJobsHere}")
+            numJobs = previousNumJobs + numJobsHere
+            # report
+            data = {'subresource': 'edit', 'column': 'tm_num_jobs',
+                    'value': numJobs, 'workflow': taskname}
+            R = crabserver.post(api='task', data=urlencode(data))
+            self.logger.info(f"HTTP POST returned {R}")
 
     def executeInternal(self, *args, **kw):
         """ all real work is done here """


### PR DESCRIPTION
this PR brings in 3 things

1. reports to DB Number of Jobs in DAG. Works also for automatic splitting.
2. reports to DB status of DAG. More work still needed for automatic splitting, but OK otherwise
3. runs new version of status_cache.py code which was in since years but never enabled. At the moment the new version is run "parassitically", output compared and mail sent to Stefano in case of difference.

I'd like to have this in Canary so I can make sure that 3. is OK (or fix) and to get examples of more complex automatic splitting jobs to finalize code