### PR TITLE
Use python3 for wmc httpd

### DIFF
--- a/cicd/crabserver_pypi/manage.sh
+++ b/cicd/crabserver_pypi/manage.sh
@@ -75,7 +75,7 @@ status_srv() {
     # Note that PID is actually PGID.
     script_env
     rc=0
-    out="$(wmc-httpd -s -d $STATEDIR $CFGFILE)" || rc=$?
+    out="$(python3 /usr/local/bin/wmc-httpd -s -d $STATEDIR $CFGFILE)" || rc=$?
     echo "${out}"
     pgid=$(echo "${out}" | awk '{print $NF}')
     if [[ "${pgid}" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
one instance was missing, making `./status.sh` fail inside crabserver pod