### PR TITLE
Robustify monit_reportrecallquota, inhibit flooding emails.

### DIFF
--- a/src/python/RucioUtils.py
+++ b/src/python/RucioUtils.py
@@ -4,7 +4,6 @@ import time
 from TaskWorker.WorkerExceptions import TaskWorkerException
 from rucio.client import Client as NativeClient
 from rucio.common.exception import RSENotFound, RuleNotFound, RucioException
-from requests.exceptions import ChunkedEncodingError
 
 class Client:
     # Wraps NativeClient with configurable retry logic and logging
@@ -188,11 +187,7 @@ def getRucioUsage(rucioClient=None, account=None, activity =None):
         # Calculate usage only if valid_states is set
         # Rucio does not keep track by activity internally, so we need to find all rules and sum all files locked by each rule
         if valid_states:
-            try:
-                totalusage = sum(getRuleQuota(rucioClient, rule['id']) for rule in rules if rule['state'] in valid_states)
-            except ChunkedEncodingError as e:
-                print(f"RuleId: {ruleId} encountered Incomplete reponse, Chunked encoding error.")
-                totalusage = -1
+            totalusage = sum(getRuleQuota(rucioClient, rule['id']) for rule in rules if rule['state'] in valid_states)
         else:
             totalusage = 0
 


### PR DESCRIPTION
Resolve #9241

Ciao @belforte,

IMO, I think just skipping accounts quota checking for this cycle, is Good enough, we don't need retry/attempts with max_attempts/exponential backoff in this case?
\> Since, CRON are retrying mechanism by itself. just skipped noises and wait for the next cycle?

P.S. Forgive me, I better try to bring RucioUtils like getRucioUsage into the loop of Vijay's Robustified RucioClient wrapper, to utilized it OR try to figure out why its not covered in each currently flooding cases, happened right now.

If we could used Vijay's wrapper it would be much more elegant/intuitive, Let me get back to you with new PR instead. 