### PR TITLE
Revert add jitter delays to Publisher DBS API calls to prevent throttling.

### DIFF
--- a/src/python/Publisher/PublisherDbsUtils.py
+++ b/src/python/Publisher/PublisherDbsUtils.py
@@ -8,7 +8,6 @@ import os
 import logging
 import json
 import time
-import random
 from datetime import datetime
 
 from dbs.apis.dbsClient import DbsApi
@@ -134,7 +133,6 @@ def findParentBlocks(listOfFileDicts=None, DBSApis=None, logger=None, verbose=No
                     blocksDict = DBSApis['destRead'].listBlocks(logical_file_name=parentFile)
                 except Exception:
                     file['parents'].remove(parentFile)
-                    time.sleep(random.uniform(0.1, 0.3)) # wait a random time to avoid overwhelming the DBS server
                     continue
                 if not blocksDict:
                     # No, this parent file is not in the destination DBS instance.
@@ -160,7 +158,6 @@ def findParentBlocks(listOfFileDicts=None, DBSApis=None, logger=None, verbose=No
                 # Put it in the set of parent files for which migration should be skipped.
                 if not blocksDict:
                     parentsToSkip.add(parentFile)
-                time.sleep(random.uniform(0.1, 0.3)) # wait a random time to avoid overwhelming the DBS server
             # If this parent file should not be migrated because it is not known to DBS,
             # we remove it from the list of parents in the file-to-publish info dictionary
             # (so that when publishing, this "parent" file will not appear as a parent).
@@ -315,7 +312,6 @@ def migrateByBlockDBS3(taskname, migrateApi, destReadApi, sourceApi, blocks,  # 
             migrationsInProgress.append(block)
         else:
             numFailedSubmissions += 1
-        time.sleep(random.uniform(0.2, 0.5)) # wait a random time to avoid overwhelming the DBS server
 
     numMigrationsInProgress = len(migrationsInProgress)
     msg = f"{numMigrationsInProgress} block migration requests successfully submitted."
@@ -360,7 +356,6 @@ def migrateByBlockDBS3(taskname, migrateApi, destReadApi, sourceApi, blocks,  # 
                 numFailedMigrations += 1
             if inProgress:
                 pass  # will check again later
-            time.sleep(random.uniform(0.2, 0.5))
         numMigrationsInProgress = len(migrationsInProgress)  # update counter at the end of loop
         # Stop waiting if there are no more migrations in progress.
         if numMigrationsInProgress == 0:

--- a/src/python/Publisher/TaskPublish.py
+++ b/src/python/Publisher/TaskPublish.py
@@ -10,7 +10,6 @@ import json
 import traceback
 import argparse
 import pprint
-import random
 
 from WMCore.Configuration import loadConfigurationFile
 
@@ -321,7 +320,6 @@ def publishInDBS3(config, taskname, verbose, console):
             logger.error("FAILING BLOCK DUE TO %s SAVED AS %s", str(ex), fname)
         finally:
             elapsed = int(time.time() - t1)
-            time.sleep(random.uniform(0.2, 0.5)) # wait a random time to avoid overwhelming the DBS server
             msg = f"PUBSTAT: Nfiles={len(dbsFiles):{4}}, filestructSize={dbsFilesSize:{6}}"
             msg += f", lumis={nLumis:{7}}, iter={nIter:{2}}"
             msg += f", blockSize={blockSize:{6}}, time={elapsed:{3}}"

--- a/src/python/Publisher/TaskPublishRucio.py
+++ b/src/python/Publisher/TaskPublishRucio.py
@@ -9,7 +9,6 @@ import json
 import traceback
 import argparse
 import pprint
-import random
 
 from WMCore.Configuration import loadConfigurationFile
 
@@ -306,7 +305,6 @@ def publishInDBS3(config, taskname, verbose, console):  # pylint: disable=too-ma
         blockDict['files'] = block['files']
         lfnsInBlock = [f['source_lfn'] for f in blockDict['files']]
         result = publishOneBlockInDBS(blockDict=blockDict, DBSConfigs=DBSConfigs, logger=logger)
-        time.sleep(random.uniform(0.2, 0.5)) # wait a random time to avoid overwhelming the DBS server
         if result['status'] == 'OK':
             logger.info('Publish OK   for Block: %s', blockDict['block_name'])
             publishedBlocks += 1


### PR DESCRIPTION
Regarding #9299 

This reverts commit b5efe4f55b9cc9a69ad60ccdc27639f71d4e0c3b.