### PR TITLE
fix typo in commit f247e4ad

### DIFF
--- a/scripts/Utils/CheckTapeRecall.py
+++ b/scripts/Utils/CheckTapeRecall.py
@@ -60,7 +60,7 @@ def sendAndCheck(document):
     # print(type(document), document)
     # PROD
     response = send(document)
-    msg = f"With document: {document}.\nStatus code: {response.status.code}. Message: {response.text}"
+    msg = f"With document: {document}.\nStatus code: {response.status_code}. Message: {response.text}"
     print(msg)
 
 def main():


### PR DESCRIPTION
in commit f247e4ad `status_code` had been changed by mistake to `status.code`