### PR TITLE
use v2 HTCondor API. so it works with HTC 25.x and later

### DIFF
--- a/src/python/TaskWorker/Actions/Recurring/RenewRemoteProxies.py
+++ b/src/python/TaskWorker/Actions/Recurring/RenewRemoteProxies.py
@@ -5,8 +5,8 @@ import sys
 import time
 import logging
 
-import classad
-import htcondor
+import classad2 as classad
+import htcondor2 as htcondor
 
 from WMCore.Credential.Proxy import Proxy
 from WMCore.Configuration import loadConfigurationFile


### PR DESCRIPTION
We had kept RenewRemoteProxies with HTCondort python API v1 because e at the time I did the v1/v2 changes the `schedd.refreshGSIProxy` method was not available in v2 API.

Now we have moved to using HTCondor  25.x in TW image, and the old API has been remove in there. While the `refreshGSIProxy` is now in there, and it works.