### PR TITLE
use docker dns in runContainer script

### DIFF
--- a/src/script/Container/runContainer.sh
+++ b/src/script/Container/runContainer.sh
@@ -111,7 +111,14 @@ else
   DOCKER_IMAGE=${TW_REPO:-registry.cern.ch/cmscrab}/crabtaskworker:${TW_VERSION}
 fi
 
-docker run --name ${SERVICE} -t --net host --privileged $DOCKER_OPT $DOCKER_VOL $DOCKER_IMAGE $COMMAND > $tmpfile
+HOST_IP=$(ifconfig eth0|grep 'inet '|awk '{print $2}')
+if [[ -z "$HOST_IP" ]]; then
+  echo "Could not determine host IP. Exiting."
+  exit 1
+fi
+DOCKER_DNS="--dns ${HOST_IP}"
+
+docker run --name ${SERVICE} -t --net host --privileged $DOCKER_DNS $DOCKER_OPT $DOCKER_VOL $DOCKER_IMAGE $COMMAND > $tmpfile
 if [[ "${SERVICE}" == TaskWorker_monit_*  ]]; then
   echo "TaskWorker_monit_* detected, waiting for it to finish..."
   docker_wait_return=$(docker wait ${SERVICE})


### PR DESCRIPTION
Fix #9074 
Inside the containers:
DNS was not going through the host’s DNS cache (127.0.0.53 managed by systemd-resolved).
Instead, containers were resolving domains directly via CERN’s upstream DNS servers (137.138.16.5, etc.), bypassing the host's caching and configuration. This behavior was not desired, as it breaks centralized DNS resolution and caching.
 
By using --dns $HOST_IP Now containers resolve DNS via the host’s DNS stack (e.g., systemd-resolved), achieving DNS caching and consistent config. resolv.conf inside the container matches the host's. DNS queries from inside the container route via the host's resolver (systemd-resolved). No more direct queries from containers to CERN DNS servers.