### PR TITLE
Refresh input s3 cache while running PreDAG

### DIFF
--- a/src/python/CRABUtils/Utils.py
+++ b/src/python/CRABUtils/Utils.py
@@ -2,26 +2,41 @@
 generic?general utilities
 """
 
-import tarfile
-from ServerUtilities import executeCommand
+import os, tarfile
 
 def addToGZippedTarfile(fileList=None, tarFile=None):
     """
     add file names in fileListd to a gzipped tarFile
     it is assumed that tarFile name has the format: xxx.tar.gz
-    this requires unzipping the tarfile, adding, zipping again
+    since tar operated as a stream and only allow appending
+    there is no concept of replacing, archive will grow by duplicated key records
+    thus this function will rebuild/clone tarInfo of all non duplicated members
+    from src tarFile into the new tar.gz one and add new fresh files
+    as overwritten/replacement for duplicated arc names in archive.
     """
     if not fileList or not tarFile:
         return
-    cmd = f"gunzip {tarFile}"
-    out, err, exitcode = executeCommand(cmd)
-    if exitcode:
-        raise Exception(f"Failed to gunzip {tarFile}: exitcode {exitcode}\n stdout: {out}\n stderr:{err}")
-    unzippedTarFile = tarFile.replace(".gz", "")
-    with tarfile.open(unzippedTarFile, mode='a') as tf:
-        for f in fileList:
-            tf.add(f)
-    cmd = f"gzip {unzippedTarFile}"
-    out, err, exitcode = executeCommand(cmd)
-    if exitcode:
-        raise Exception(f"Failed to gzip {unzippedTarFile}: exitcode {exitcode}\n stdout: {out}\n stderr:{err}")
+
+    tmp = tarFile + ".tmp"
+    to_replaces = [(os.path.basename(file_path), file_path) for file_path in fileList]
+    arc_names = [arc for arc, _ in to_replaces]
+    with tarfile.open(tarFile, "r:gz") as src, tarfile.open(tmp, "w:gz") as dst:
+        # copy all members except the ones we will replace
+        for member in src:
+            if member.name not in arc_names:
+                if member.isfile():
+                    fobj = src.extractfile(member)
+                    try:
+                        dst.addfile(member, fobj)
+                    finally:
+                        if fobj is not None:
+                            fobj.close()
+                else: # in case of dirs/symlinks
+                    dst.addfile(member) 
+        # ones we replace 
+        for arc, file_path in to_replaces:
+            dst.add(file_path, arcname=arc)
+
+    # non-atomic replace but compatible with both py2/py3.
+    os.remove(tarFile)
+    os.rename(tmp, tarFile)

--- a/src/python/TaskWorker/Actions/PreDAG.py
+++ b/src/python/TaskWorker/Actions/PreDAG.py
@@ -330,7 +330,7 @@ class PreDAG():
 
         filesToUpdate = ['run_and_lumis.tar.gz', 'input_files.tar.gz']
         addToGZippedTarfile(filesToUpdate, 'CMSRunAnalysis.tar.gz')
-        addToGZippedTarfile(['CMSRunAnalysis.tar.gz', 'InputFiles.tar.gz')
+        addToGZippedTarfile(['CMSRunAnalysis.tar.gz'], 'InputFiles.tar.gz')
         uploadToS3(crabserver=self.crabserver, filepath='InputFiles.tar.gz',
                    objecttype='runtimefiles', taskname=task['tm_taskname'],
                    logger=self.logger)

--- a/src/python/TaskWorker/Actions/PreDAG.py
+++ b/src/python/TaskWorker/Actions/PreDAG.py
@@ -328,8 +328,6 @@ class PreDAG():
             return 1
         self.saveProcessedJobs(unprocessed)
 
-        filesToUpdate = ['run_and_lumis.tar.gz', 'input_files.tar.gz']
-        addToGZippedTarfile(filesToUpdate, 'CMSRunAnalysis.tar.gz')
         addToGZippedTarfile(['CMSRunAnalysis.tar.gz'], 'InputFiles.tar.gz')
         uploadToS3(crabserver=self.crabserver, filepath='InputFiles.tar.gz',
                    objecttype='runtimefiles', taskname=task['tm_taskname'],

--- a/src/python/TaskWorker/Actions/PreDAG.py
+++ b/src/python/TaskWorker/Actions/PreDAG.py
@@ -36,7 +36,7 @@ from ast import literal_eval
 
 from WMCore.DataStructs.LumiList import LumiList
 
-from ServerUtilities import getLock, newX509env, MAX_IDLE_JOBS, MAX_POST_JOBS
+from ServerUtilities import getLock, newX509env, MAX_IDLE_JOBS, MAX_POST_JOBS, uploadToS3
 from RESTInteractions import CRABRest
 from RucioUtils import getNativeRucioClient
 from TaskWorker.Actions.Splitter import Splitter
@@ -326,6 +326,9 @@ class PreDAG():
             failTask(task['tm_taskname'], self.crabserver, failTaskMsg, self.logger, 'FAILED')
             return 1
         self.saveProcessedJobs(unprocessed)
+        uploadToS3(crabserver=self.crabserver, filepath='InputFiles.tar.gz',
+                   objecttype='runtimefiles', taskname=task['tm_taskname'],
+                   logger=self.logger)
         return 0
 
     @staticmethod

--- a/src/python/TaskWorker/Actions/PreDAG.py
+++ b/src/python/TaskWorker/Actions/PreDAG.py
@@ -39,6 +39,7 @@ from WMCore.DataStructs.LumiList import LumiList
 from ServerUtilities import getLock, newX509env, MAX_IDLE_JOBS, MAX_POST_JOBS, uploadToS3
 from RESTInteractions import CRABRest
 from RucioUtils import getNativeRucioClient
+from CRABUtils.Utils import addToGZippedTarfile
 from TaskWorker.Actions.Splitter import Splitter
 from TaskWorker.Actions.DagmanCreator import DagmanCreator
 from TaskWorker.Actions.Recurring.BanDestinationSites import CRAB3BanDestinationSites
@@ -326,10 +327,11 @@ class PreDAG():
             failTask(task['tm_taskname'], self.crabserver, failTaskMsg, self.logger, 'FAILED')
             return 1
         self.saveProcessedJobs(unprocessed)
-        uploadToS3(crabserver=self.crabserver, filepath='run_and_lumis.tar.gz',
-                   objecttype='runtimefiles', taskname=task['tm_taskname'],
-                   logger=self.logger)
-        uploadToS3(crabserver=self.crabserver, filepath='input_files.tar.gz',
+
+        filesToUpdate = ['run_and_lumis.tar.gz', 'input_files.tar.gz']
+        addToGZippedTarfile(filesToUpdate, 'CMSRunAnalysis.tar.gz')
+        addToGZippedTarfile(['CMSRunAnalysis.tar.gz', 'InputFiles.tar.gz')
+        uploadToS3(crabserver=self.crabserver, filepath='InputFiles.tar.gz',
                    objecttype='runtimefiles', taskname=task['tm_taskname'],
                    logger=self.logger)
         return 0

--- a/src/python/TaskWorker/Actions/PreDAG.py
+++ b/src/python/TaskWorker/Actions/PreDAG.py
@@ -327,10 +327,10 @@ class PreDAG():
             return 1
         self.saveProcessedJobs(unprocessed)
         uploadToS3(crabserver=self.crabserver, filepath='run_and_lumis.tar.gz',
-                   objecttype='clientlog', taskname=task['tm_taskname'],
+                   objecttype='runtimefiles', taskname=task['tm_taskname'],
                    logger=self.logger)
         uploadToS3(crabserver=self.crabserver, filepath='input_files.tar.gz',
-                   objecttype='clientlog', taskname=task['tm_taskname'],
+                   objecttype='runtimefiles', taskname=task['tm_taskname'],
                    logger=self.logger)
         return 0
 

--- a/src/python/TaskWorker/Actions/PreDAG.py
+++ b/src/python/TaskWorker/Actions/PreDAG.py
@@ -326,8 +326,11 @@ class PreDAG():
             failTask(task['tm_taskname'], self.crabserver, failTaskMsg, self.logger, 'FAILED')
             return 1
         self.saveProcessedJobs(unprocessed)
-        uploadToS3(crabserver=self.crabserver, filepath='InputFiles.tar.gz',
-                   objecttype='runtimefiles', taskname=task['tm_taskname'],
+        uploadToS3(crabserver=self.crabserver, filepath='run_and_lumis.tar.gz',
+                   objecttype='clientlog', taskname=task['tm_taskname'],
+                   logger=self.logger)
+        uploadToS3(crabserver=self.crabserver, filepath='input_files.tar.gz',
+                   objecttype='clientlog', taskname=task['tm_taskname'],
                    logger=self.logger)
         return 0
 


### PR DESCRIPTION
In response to https://github.com/dmwm/CRABClient/issues/5413.

when crab report fails in case of automatic splitting, cause by the missing of user's jobs lumis, input_file in S3.
```bash
File job_lumis_1.json not found in run_and_lumis.tar.gz
File job_input_file_list_1.txt not found in input_files.tar.gz
ERROR: KeyError: '1'
```

Actually *0*, parent dag idx, was properly uploaded to s3 cache during first boostrapping once but it just our parent dag (CRAB matter) reached to s3, Other ***1++*** parent_idx/job_ids were missing. (so called User specific jobs/DAG part).
```bash
[kphornsi@lxplus975 temp_krittin]$ tar -zxvf input_files.tar.gz
job_input_file_list_0-1.txt
job_input_file_list_0-2.txt
job_input_file_list_0-3.txt
job_input_file_list_0-4.txt
job_input_file_list_0-5.txt
```

Thus, we just have to refresh cache again once user's DAG was completely settled. 

And at the end of PreDAG (as you hint) also be a good timing. 
_______
Things might could be done better from my side:
1. me wrapping this refresh cache as function.
2. make it recursively pick ups important files, and update it in hierarchically manner? make it more generic refresh cache function.
3. wrapping as new TaskAction like Uploader, but this one aim to be more generic and reusable for people how want to refresh S3 cache keep things in SPOOL_DIR/WEB_DIR in sync. (every time we need checkpoint.)

All in all, I'm trying not to overdo it. so please let me hear your thoughts on these. @belforte 