### PR TITLE
Handle kill in rucio aso 8429

### DIFF
--- a/scripts/task_process/cache_status.py
+++ b/scripts/task_process/cache_status.py
@@ -400,6 +400,10 @@ def parseCondorLog(cacheDoc):
     newCacheDoc['fjrParseResCheckpoint'] = newFjrParseResCheckpoint
     newCacheDoc['nodes'] = nodes
     newCacheDoc['nodeMap'] = nodeMap
+    logging.info(f"Full dagStatus is {nodes['DagStatus']}")
+    collapsedDagStatus = collapseDAGStatus(nodes['DagStatus'])
+    logging.info(f"Collapsed DAG status for reportig is {collapsedDagStatus}")
+    newCacheDoc['overallDagStatus'] = collapsedDagStatus
     return newCacheDoc
 
 
@@ -504,22 +508,13 @@ def summarizeFjrParseResults(checkpoint):
     return None, 0
 
 
-def reportDagStatusToDB(dagStatus):
+def reportDagStatusToDB(statusName):
     """
     argument
-    dagStatus : a dictionary. Example for normal (no autom. splitt.) task:
-     { "SubDagStatus": {}, "SubDags": {}, "Timestamp": 1741859306,
-      "NodesTotal": 30, "DagStatus": 6 }
-       Example for an automatic splitting task with not tails:
-     {'SubDagStatus': {'Job0SubJobs': 99, 'Job1SubJobs': 5},
-      'SubDags': {0: {'Timestamp': 1744826643, 'NodesTotal': 26, 'DagStatus': 5}},
-       'Timestamp': 1744823021, 'NodesTotal': 6, 'DagStatus': 5}
-    this is the value of the `DagStatus' key in the 'nodes' dictionary
-    created inside parseNodeStateV2 function
+    statusName: string : the name to insert in Tasks table
     """
-    statusName = collapseDAGStatus((dagStatus))
+    #statusName = collapseDAGStatus((dagStatus))
     logging.info("UPDATE DAG STATUS IN TASK DB")
-    logging.info(f"Full dagStatus is {dagStatus}")
     logging.info(f"Will report {statusName}")
 
     with open(os.environ['_CONDOR_JOB_AD'], 'r', encoding='utf-8') as fd:
@@ -544,7 +539,19 @@ def reportDagStatusToDB(dagStatus):
 
 
 def collapseDAGStatus(dagInfo):
-    """Collapse the status of one or several DAGs to a single one.
+    """
+    Collapse the status of one or several DAGs to a single one.
+
+    argument
+    dagStatus : a dictionary. Example for normal (no autom. splitt.) task:
+     { "SubDagStatus": {}, "SubDags": {}, "Timestamp": 1741859306,
+      "NodesTotal": 30, "DagStatus": 6 }
+       Example for an automatic splitting task with not tails:
+     {'SubDagStatus': {'Job0SubJobs': 99, 'Job1SubJobs': 5},
+      'SubDags': {0: {'Timestamp': 1744826643, 'NodesTotal': 26, 'DagStatus': 5}},
+       'Timestamp': 1744823021, 'NodesTotal': 6, 'DagStatus': 5}
+    this is the value of the `DagStatus' key in the 'nodes' dictionary
+    created inside parseNodeStateV2 function
 
     Take into account that subdags can be submitted to the queue on the
     schedd, but not yet started.
@@ -651,7 +658,8 @@ def main():
         # make sure that we only do this when status has changed, not every 5 minutes
         # even if...all in all.. one call per task every 5min is a drop in the ocean
         # isTimeToReport
-        reportDagStatusToDB(updatedInfo['nodes']['DagStatus'])
+        #reportDagStatusToDB(updatedInfo['nodes']['DagStatus'])
+        reportDagStatusToDB(updatedInfo['overallDagStatus'])
 
     except Exception:  # pylint: disable=broad-except
         logging.exception("error during main loop")

--- a/scripts/task_process/cache_status.py
+++ b/scripts/task_process/cache_status.py
@@ -607,7 +607,7 @@ def collapseDAGStatus(dagInfo):
 
 def translateDagStatus(status):
     """
-    from a number to a string which CRAB people can understand
+    Translate from a number to a string which CRAB people can understand
     From
     https://htcondor.readthedocs.io/en task_process/cache_status.py
 /latest/automated-workflows/dagman-information-files.html#current-node-status-file

--- a/src/python/ASO/Rucio/Main.py
+++ b/src/python/ASO/Rucio/Main.py
@@ -37,7 +37,7 @@ def main():
     # default here must change because theses current value is too low (chunk=2/max=5)
     opt.add_argument("--replicas-chunk-size", dest="replicas_chunk_size", default=5, type=int,
                      help="")
-    opt.add_argument("--max-file-per-dataset", dest="max_file_per_dataset", default=20, type=int,
+    opt.add_argument("--max-file-per-dataset", dest="max_file_per_dataset", default=100, type=int,
                      help="")
     opt.add_argument("--last-line-path", dest="last_line_path",
                      default='task_process/transfers/last_transfer.txt',
@@ -63,7 +63,7 @@ def main():
     opt.add_argument("--ignore-bookkeeping-block-complete", dest="ignore_bookkeeping_block_complete",
                      action='store_true',
                      help="")
-    opt.add_argument("--open-dataset-timeout", dest="open_dataset_timeout", default=1*60*60, type=int, # 1 hours
+    opt.add_argument("--open-dataset-timeout", dest="open_dataset_timeout", default=4*60*60, type=int, # 4 hours
                      help="Open dataset timeout in seconds")
     opt.add_argument("--lfn2pfn-map-path", dest="lfn2pfn_map_path",
                      default='task_process/transfers/lfn2pfn_map.json',

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -364,7 +364,7 @@ class DagmanCreator(TaskAction):
         jobSubmit['My.CRAB_RetryOnASOFailures'] = retry_aso
         if task['tm_output_lfn'].startswith('/store/user/rucio') or \
                 task['tm_output_lfn'].startswith('/store/group/rucio'):
-            jobSubmit['My.CRAB_ASOTimeout'] = str(getattr(self.config.TaskWorker, 'ASORucioTimeout', 0))
+            jobSubmit['My.CRAB_ASOTimeout'] = str(2 * TASKLIFETIME)  # effectivley infinite
         else:
             jobSubmit['My.CRAB_ASOTimeout'] = str(getattr(self.config.TaskWorker, 'ASOTimeout', 0))
         jobSubmit['My.CRAB_RestHost'] = classad.quote(task['resthost'])

--- a/src/python/TaskWorker/Actions/DagmanSubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanSubmitter.py
@@ -502,7 +502,7 @@ class DagmanSubmitter(TaskAction.TaskAction):
         dagJobJDL['My.CRAB_TaskEndTime'] = str(int(task['tm_start_time']) + TASKLIFETIME)
         #For task management info see https://github.com/dmwm/CRABServer/issues/4681#issuecomment-302336451
         dagJobJDL["LeaveJobInQueue"] = "True"
-        dagJobJDL["PeriodicHold"] = "time() > CRAB_TaskEndTime"
+        dagJobJDL["PeriodicRemove"] = "time() > CRAB_TaskEndTime"
         dagJobJDL["OnExitHold"] = "(ExitCode =!= UNDEFINED && ExitCode != 0)"
         dagJobJDL["OnExitRemove"] = "( ExitSignal =?= 11 || (ExitCode =!= UNDEFINED && ExitCode >=0 && ExitCode <= 2))"
         # dagJobJDL["OtherJobRemoveRequirements"] = "DAGManJobId =?= ClusterId"  # appears unused SB


### PR DESCRIPTION
Fixes #8429 via closing dataset if overallDagStatus is final  and a these connected sub-issues
-  do not timeout PostJob when using Rucio. Fix #9078
- Remove DAGs after TASKLIFETIME. Fix #9077

