### PR TITLE
Hotfix on CI pipeline, preprod naming should be consistent.

### DIFF
--- a/cicd/gitlab/env/preprod
+++ b/cicd/gitlab/env/preprod
@@ -1,4 +1,4 @@
-KUBECONTEXT=cmsweb-testbed
+KUBECONTEXT=cmsweb-preprod
 Environment=crab-preprod-tw01
 REST_Instance=preprod
 CRABClient_version=dev


### PR DESCRIPTION
Hotfix for #9178 