### PR TITLE
allow config.TaskWorker.maxMemorySingleCore to override default

### DIFF
--- a/src/python/TaskWorker/Actions/DagmanResubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanResubmitter.py
@@ -57,7 +57,7 @@ class DagmanResubmitter(TaskAction):
             raise TaskWorkerException(msg) from exp
 
         # Check memory and walltime
-        checkMemoryWalltime(task, 'resubmit', self.logger, self.uploadWarning)
+        checkMemoryWalltime(self.config.TaskWorker, task, 'resubmit', self.logger, self.uploadWarning)
 
         # Find only the originally submitted DAG to hold and release: this
         # will re-trigger the scripts and adjust retries and other


### PR DESCRIPTION
Fix #9217
allow `config.TaskWorker.maxMemorySingleCore` to override default in `ServerUtilities.MAX_MEMORY_SINGLE_CORE`