### PR TITLE
bump htcondor to latest stable 25.4.0.

### DIFF
--- a/cicd/crabtaskworker_pypi/requirements.txt
+++ b/cicd/crabtaskworker_pypi/requirements.txt
@@ -3,7 +3,7 @@
 
 dbs3-client~=4.0.12
 future~=0.18.2
-htcondor~=24.3
+htcondor~=25.4
 psutil~=5.9.1
 pycurl~=7.45.1
 pyOpenSSL~=18.0.0


### PR DESCRIPTION
In response to Stefano upgrading ***All*** CRAB *APs* today. We will bump client in **TW** accordingly now.