### PR TITLE
Hot patch: ignore CMSSW below 10_1_0 until next crab-dev release.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,9 +62,6 @@ stages:
     - CMSSW_12_5_0
     - CMSSW_11_3_4
     - CMSSW_10_6_26
-    - CMSSW_10_1_0
-    - CMSSW_9_4_21
-    - CMSSW_8_0_36
 
 get_env:
   # NB rules are evaluated like python `any()`. If there is no rule the job runs all of the times.


### PR DESCRIPTION
In response to [Pipeline Failed](https://gitlab.cern.ch/crab3/CRABServer/-/pipelines/12960198).

We'll ignores these CMSSW versions for now until the slipped-in bug is resolved. 

Please, allow me to quick merge this minor changes. Such that you guys can rebase master on your feature branch.