### PR TITLE
workaround for remote proxy renewal failed in delegation mode.

### DIFF
--- a/cicd/crabtaskworker_pypi/condor_config
+++ b/cicd/crabtaskworker_pypi/condor_config
@@ -1,3 +1,4 @@
 # This file is intentionally empty
 # We do not need a condor_config in the TaskWorker, but
 # having it avoid complaints and/or error from HTC bindings
+DELEGATE_JOB_GSI_CREDENTIALS=False


### PR DESCRIPTION
As you mentioned @belforte 

We will patched it now while waiting for HTC 25.0.3 fixes.
Just in case we forgot & released new tag w/o this workaround flag.