### PR TITLE
Add manual pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,9 +5,18 @@ default:
     - crab3
 
 variables:
-  VERBOSE: "0"  # will pass $Verbose env. var. to various scripts 0=~silent, 1=medium, 2=long, 3=fullblown
+  VERBOSE:
+    description: "Will pass $Verbose env. var. to various scripts 0=~silent, 1=medium, 2=long, 3=fullblown"
+    options:
+      - "0"
+      - "1"
+      - "2"
+      - "3"
+    value: "0"
   # DEBUG _TEST do not uncomment !! if not set, is ignored, if set (any value) ST will use only one task to allow quick debug
-  IMAGE_TAG: "${CI_COMMIT_REF_SLUG}"  # to distinct it from commit tag and final image tag
+  IMAGE_TAG:
+    description: "tag for the image to be built/deployed"
+    value: "${CI_COMMIT_REF_SLUG}"  # to distinct it from commit tag and final image tag
   RELEASE_IMAGE_TAG: "${CI_COMMIT_TAG}-stable" # final tag name, e.g., v3.240904-stable
   # The `DOCKER_TLS_CERTDIR` variables is needed to run Docker-in-Docker, `DOCKER_BUILDKIT` is to make sure the docker build use the new BuildKit.
   # https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#docker-in-docker-with-tls-enabled-in-the-docker-executor
@@ -15,13 +24,48 @@ variables:
   # https://docs.docker.com/build/cache/backends/
   DOCKER_TLS_CERTDIR: "/certs"
   DOCKER_BUILDKIT: 1
-  STATUS_TRACKING: "true"
-  CLIENT_CONFIGURATION_VALIDATION: "true"
-  CLIENT_VALIDATION: "true"
-  SKIP_BUILD: "false"
-  SKIP_DEPLOY: "false"
-  SKIP_SUBMIT: "false"
-  SKIP_CLEANUP: "false"
+  STATUS_TRACKING:
+    description: "Whether to execute StatusTracking tests"
+    options:
+      - "true"
+      - "false"
+    value: "true"
+  CLIENT_CONFIGURATION_VALIDATION:
+    description: "Whether to execute CCV tests"
+    options:
+      - "true"
+      - "false"
+    value: "true"
+  CLIENT_VALIDATION:
+    description: "Whether to execute CV tests"
+    options:
+      - "true"
+      - "false"
+    value: "true"
+  SKIP_BUILD:
+    description: "Skip build step"
+    options:
+      - "true"
+      - "false"
+    value: "false"
+  SKIP_DEPLOY:
+    description: "Skip deploy step"
+    options:
+      - "true"
+      - "false"
+    value: "false"
+  SKIP_SUBMIT:
+    description: "Skip submit step"
+    options:
+      - "true"
+      - "false"
+    value: "false"
+  SKIP_CLEANUP:
+    description: "Skip Rucio rules cleanup step"
+    options:
+      - "true"
+      - "false"
+    value: "false"
 
 # This key define variables which are later used in `!reference` tag in `rules`.
 # Ref https://docs.gitlab.com/ee/ci/jobs/index.html#hide-jobs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,8 @@ default:
     - crab3
 
 variables:
+  # having descriptions, options and value simplifies manually triggering the pipeline
+  # Ref: https://docs.gitlab.com/ci/pipelines/#prefill-variables-in-manual-pipelines
   VERBOSE:
     description: "Will pass $Verbose env. var. to various scripts 0=~silent, 1=medium, 2=long, 3=fullblown"
     options:
@@ -14,6 +16,17 @@ variables:
       - "3"
     value: "0"
   # DEBUG _TEST do not uncomment !! if not set, is ignored, if set (any value) ST will use only one task to allow quick debug
+  ENV_NAME:
+    description: "the target for deployment and test: preprod or testX, if empty will be taken from tag name"
+    options:
+      - ""
+      - "preprod"
+      - "test1"
+      - "test2"
+      - "test11"
+      - "test12"
+      - "test14"
+    value: ""
   IMAGE_TAG:
     description: "tag for the image to be built/deployed"
     value: "${CI_COMMIT_REF_SLUG}"  # to distinct it from commit tag and final image tag

--- a/cicd/gitlab/parseEnv.sh
+++ b/cicd/gitlab/parseEnv.sh
@@ -9,19 +9,24 @@
 set -euo pipefail
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-TAG="${1}"
-
-# validate tag
-REGEX_DEV_TAG='^pypi-(preprod|test2|test11|test12|test1|test14)-.*'
-REGEX_RELEASE_TAG='^v3\.[0-9]{6}.*'
-if [[ $TAG =~ $REGEX_DEV_TAG ]]; then # Do not quote regexp variable here
-    IFS='-' read -ra TMPSTR <<< "${TAG}"
-    ENV_NAME=${ENV_NAME:-${TMPSTR[1]}}
-elif [[ $TAG =~ $REGEX_RELEASE_TAG ]]; then
-    ENV_NAME=${ENV_NAME:-preprod}
+# if ENV_NAME is already defined, use it
+if [ "X${ENV_NAME}" != "X" ]; then
+  :  # means continue in bash
 else
-    >&2 echo "fail to parse env from string: $TAG"
-    exit 1
+  # use tag passed as argument
+  TAG="${1}"
+  # validate tag
+  REGEX_DEV_TAG='^pypi-(preprod|test2|test11|test12|test1|test14)-.*'
+  REGEX_RELEASE_TAG='^v3\.[0-9]{6}.*'
+  if [[ $TAG =~ $REGEX_DEV_TAG ]]; then # Do not quote regexp variable here
+      IFS='-' read -ra TMPSTR <<< "${TAG}"
+      ENV_NAME=${ENV_NAME:-${TMPSTR[1]}}
+  elif [[ $TAG =~ $REGEX_RELEASE_TAG ]]; then
+      ENV_NAME=${ENV_NAME:-preprod}
+  else
+      >&2 echo "fail to parse env from string: $TAG"
+      exit 1
+  fi
 fi
 
 echo "Use env: ${ENV_NAME}"


### PR DESCRIPTION
This PR does not really add manual pipelines, which is  a [gitlab feature](https://docs.gitlab.com/ci/pipelines/#run-a-pipeline-manually), but simply makes it easy by pre-filling the new pipeline page with the variables which one may want to change.
When a pipeline is started manually, rather than via a push, there may not be a git tag in the format `pypi-testX-` , or one may want to run for an existing tag (e.g. `v3.yymmdd`). Therefore it is useful to have a way to  select manually the rest/tw/pub hosts. For that goal, this PR  introduces the `ENV_NAME` variable (see the new `parseEnv.sh`)
