### PR TITLE
give StatusTracking more time to complete

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -498,6 +498,7 @@ check_status_tracking:
     - export CMSSW_release=$CMSSW_release
     - export SCRAM_ARCH=el8_amd64_gcc11
     - export Check_Publication_Status=Yes
+    - export RETRY_SLEEP_SECONDS=1800
     - bash cicd/gitlab/retry.sh bash -x cicd/gitlab/executeStatusTracking.sh
   cache:
     - key: "Key_${CI_PIPELINE_ID}_${CMSSW_release}"


### PR DESCRIPTION
currently tests are retried every 15min up to 10 times. But StatusTracking has large tasks which often requires resubmission, and it can easily take a few hours.
I am increasing to 30min the sleep time at each iteration.