### PR TITLE
Enable ArgoCD deployment on test2, test12, support normal base ref from kustomization resources

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -227,7 +227,7 @@ deploy_server:
     - export KUBECONFIG=$KUBECONFIG_FILE
     - export DESIRED_IMAGE="registry.cern.ch/cmscrab/crabserver:${IMAGE_TAG}"
     - |
-      if [[ "$KUBECONTEXT" =~ ^cmsweb-test14$ ]]; then
+      if [[ "$KUBECONTEXT" =~ ^cmsweb-test(2|12|14)$ ]]; then
         export DEPLOY_ENV="${KUBECONTEXT#cmsweb-}"         # "test14"
         export NEW_IMAGE_TAG="${IMAGE_TAG}"
         ./cicd/scripts/updateCRABServerImageTag.sh


### PR DESCRIPTION
Regarding #9170, #9152 

Guys, I've enable test2, test12 to use argocd deployment approach via sidecar.

Also have extended the script, such that CI/CD could easily switch back and forth from workaround branch and on-going migration branch.

As usual, let me merged this changes for further testing in our pipeline, Thanks!.