### PR TITLE
Add awareness of Rucio HTTP exceptions and retry up to 10 times over ~20 minutes

### DIFF
--- a/src/python/RucioUtils.py
+++ b/src/python/RucioUtils.py
@@ -7,7 +7,7 @@ from TaskWorker.WorkerExceptions import TaskWorkerException
 from rucio.client import Client as NativeClient
 from rucio.common.exception import RSENotFound, RuleNotFound, RucioException
 
-RETRIABLE_RUCIO_HTTP_STATUSES = [403, 429, 500, 502, 503]
+RETRIABLE_RUCIO_HTTP_STATUSES = [503]
 
 def _is_rucio_retriable_http_error(exc):
     """True if this RucioException wraps a transient HTTP error we should retry."""

--- a/src/python/RucioUtils.py
+++ b/src/python/RucioUtils.py
@@ -7,7 +7,14 @@ from TaskWorker.WorkerExceptions import TaskWorkerException
 from rucio.client import Client as NativeClient
 from rucio.common.exception import RSENotFound, RuleNotFound, RucioException
 
-def withExponentialBackOffRetry(retryAttempts=5, fatalExceptions=(), retryExceptions=(Exception,)):
+RETRIABLE_RUCIO_HTTP_STATUSES = [403, 429, 500, 502, 503]
+
+def _is_rucio_retriable_http_error(exc):
+    """True if this RucioException wraps a transient HTTP error we should retry."""
+    msg = str(exc).lower()
+    return any(f"http status code: {code}" in msg for code in RETRIABLE_RUCIO_HTTP_STATUSES)
+
+def withExponentialBackOffRetry(retryAttempts=5, fatalExceptions=(), retryExceptions=(Exception,), retryPredicate=None):
     """
     Generic Exponential Back-off Retry
     - retryAttempts: The number of retry attempts to perform before giving up.
@@ -17,6 +24,8 @@ def withExponentialBackOffRetry(retryAttempts=5, fatalExceptions=(), retryExcept
             9/10 attempts -- Long-running or critical operations such as job submission, task management, and tape recall (≈ 17/34 minutes tolerance).
     - fatalExceptions: A tuple of exception types that should not be retried, raise immediately.
     - retryExceptions: A tuple of exception types that are eligible for retry. Otherwise will be raise right away as well. (But our default is built-in Exception, so all exception will be catch and retry anyhow.
+    - retryPredicate: Optional callable(exception) -> bool. When a fatalException is caught,
+        if retryPredicate returns True, it is retried instead of raised. Extra sleep tolerance is applied.
     """
     fatalExceptions = tuple(fatalExceptions)
     retryExceptions = tuple(retryExceptions)
@@ -38,7 +47,18 @@ def withExponentialBackOffRetry(retryAttempts=5, fatalExceptions=(), retryExcept
                 try:
                     return func(*args, **kwargs)
                 except fatalExceptions as e:
-                    # Fatal Exception will not be retry, raise immediately.
+                    if retryPredicate and retryPredicate(e):
+                        if attempt > retryAttempts:
+                            logger.error(f"Operation '{name}' failed after {attempt} retries (retryPredicate matched): {e}")
+                            raise
+                        sleepTime = 20 + (2 ** attempt)
+                        logger.warning(
+                            f"Retriable exception in '{name}' (attempt {attempt+1}/{retryAttempts}): "
+                            f"{e}, waiting for {sleepTime} seconds..."
+                        )
+                        time.sleep(sleepTime)
+                        attempt += 1
+                        continue
                     logger.exception(f"Fatal exception in '{name}' : {e}")
                     logger.exception(f"Type of Exception: {type(e)}")
                     logger.exception(f"repr(): {repr(e)}")
@@ -67,7 +87,7 @@ class Client:
         if not callable(attr):
             return attr
 
-        @withExponentialBackOffRetry(retryAttempts=8, fatalExceptions=(RucioException,))
+        @withExponentialBackOffRetry(retryAttempts=10, fatalExceptions=(RucioException,), retryPredicate=_is_rucio_retriable_http_error)
         @wraps(attr)
         def call(*args, **kwargs):
             return attr(*args, **kwargs)
@@ -173,7 +193,7 @@ def getWritePFN(rucioClient=None, siteName='', lfn='',  # pylint: disable=danger
 
     return pfn
 
-@withExponentialBackOffRetry(retryAttempts=8, fatalExceptions=(RucioException,))
+@withExponentialBackOffRetry(retryAttempts=10, fatalExceptions=(RucioException,))
 def getRuleQuota(rucioClient=None, ruleId=None):
     """ return quota needed by this rule in Bytes """
     size = 0
@@ -185,7 +205,7 @@ def getRuleQuota(rucioClient=None, ruleId=None):
     size = sum(file['bytes'] for file in files)
     return size
 
-@withExponentialBackOffRetry(retryAttempts=8, fatalExceptions=(RucioException,))
+@withExponentialBackOffRetry(retryAttempts=10, fatalExceptions=(RucioException,))
 def getRucioUsage(rucioClient=None, account=None, activity =None):
     """ size of Rucio usage for this account (if provided) or by activity """
     if activity is None:

--- a/src/python/RucioUtils.py
+++ b/src/python/RucioUtils.py
@@ -1,4 +1,5 @@
 """ a small set of utilities to work with Rucio used in various places """
+import re
 import logging
 import time
 import traceback
@@ -7,12 +8,15 @@ from TaskWorker.WorkerExceptions import TaskWorkerException
 from rucio.client import Client as NativeClient
 from rucio.common.exception import RSENotFound, RuleNotFound, RucioException
 
-RETRIABLE_RUCIO_HTTP_STATUSES = [503]
-
-def _is_rucio_retriable_http_error(exc):
-    """True if this RucioException wraps a transient HTTP error we should retry."""
-    msg = str(exc).lower()
-    return any(f"http status code: {code}" in msg for code in RETRIABLE_RUCIO_HTTP_STATUSES)
+def is_rucio_http_error(exc):
+    """Return True if the exception message contains any HTTP status code."""
+    return bool(
+        re.search(
+            r"\bhttp status code:\s*[1-5]\d{2}\b",
+            str(exc),
+            re.IGNORECASE,
+        )
+    )
 
 def withExponentialBackOffRetry(retryAttempts=5, fatalExceptions=(), retryExceptions=(Exception,), retryPredicate=None):
     """
@@ -87,7 +91,7 @@ class Client:
         if not callable(attr):
             return attr
 
-        @withExponentialBackOffRetry(retryAttempts=10, fatalExceptions=(RucioException,), retryPredicate=_is_rucio_retriable_http_error)
+        @withExponentialBackOffRetry(retryAttempts=10, fatalExceptions=(RucioException,), retryPredicate=is_rucio_http_error)
         @wraps(attr)
         def call(*args, **kwargs):
             return attr(*args, **kwargs)

--- a/src/python/RucioUtils.py
+++ b/src/python/RucioUtils.py
@@ -20,16 +20,26 @@ def is_rucio_http_error(exc):
 
 def withExponentialBackOffRetry(retryAttempts=5, fatalExceptions=(), retryExceptions=(Exception,), retryPredicate=None):
     """
-    Generic Exponential Back-off Retry
-    - retryAttempts: The number of retry attempts to perform before giving up.
-        Guidances:
-            5 attempts -- Industrial Standard for HTTP API calls — (≈ 30 seconds tolerance, default).
-            8 attempts -- Standard HTTP around Rucio API calls — (≈ 8.5 mins tolerance).
-            9/10 attempts -- Long-running or critical operations such as job submission, task management, and tape recall (≈ 17/34 minutes tolerance).
-    - fatalExceptions: A tuple of exception types that should not be retried, raise immediately.
-    - retryExceptions: A tuple of exception types that are eligible for retry. Otherwise will be raise right away as well. (But our default is built-in Exception, so all exception will be catch and retry anyhow.
-    - retryPredicate: Optional callable(exception) -> bool. When a fatalException is caught,
-        if retryPredicate returns True, it is retried instead of raised. Extra sleep tolerance is applied.
+    Decorator implementing exponential backoff retries.
+
+    Semantics:
+      - ``retryAttempts`` is the max number of retries after the initial failure.
+        Example: ``retryAttempts=5`` means up to 1 initial call + 5 retries.
+      - Normal retry delay is ``2**attempt`` seconds, where attempt starts at 0.
+      - For exceptions in ``fatalExceptions``, retries happen only if
+        ``retryPredicate(exc)`` returns True; in that case delay is
+        ``20 + 2**attempt`` seconds.
+
+    Guidance:
+      - 5 retries: common HTTP retry profile (~30s total wait).
+      - 8 retries: medium tolerance profile (~8.5m total wait).
+      - 9-10 retries: long tolerance profile (~17-34m total wait).
+
+    Args:
+      - retryAttempts: int, maximum retries.
+      - fatalExceptions: tuple of exception classes, normally not retried.
+      - retryExceptions: tuple of exception classes, retried by default.
+      - retryPredicate: optional callable(exc) -> bool to override fatal behavior.
     """
     fatalExceptions = tuple(fatalExceptions)
     retryExceptions = tuple(retryExceptions)
@@ -52,7 +62,7 @@ def withExponentialBackOffRetry(retryAttempts=5, fatalExceptions=(), retryExcept
                     return func(*args, **kwargs)
                 except fatalExceptions as e:
                     if retryPredicate and retryPredicate(e):
-                        if attempt > retryAttempts:
+                        if attempt >= retryAttempts:
                             logger.error(f"Operation '{name}' failed after {attempt} retries (retryPredicate matched): {e}")
                             raise
                         sleepTime = 20 + (2 ** attempt)


### PR DESCRIPTION
Resolve https://github.com/dmwm/CRABServer/issues/9285

I've released this patch to **crab-dev-tw02** via `v3.latest`, `v3-260409-tolerate-rucio-http-exceptions`.
See also [latest tag in harbour](https://registry.cern.ch/harbor/projects/1891/repositories/crabtwmonit/artifacts-tab)

## How to test
From now on, we should expect *one-sided reporting/emailing* from *only* `crab-prod-tw02` about **503 exceptions.**

*P.S. If its works well, we will promote it into prod with proper release tag.* 