### PR TITLE
switch back to pre-argocd deploying method until convergence to monorepo at CMSKubernetes.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -227,8 +227,8 @@ deploy_server:
     - export KUBECONFIG=$KUBECONFIG_FILE
     - export DESIRED_IMAGE="registry.cern.ch/cmscrab/crabserver:${IMAGE_TAG}"
     - |
-      if [[ "$KUBECONTEXT" =~ ^cmsweb-(test2|test12|test14)$ ]]; then
-        export DEPLOY_ENV="${KUBECONTEXT#cmsweb-}"         # "test14"
+      if [[ "$KUBECONTEXT" =~ ^cmsweb-(testX)$ ]]; then
+        export DEPLOY_ENV="${KUBECONTEXT#cmsweb-}"  # e.g. test14,preprod
         export NEW_IMAGE_TAG="${IMAGE_TAG}"
         ./cicd/scripts/updateCRABServerImageTag.sh
         ./cicd/scripts/waitForArgoCDToDeployed.sh


### PR DESCRIPTION
We will pause deploying via ArgoCD for a while. I've pause argocd both automatic and manual syncing from `crab-k8s-overlays` now. There should be no noticeable changes on our CI/CD dev/test workflow.

You guys are also free to use `kubectl edit deployment ...` for manual bumping image tag, since ArgoCD no longer take control over our live manifests anymore.