### PR TITLE
use docker dns

### DIFF
--- a/src/script/Container/runContainer.sh
+++ b/src/script/Container/runContainer.sh
@@ -111,8 +111,14 @@ else
   DOCKER_IMAGE=${TW_REPO:-registry.cern.ch/cmscrab}/crabtaskworker:${TW_VERSION}
 fi
 
+HOST_IP=$(ip -4 addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
+if [[ -z "$HOST_IP" ]]; then
+  echo "Could not determine host IP. Exiting."
+  exit 1
+fi
+DOCKER_DNS="--dns ${HOST_IP}"
 
-docker run --name ${SERVICE} -t --net host --privileged $DOCKER_OPT $DOCKER_VOL $DOCKER_IMAGE $COMMAND > $tmpfile
+docker run --name ${SERVICE} -t --net host --privileged $DOCKER_DNS $DOCKER_OPT $DOCKER_VOL $DOCKER_IMAGE $COMMAND > $tmpfile
 if [[ "${SERVICE}" == TaskWorker_monit_*  ]]; then
   echo "TaskWorker_monit_* detected, waiting for it to finish..."
   docker_wait_return=$(docker wait ${SERVICE})

--- a/src/script/Container/runContainer.sh
+++ b/src/script/Container/runContainer.sh
@@ -111,7 +111,14 @@ else
   DOCKER_IMAGE=${TW_REPO:-registry.cern.ch/cmscrab}/crabtaskworker:${TW_VERSION}
 fi
 
-docker run --name ${SERVICE} -t --net host --privileged $DOCKER_OPT $DOCKER_VOL $DOCKER_IMAGE $COMMAND > $tmpfile
+HOST_IP=$(ifconfig eth0|grep 'inet '|awk '{print $2}')
+if [[ -z "$HOST_IP" ]]; then
+  echo "Could not determine host IP. Exiting."
+  exit 1
+fi
+DOCKER_DNS="--dns ${HOST_IP}"
+
+docker run --name ${SERVICE} -t --net host --privileged $DOCKER_DNS $DOCKER_OPT $DOCKER_VOL $DOCKER_IMAGE $COMMAND > $tmpfile
 if [[ "${SERVICE}" == TaskWorker_monit_*  ]]; then
   echo "TaskWorker_monit_* detected, waiting for it to finish..."
   docker_wait_return=$(docker wait ${SERVICE})

--- a/src/script/Container/runContainer.sh
+++ b/src/script/Container/runContainer.sh
@@ -111,14 +111,7 @@ else
   DOCKER_IMAGE=${TW_REPO:-registry.cern.ch/cmscrab}/crabtaskworker:${TW_VERSION}
 fi
 
-HOST_IP=$(ifconfig eth0|grep 'inet '|awk '{print $2}')
-if [[ -z "$HOST_IP" ]]; then
-  echo "Could not determine host IP. Exiting."
-  exit 1
-fi
-DOCKER_DNS="--dns ${HOST_IP}"
-
-docker run --name ${SERVICE} -t --net host --privileged $DOCKER_DNS $DOCKER_OPT $DOCKER_VOL $DOCKER_IMAGE $COMMAND > $tmpfile
+docker run --name ${SERVICE} -t --net host --privileged $DOCKER_OPT $DOCKER_VOL $DOCKER_IMAGE $COMMAND > $tmpfile
 if [[ "${SERVICE}" == TaskWorker_monit_*  ]]; then
   echo "TaskWorker_monit_* detected, waiting for it to finish..."
   docker_wait_return=$(docker wait ${SERVICE})


### PR DESCRIPTION
Fix #9074 
Tested on crab-dev-tw03
```
[vchakrav@crab-dev-tw03 ~]$ ./runContainer.sh -v v3.250509-stable -s TaskWorker
Sleeping for 3 seconds.
Running containers:
CONTAINER ID   IMAGE                                                        COMMAND                  CREATED         STATUS         PORTS     NAMES
cfa2a172b870   registry.cern.ch/cmscrab/crabtaskworker:v3.250509-stable     "tini -- /data/run.sh"   3 seconds ago   Up 3 seconds             TaskWorker
```