### PR TITLE
Mitigate terminally failed migration baseline by adding jitter delays between our Publisher DBS API calls.

### DIFF
--- a/src/python/Publisher/PublisherDbsUtils.py
+++ b/src/python/Publisher/PublisherDbsUtils.py
@@ -8,6 +8,7 @@ import os
 import logging
 import json
 import time
+import random
 from datetime import datetime
 
 from dbs.apis.dbsClient import DbsApi
@@ -133,6 +134,7 @@ def findParentBlocks(listOfFileDicts=None, DBSApis=None, logger=None, verbose=No
                     blocksDict = DBSApis['destRead'].listBlocks(logical_file_name=parentFile)
                 except Exception:
                     file['parents'].remove(parentFile)
+                    time.sleep(random.uniform(0.1, 0.3)) # wait a random time to avoid overwhelming the DBS server
                     continue
                 if not blocksDict:
                     # No, this parent file is not in the destination DBS instance.
@@ -158,6 +160,7 @@ def findParentBlocks(listOfFileDicts=None, DBSApis=None, logger=None, verbose=No
                 # Put it in the set of parent files for which migration should be skipped.
                 if not blocksDict:
                     parentsToSkip.add(parentFile)
+                time.sleep(random.uniform(0.1, 0.3)) # wait a random time to avoid overwhelming the DBS server
             # If this parent file should not be migrated because it is not known to DBS,
             # we remove it from the list of parents in the file-to-publish info dictionary
             # (so that when publishing, this "parent" file will not appear as a parent).
@@ -312,6 +315,7 @@ def migrateByBlockDBS3(taskname, migrateApi, destReadApi, sourceApi, blocks,  # 
             migrationsInProgress.append(block)
         else:
             numFailedSubmissions += 1
+        time.sleep(random.uniform(0.2, 0.5)) # wait a random time to avoid overwhelming the DBS server
 
     numMigrationsInProgress = len(migrationsInProgress)
     msg = f"{numMigrationsInProgress} block migration requests successfully submitted."
@@ -356,6 +360,7 @@ def migrateByBlockDBS3(taskname, migrateApi, destReadApi, sourceApi, blocks,  # 
                 numFailedMigrations += 1
             if inProgress:
                 pass  # will check again later
+            time.sleep(random.uniform(0.2, 0.5))
         numMigrationsInProgress = len(migrationsInProgress)  # update counter at the end of loop
         # Stop waiting if there are no more migrations in progress.
         if numMigrationsInProgress == 0:

--- a/src/python/Publisher/TaskPublish.py
+++ b/src/python/Publisher/TaskPublish.py
@@ -10,6 +10,7 @@ import json
 import traceback
 import argparse
 import pprint
+import random
 
 from WMCore.Configuration import loadConfigurationFile
 
@@ -320,6 +321,7 @@ def publishInDBS3(config, taskname, verbose, console):
             logger.error("FAILING BLOCK DUE TO %s SAVED AS %s", str(ex), fname)
         finally:
             elapsed = int(time.time() - t1)
+            time.sleep(random.uniform(0.2, 0.5)) # wait a random time to avoid overwhelming the DBS server
             msg = f"PUBSTAT: Nfiles={len(dbsFiles):{4}}, filestructSize={dbsFilesSize:{6}}"
             msg += f", lumis={nLumis:{7}}, iter={nIter:{2}}"
             msg += f", blockSize={blockSize:{6}}, time={elapsed:{3}}"

--- a/src/python/Publisher/TaskPublishRucio.py
+++ b/src/python/Publisher/TaskPublishRucio.py
@@ -9,6 +9,7 @@ import json
 import traceback
 import argparse
 import pprint
+import random
 
 from WMCore.Configuration import loadConfigurationFile
 
@@ -305,6 +306,7 @@ def publishInDBS3(config, taskname, verbose, console):  # pylint: disable=too-ma
         blockDict['files'] = block['files']
         lfnsInBlock = [f['source_lfn'] for f in blockDict['files']]
         result = publishOneBlockInDBS(blockDict=blockDict, DBSConfigs=DBSConfigs, logger=logger)
+        time.sleep(random.uniform(0.2, 0.5)) # wait a random time to avoid overwhelming the DBS server
         if result['status'] == 'OK':
             logger.info('Publish OK   for Block: %s', blockDict['block_name'])
             publishedBlocks += 1


### PR DESCRIPTION
Resolve #9299 

## Summary
When processing many tasks with 100-200+ blocks simultaneously, the Publisher fires rapid back-to-back
DBS API calls (submitMigration, statusMigration, listBlocks, insertBulkBlock) with
no delay between requests (Like a mini-While-True loop). 

This overwhelms/break the DBS server or cms-auth-proxy or may trigger CERN firewall appliances, causing rate-limiting or intermittent/abrupt connection drops, resulting in empty responses or errors, which make files stuck in the acquire-status checking loop and eventually misclassified as terminal migration failures, leaving them permanently stuck in the Acquire state.

## So this PR will resolved/mitigated the issues by:
Added randomized jitter delays (random.uniform) between DBS API calls in:
- `findParentBlocks` — after each parent file lookup round (0.1-0.3s)
- `migrateByBlockDBS3` — between migration submissions (0.2-0.5s)
- `migrateByBlockDBS3` — between migration status checks (0.2-0.5s)
- `TaskPublish.publishInDBS3` — between block insertions (0.2-0.5s)
- `TaskPublishRucio.publishInDBS3` — between block insertions (0.2-0.5s)

## Why **Jitter** (randomized sleep)? 
it is used instead of fixed sleep to prevent multiple concurrent Publisher processes from synchronizing, self-organized criticality of hitting DBS simultaneously with same IP.

## Expectations
- [ ] Publisher logs show expected delays between DBS calls.
- [ ] Terminally failed migration, which not running out of their retry_count=10 yet, can make a progress, completed their migrations, or been able to resubmitted request new migrations.
- [ ] Acquired file backlog should decreases over time, since we have less and less terminally failures. 
*(Of course, with some kick, manually resubmit, but may never have to **blacklist** tasks?)*

______
*My suggestion is that we should release this PR ASAP to prevent new submissions from getting stuck and to rescue some migrations that are still recoverable or retryable.*
P.S. we've reached all-time-high O(112k) now.