### PR TITLE
hotfix, forgot to deprecate retires, delays args from wrapper.

### DIFF
--- a/src/python/RucioUtils.py
+++ b/src/python/RucioUtils.py
@@ -113,9 +113,7 @@ def getNativeRucioClient(config=None, logger=None):
         account=rucioConfig.Rucio_account,
         creds={"client_cert": rucioCert, "client_key": rucioKey},
         auth_type='x509',
-        logger=rucioLogger,
-        retries=3,
-        delay=180
+        logger=rucioLogger
     )
 
     # Initial check: these calls now retry automatically


### PR DESCRIPTION
Hotfix for #9243, which failed on `preprod` now.
*P.S. Mostly i've tested via CRON monit but never tested it on *Publisher_rucio* thus fail during pipeline deployment stage.*