### PR TITLE
Use RRN and Exitcodes to overhaul resubmission and retry policy

### DIFF
--- a/scripts/dagman/AdjustSites.py
+++ b/scripts/dagman/AdjustSites.py
@@ -27,6 +27,7 @@ from urllib.parse import urlencode
 import traceback
 from datetime import datetime
 from http.client import HTTPException
+import json
 
 from RESTInteractions import CRABRest
 from ServerUtilities import getProxiedWebDir, getColumn, downloadFromS3
@@ -169,6 +170,93 @@ def getGlob(ad, normal, automatic):
         return glob.glob(automatic)
     return [normal]
 
+def resetRRN():
+    """
+    Reset RRN counters for jobs listed in rrn_info/resubmit_record.json.
+    Idempotent: uses per-job last_reset_epoch to skip already-processed jobs,
+    so DAGMan restarts running AdjustSites again are safe.
+    """
+    record_path = os.path.join("rrn_info", "resubmit_record.json")
+    if not os.path.exists(record_path):
+        printLog("No resubmit_record.json found, skipping RRN reset")
+        return
+
+    with open(record_path, 'r', encoding='utf-8') as fd:
+        record = json.load(fd)
+
+    current_epoch = record.get('epoch', 0)
+    job_ids = record.get('job_ids')       # None means resubmit all
+    resubmit_all = (job_ids is None)
+
+    if resubmit_all:
+        targets = glob.glob(os.path.join("rrn_info", "job.*.txt"))
+    else:
+        targets = [os.path.join("rrn_info", f"job.{jid}.txt") for jid in job_ids]
+
+    printLog(f"resetRRN: epoch={current_epoch}, targets={'ALL' if resubmit_all else job_ids}")
+
+    for fpath in targets:
+        try:
+            data = {}
+            if os.path.exists(fpath):
+                with open(fpath, 'r', encoding='utf-8') as fd:
+                    data = json.load(fd)
+
+            last_reset_epoch = data.get('last_reset_epoch', 0)
+            if last_reset_epoch >= current_epoch:
+                printLog(f"Skipping {fpath}: last_reset_epoch={last_reset_epoch} "
+                         f">= current_epoch={current_epoch}")
+                continue
+
+            data['rrn'] = 0
+            data['last_reset_epoch'] = current_epoch
+            tmp = fpath + ".tmp"
+            with open(tmp, 'w', encoding='utf-8') as fd:
+                json.dump(data, fd)
+            os.rename(tmp, fpath)
+            printLog(f"Reset RRN for {fpath}, last_reset_epoch set to {current_epoch}")
+
+        except Exception as ex:
+            printLog(f"WARNING: failed to reset RRN for {fpath}: {ex}")
+
+def writeResubmitRecord(ad):
+    """
+    Write rrn_info/resubmit_record.json from the CRAB_ResubmitRecord classAd.
+    This classAd is written atomically by DagmanResubmitter as a JSON string
+    containing both epoch and job_ids, so we never see a mismatched pair.
+    """
+    if 'CRAB_ResubmitRecord' not in ad:
+        printLog("CRAB_ResubmitRecord not in classAd, skipping resubmit record write")
+        return
+
+    try:
+        record = json.loads(str(ad['CRAB_ResubmitRecord']))
+    except Exception as ex:
+        printLog(f"Failed to parse CRAB_ResubmitRecord: {ex}, skipping")
+        return
+
+    epoch = record.get('epoch', 0)
+    job_ids = record.get('job_ids')  # list of strings or None
+
+    os.makedirs("rrn_info", exist_ok=True)
+    record_path = os.path.join("rrn_info", "resubmit_record.json")
+
+    # Idempotency: if we already wrote this epoch, skip
+    if os.path.exists(record_path):
+        try:
+            with open(record_path, 'r', encoding='utf-8') as fd:
+                existing = json.load(fd)
+            if existing.get('epoch') == epoch:
+                printLog(f"resubmit_record.json already at epoch {epoch}, skipping")
+                return
+        except Exception as ex:
+            printLog(f"Could not read existing resubmit_record.json: {ex}, overwriting")
+
+    tmp = record_path + ".tmp"
+    with open(tmp, 'w', encoding='utf-8') as fd:
+        json.dump(record, fd)
+    os.rename(tmp, record_path)
+    printLog(f"Written resubmit_record.json: {record}")
 
 def adjustMaxRetries(adjustJobIds, ad):
     """
@@ -588,6 +676,9 @@ def main():
         ## job is in failed status or not just from the RunJobs.dag file, while job ids
         ## in adjustedJobIds correspond only to failed jobs.
         adjustMaxRetries(adjustedJobIds, ad)
+
+    writeResubmitRecord(ad)
+    resetRRN()
 
     if resubmitJobIds and ad.get('CRAB_SplitAlgo') == 'Automatic':
         printLog("Releasing processing and tail DAGs")

--- a/scripts/dagman/AdjustSites.py
+++ b/scripts/dagman/AdjustSites.py
@@ -216,7 +216,7 @@ def resetRRN():
             os.rename(tmp, fpath)
             printLog(f"Reset RRN for {fpath}, last_reset_epoch set to {current_epoch}")
 
-        except Exception as ex:
+        except Exception as ex: # pylint: disable=broad-exception-caught
             printLog(f"WARNING: failed to reset RRN for {fpath}: {ex}")
 
 def writeResubmitRecord(ad):
@@ -231,13 +231,13 @@ def writeResubmitRecord(ad):
 
     try:
         record = json.loads(str(ad['CRAB_ResubmitRecord']))
-    except Exception as ex:
+    except Exception as ex: # pylint: disable=broad-exception-caught
         printLog(f"Failed to parse CRAB_ResubmitRecord: {ex}, skipping")
         return
 
     epoch = record.get('epoch', 0)
-    job_ids = record.get('job_ids')  # list of strings or None
-
+    job_ids = record.get('job_ids')
+    printLog(f"epoch={epoch}, job_ids={job_ids}")
     os.makedirs("rrn_info", exist_ok=True)
     record_path = os.path.join("rrn_info", "resubmit_record.json")
 
@@ -249,7 +249,7 @@ def writeResubmitRecord(ad):
             if existing.get('epoch') == epoch:
                 printLog(f"resubmit_record.json already at epoch {epoch}, skipping")
                 return
-        except Exception as ex:
+        except Exception as ex: # pylint: disable=broad-exception-caught
             printLog(f"Could not read existing resubmit_record.json: {ex}, overwriting")
 
     tmp = record_path + ".tmp"

--- a/scripts/dagman/AdjustSites.py
+++ b/scripts/dagman/AdjustSites.py
@@ -225,7 +225,7 @@ def writeResubmitRecord(ad):
     This classAd is written atomically by DagmanResubmitter as a JSON string
     containing both epoch and job_ids, so we never see a mismatched pair.
     """
-    if 'CRAB_ResubmitRecord' not in ad:
+    if 'CRAB_ResubmitRecord' not in ad: # this is first crab resubmit for this task
         printLog("CRAB_ResubmitRecord not in classAd, skipping resubmit record write")
         return
 

--- a/scripts/dagman/dag_bootstrap_startup.sh
+++ b/scripts/dagman/dag_bootstrap_startup.sh
@@ -43,6 +43,7 @@ mkdir -p retry_info
 mkdir -p resubmit_info
 mkdir -p defer_info
 mkdir -p transfer_info
+mkdir -p rrn_info # stores RRN counter per job
 
 #Test if bearer token is available and "notify it"
 condor_store_cred query-oauth > TOKEN 2>&1

--- a/src/python/ServerUtilities.py
+++ b/src/python/ServerUtilities.py
@@ -61,14 +61,15 @@ MAX_LUMIS_IN_BLOCK = 100000  # 100K lumis to avoid blowing up memory
 # Fatal error limits for job resource usage
 # Defaults are used if unable to load from .job.ad
 # Otherwise it uses these values.
-MAX_WALLTIME = 21 * 60 * 60 + 30 * 60
-MAX_MEMORY = 2 * 1024
+MAX_WALLTIME = 21 * 60 * 60 + 30 * 60  # 21.5 hours in seconds
+MAX_MEMORY = 2 * 1024 # 2048 MB
 # see https://github.com/dmwm/CRABServer/issues/5995
-MAX_MEMORY_PER_CORE = 2500
-MAX_MEMORY_SINGLE_CORE = 3000
-MAX_MEMORY_SINGLE_CORE_ON_RESUBMIT = 5000
+MAX_MEMORY_PER_CORE = 2500 # 2500 MB
+MAX_MEMORY_SINGLE_CORE = 3000 # 3000 MB
+MAX_MEMORY_SINGLE_CORE_ON_RESUBMIT = 5000 # 5000 MB
 MAX_DISK_SPACE = 20000000  # Disk usage is not used from .job.ad as CRAB3 is not seeting it. 20GB is max.
-
+MAX_MEMORY_AUTOMATIC_RESUBMIT = 7500 # 7500 MB
+MAX_JOB_RUNTIME_AUTOMATIC_RESUBMIT = 47 * 60 # 47 hours in minutes
 MAX_IDLE_JOBS = 1000
 MAX_POST_JOBS = 10
 

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -885,7 +885,7 @@ class DagmanCreator(TaskAction):
 
         ## In the future this parameter may be set by the user in the CRAB configuration
         ## file and we would take it from the Task DB.
-        self.task['numautomjobretries'] = getattr(self.config.TaskWorker, 'numAutomJobRetries', 5)
+        self.task['numautomjobretries'] = getattr(self.config.TaskWorker, 'numAutomJobRetries', 10)
 
         runtime = self.task['tm_split_args'].get('minutes_per_job', -1)
 

--- a/src/python/TaskWorker/Actions/DagmanCreator.py
+++ b/src/python/TaskWorker/Actions/DagmanCreator.py
@@ -885,7 +885,7 @@ class DagmanCreator(TaskAction):
 
         ## In the future this parameter may be set by the user in the CRAB configuration
         ## file and we would take it from the Task DB.
-        self.task['numautomjobretries'] = getattr(self.config.TaskWorker, 'numAutomJobRetries', 2)
+        self.task['numautomjobretries'] = getattr(self.config.TaskWorker, 'numAutomJobRetries', 5)
 
         runtime = self.task['tm_split_args'].get('minutes_per_job', -1)
 

--- a/src/python/TaskWorker/Actions/DagmanResubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanResubmitter.py
@@ -86,7 +86,7 @@ class DagmanResubmitter(TaskAction):
                 # is saving the values of the parameters for each job retry in text files (the
                 # files are in the directory resubmit_info in the schedd).
                 # We use classAds here as way to pass informations to PreJobs.
-                # Value in schedd.exit(const, ad, value) can be string or ExprTree
+                # Value in schedd.edit(const, ad, value) can be string or ExprTree
                 # https://htcondor.readthedocs.io/en/latest/apis/python-bindings/api/version2/htcondor2/schedd.html#htcondor2.Schedd.edit
                 # We need ExprTree when the ad correspond to a python list
                 for adparam, taskparam in params.items():

--- a/src/python/TaskWorker/Actions/DagmanResubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanResubmitter.py
@@ -96,6 +96,34 @@ class DagmanResubmitter(TaskAction):
                         else:
                             newAdValue = str(task['resubmit_'+taskparam])
                         schedd.edit(rootConst, adparam, newAdValue)
+                
+                # Read current epoch
+                currentEpoch = 0
+                try:
+                    ads = schedd.query(rootConst, projection=["CRAB_ResubmitEpoch"])
+                    if ads and "CRAB_ResubmitEpoch" in ads[0]:
+                        currentEpoch = int(ads[0]["CRAB_ResubmitEpoch"])
+                except Exception as ex:
+                    self.logger.warning("Could not read CRAB_ResubmitEpoch, defaulting to 0: %s", ex)
+
+                newEpoch = currentEpoch + 1
+
+                # Build the record as a JSON string stored in a single classAd.
+                # This is written atomically in one schedd.edit call, so AdjustSites
+                # always sees a consistent (epoch, job_ids) pair — never a stale
+                # job_ids list paired with a new epoch.
+                resubmitRecord = json.dumps({
+                    'epoch': newEpoch,
+                    'job_ids': task['resubmit_jobids']  # the actual list for this resubmit
+                })
+
+                self.logger.info(
+                    "Setting CRAB_ResubmitRecord=%s for workflow %s", resubmitRecord, workflow
+                )
+                # Write epoch separately too so DagmanResubmitter can read it back next time
+                schedd.edit(rootConst, "CRAB_ResubmitEpoch", str(newEpoch))
+                # Write the full record atomically
+                schedd.edit(rootConst, "CRAB_ResubmitRecord", classad.quote(resubmitRecord))
                 # finally restart the dagman with the 3 lines below
                 schedd.act(htcondor.JobAction.Hold, rootConst)
                 schedd.edit(rootConst, "HoldKillSig", 'SIGUSR1')

--- a/src/python/TaskWorker/Actions/DagmanResubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanResubmitter.py
@@ -103,7 +103,7 @@ class DagmanResubmitter(TaskAction):
                     ads = schedd.query(rootConst, projection=["CRAB_ResubmitEpoch"])
                     if ads and "CRAB_ResubmitEpoch" in ads[0]:
                         currentEpoch = int(ads[0]["CRAB_ResubmitEpoch"])
-                except Exception as ex:
+                except Exception as ex: # pylint: disable=broad-exception-caught
                     self.logger.warning("Could not read CRAB_ResubmitEpoch, defaulting to 0: %s", ex)
 
                 newEpoch = currentEpoch + 1

--- a/src/python/TaskWorker/Actions/DagmanResubmitter.py
+++ b/src/python/TaskWorker/Actions/DagmanResubmitter.py
@@ -1,7 +1,7 @@
 """ Resubmit failed jobs in tasks """
 
 import os
-
+import json
 from http.client import HTTPException
 from urllib.parse import urlencode
 

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -3031,10 +3031,10 @@ class PostJob():
 
     def get_rrn(self):
         """
-        Read RRN from the individual job's classAd where PreJob stamped it.
+        Read RRN from the individual job's classAd where PreJob stamped it after crab resubmit.
         This is completely independent of dag_retry, crab_retry, and max_retries.
-        Falls back to rrn_info file if classAd not available (e.g. job never ran
-        because PreJob itself failed).
+        Falls back to rrn_info file if classAd not available (happens in all the 
+        retries of first submission, when user has not done crab resubmit).
         """
         # Primary: read from job classAd stamped by PreJob.alter_submit()
         if self.job_ad and 'CRAB_RRN' in self.job_ad:
@@ -3042,7 +3042,8 @@ class PostJob():
             self.logger.info("Read CRAB_RRN=%d from job classAd", rrn)
             return rrn
 
-        # Fallback: read from file directly (job never ran, classAd unavailable)
+        # Fallback: read from file directly (classAd unavailable)
+        # This fallback happens on the first run before CRAB resubmit
         self.logger.warning(
             "CRAB_RRN not in job classAd, falling back to rrn_info file"
         )

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -1660,8 +1660,8 @@ class PostJob():
             # DAGMan will resubmit the job unless the maximum allowed number of retries has
             # been reached already (DAGMan compares the DAGMan retry count against the
             # maximum allowed number of retries).
-            msg = "This is job retry number %d." % (self.dag_retry)
-            msg += " The maximum allowed number of retries is %d." % (self.max_retries)
+            msg = "This is job retry number %d." % (self.get_rrn())
+            msg += " The maximum allowed number of retries is %d." % (self.get_max_retry())
             self.logger.info(msg)
             # Print a message about the DAG cluster ID of the job, which can be -1 when the
             # job has not been executed. The later can happen when a DAG node is restarted
@@ -1796,7 +1796,7 @@ class PostJob():
                 self.logger.info("====== Finished to analyze job exit status.")
                 res = JOB_RETURN_CODES.FATAL_ERROR, ""
             elif self.retryjob_retval == JOB_RETURN_CODES.RECOVERABLE_ERROR:
-                if self.get_rrn() >= self.max_retries:
+                if self.get_rrn() >= self.get_max_retry():
                     msg = "The retry handler indicated this was a recoverable error,"
                     msg += " but the maximum number of retries was already hit."
                     msg += " DAGMan will not retry."
@@ -1823,7 +1823,7 @@ class PostJob():
                 res = JOB_RETURN_CODES.FATAL_ERROR, "" #MarcoM: this should never happen
         # This is for the case in which we don't run the retry-job.
         elif self.job_return_code != JOB_RETURN_CODES.OK:
-            if self.get_rrn() >= self.max_retries:
+            if self.get_rrn() >= self.get_max_retry():
                 msg = "The maximum allowed number of retries was hit and the job failed."
                 msg += " Setting this node (job) to permanent failure."
                 self.logger.info(msg)
@@ -3013,7 +3013,7 @@ class PostJob():
         number of job retries was hit. If it was, the post-job should return with the
         fatal error exit code. Otherwise with the recoverable error exit code.
         """
-        if self.get_rrn() >= self.max_retries:
+        if self.get_rrn() >= self.get_max_retry():
             msg = "Job could be retried, but the maximum allowed number of retries was hit."
             msg += " Setting this node (job) to permanent failure. DAGMan will NOT retry."
             self.logger.info(msg)
@@ -3031,20 +3031,38 @@ class PostJob():
 
     def get_rrn(self):
         """
-        Read the current RRN for this job from rrn_info/job.<job_id>.txt.
-        Returns 0 if the file doesn't exist yet (first submission).
+        Read RRN from the individual job's classAd where PreJob stamped it.
+        This is completely independent of dag_retry, crab_retry, and max_retries.
+        Falls back to rrn_info file if classAd not available (e.g. job never ran
+        because PreJob itself failed).
         """
+        # Primary: read from job classAd stamped by PreJob.alter_submit()
+        if self.job_ad and 'CRAB_RRN' in self.job_ad:
+            rrn = int(self.job_ad['CRAB_RRN'])
+            self.logger.info("Read CRAB_RRN=%d from job classAd", rrn)
+            return rrn
+
+        # Fallback: read from file directly (job never ran, classAd unavailable)
+        self.logger.warning(
+            "CRAB_RRN not in job classAd, falling back to rrn_info file"
+        )
         rrn_file = os.path.join("rrn_info", f"job.{self.job_id}.txt")
         if not os.path.exists(rrn_file):
-            self.logger.warning("RRN file %s not found, assuming RRN=0", rrn_file)
+            self.logger.warning("rrn_info file %s not found, assuming RRN=0", rrn_file)
             return 0
         try:
             with open(rrn_file, 'r', encoding='utf-8') as fd:
                 data = json.load(fd)
             return int(data.get('rrn', 0))
         except Exception:
-            self.logger.exception("Failed to read RRN file %s, assuming RRN=0", rrn_file)
+            self.logger.exception("Failed to read %s, assuming RRN=0", rrn_file)
             return 0
+
+    def get_max_retry(self):
+        """
+        Return the configured maxRetry from the job ad.
+        """
+        return int(self.job_ad.get('CRAB_NumAutomJobRetries', 5))
 
     # = = = = = PostJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 

--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -1796,7 +1796,7 @@ class PostJob():
                 self.logger.info("====== Finished to analyze job exit status.")
                 res = JOB_RETURN_CODES.FATAL_ERROR, ""
             elif self.retryjob_retval == JOB_RETURN_CODES.RECOVERABLE_ERROR:
-                if self.dag_retry >= self.max_retries:
+                if self.get_rrn() >= self.max_retries:
                     msg = "The retry handler indicated this was a recoverable error,"
                     msg += " but the maximum number of retries was already hit."
                     msg += " DAGMan will not retry."
@@ -1823,7 +1823,7 @@ class PostJob():
                 res = JOB_RETURN_CODES.FATAL_ERROR, "" #MarcoM: this should never happen
         # This is for the case in which we don't run the retry-job.
         elif self.job_return_code != JOB_RETURN_CODES.OK:
-            if self.dag_retry >= self.max_retries:
+            if self.get_rrn() >= self.max_retries:
                 msg = "The maximum allowed number of retries was hit and the job failed."
                 msg += " Setting this node (job) to permanent failure."
                 self.logger.info(msg)
@@ -3013,7 +3013,7 @@ class PostJob():
         number of job retries was hit. If it was, the post-job should return with the
         fatal error exit code. Otherwise with the recoverable error exit code.
         """
-        if self.dag_retry >= self.max_retries:
+        if self.get_rrn() >= self.max_retries:
             msg = "Job could be retried, but the maximum allowed number of retries was hit."
             msg += " Setting this node (job) to permanent failure. DAGMan will NOT retry."
             self.logger.info(msg)
@@ -3026,6 +3026,25 @@ class PostJob():
         self.set_state_ClassAds('COOLOFF', exitCode=exitCode)
 
         return JOB_RETURN_CODES.RECOVERABLE_ERROR
+
+    # = = = = = PostJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+    def get_rrn(self):
+        """
+        Read the current RRN for this job from rrn_info/job.<job_id>.txt.
+        Returns 0 if the file doesn't exist yet (first submission).
+        """
+        rrn_file = os.path.join("rrn_info", f"job.{self.job_id}.txt")
+        if not os.path.exists(rrn_file):
+            self.logger.warning("RRN file %s not found, assuming RRN=0", rrn_file)
+            return 0
+        try:
+            with open(rrn_file, 'r', encoding='utf-8') as fd:
+                data = json.load(fd)
+            return int(data.get('rrn', 0))
+        except Exception:
+            self.logger.exception("Failed to read RRN file %s, assuming RRN=0", rrn_file)
+            return 0
 
     # = = = = = PostJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 

--- a/src/python/TaskWorker/Actions/PreJob.py
+++ b/src/python/TaskWorker/Actions/PreJob.py
@@ -262,6 +262,7 @@ class PreJob:
         msg = "Setting CRAB_Retry = %s" % (crab_retry)
         self.logger.info(msg)
         newJobSubmit['My.CRAB_Retry'] = str(crab_retry)
+        newJobSubmit['My.CRAB_RRN'] = str(self.rrn)
         ## Add job and postjob log URLs
         job_retry = "%s.%s" % (self.job_id, crab_retry)
         newJobSubmit['My.CRAB_JobLogURL'] = classad.quote(os.path.join(self.userWebDirPrx, "job_out."+job_retry+".txt"))

--- a/src/python/TaskWorker/Actions/PreJob.py
+++ b/src/python/TaskWorker/Actions/PreJob.py
@@ -39,6 +39,7 @@ class PreJob:
         self.prejob_exit_code = None
         self.logger = logging.getLogger()
         self.rrn           = None
+        self.reuse_rrn     = False
 
 
     def calculate_crab_retry(self):
@@ -101,6 +102,9 @@ class PreJob:
                 retmsg += "\n\tIt seems the job has already been submitted."
                 retmsg += "\n\tSetting the pre-job exit code to 1."
                 self.prejob_exit_code = 1
+            else:
+                retmsg += "\n\tPre-job was interrupted before job completed. pre=%d > post=%d, no job_out. Reusing existing RRN." % (retry_info['pre'], retry_info['post'])
+                self.reuse_rrn = True
         ## ... or not.
         else:
             ## If the job_out doesn't exist, then this is certainly (ok, 99.99% certainly)
@@ -196,7 +200,13 @@ class PreJob:
                 except Exception:
                     self.logger.warning("Could not read %s, starting fresh", rrn_file)
                     data = {}
-
+            if self.reuse_rrn:
+                rrn = data.get('rrn', 0)
+                self.logger.info(
+                    "RRN for job %s reused as %d (interrupted pre-job, not re-incrementing)",
+                    self.job_id, rrn
+                )
+                return rrn
             rrn = data.get('rrn', 0)
             rrn += 1
             data['rrn'] = rrn

--- a/src/python/TaskWorker/Actions/PreJob.py
+++ b/src/python/TaskWorker/Actions/PreJob.py
@@ -13,7 +13,7 @@ import errno
 import logging
 from ast import literal_eval
 
-from ServerUtilities import getWebdirForDb, insertJobIdSid, pythonListToClassAdExprTree, getLock
+from ServerUtilities import getWebdirForDb, insertJobIdSid, pythonListToClassAdExprTree, getLock, MAX_MEMORY_AUTOMATIC_RESUBMIT, MAX_JOB_RUNTIME_AUTOMATIC_RESUBMIT
 from TaskWorker.Actions.RetryJob import JOB_RETURN_CODES
 
 import htcondor2 as htcondor
@@ -335,6 +335,24 @@ class PreJob:
             maxmemory     = self.resubmit_info[inkey].get('maxmemory')
             numcores      = self.resubmit_info[inkey].get('numcores')
             priority      = self.resubmit_info[inkey].get('priority')
+
+            #ExitCode Dependent automatic change in resubmission parameters
+            if self.resubmit_info:
+                retry_data = self.resubmit_info.get(inkey, {})
+                if retry_data.get("increase_memory") and maxmemory:
+                    factor = retry_data.get("memory_factor", 1.2)
+                    new_memory = int(maxmemory * factor)
+                    new_memory = min(new_memory, MAX_MEMORY_AUTOMATIC_RESUBMIT)
+                    self.logger.info(f"Increasing memory from {maxmemory} to {new_memory}")
+                    maxmemory = new_memory
+
+                if retry_data.get("increase_runtime") and maxjobruntime:
+                    factor = retry_data.get("runtime_factor", 1.2)
+                    new_runtime = int(maxjobruntime * factor)
+                    new_runtime = min(new_runtime, MAX_JOB_RUNTIME_AUTOMATIC_RESUBMIT)
+                    self.logger.info(f"Increasing walltime from {maxjobruntime} to {new_runtime}")
+                    maxjobruntime = new_runtime
+
         ## Save the (new) values of the resubmission parameters in self.resubmit_info
         ## for the current job retry number.
         outkey = str(crab_retry)
@@ -410,6 +428,9 @@ class PreJob:
         siteWhiteList = []
         siteBlackSet = set()
         siteWhiteSet = set()
+        inkey = str(crab_retry) if crab_retry == 0 else str(crab_retry - 1)
+        while inkey not in self.resubmit_info and int(inkey) > 0:
+            inkey = str(int(inkey) -  1)
         if not use_resubmit_info:
             if 'CRAB_SiteBlacklist' in self.task_ad:
                 if self.task_ad['CRAB_SiteBlacklist']:  # skip ad=''
@@ -420,9 +441,6 @@ class PreJob:
                     siteWhiteList = self.task_ad['CRAB_SiteWhitelist']
                     siteWhiteSet = set(siteWhiteList)
         else:
-            inkey = str(crab_retry) if crab_retry == 0 else str(crab_retry - 1)
-            while inkey not in self.resubmit_info and int(inkey) > 0:
-                inkey = str(int(inkey) -  1)
             siteBlackSet = set(self.resubmit_info[inkey].get('site_blacklist', []))
             siteWhiteSet = set(self.resubmit_info[inkey].get('site_whitelist', []))
         ## Save the current site black- and whitelists in self.resubmit_info for the
@@ -451,6 +469,18 @@ class PreJob:
             self.logger.error("Can not submit since DESIRED_Sites list is empty")
             self.prejob_exit_code = 1
             sys.exit(self.prejob_exit_code)
+
+        # ExitCode Dependent discard of previous_site
+        retry_data = self.resubmit_info.get(inkey, {})
+        previous_site = retry_data.get("site")
+        if retry_data.get("change_site") and previous_site:
+            self.logger.info(f"Last Exit Code indicated that a change in site might help. inkey was {inkey}")
+            if previous_site in availableSet and len(availableSet) > 1:
+                self.logger.info(f"Removing previous site {previous_site} from candidate sites")
+                availableSet.discard(previous_site)
+        else:
+            self.logger.info(f"No need to discard last site. inkey was {inkey}")
+
         ## Make sure that attributest which will be used in MatchMaking are SORTED lists
         available = list(availableSet)
         available.sort()
@@ -493,19 +523,42 @@ class PreJob:
             slow release of jobs in a task.
             The function return True if CRAB_JobReleaseTimeout is defined and not 0, and if the submit
             time of the task plus the defer time is greater than the current time.
+            Additionally retry policy delay
         """
         deferTime = int(self.task_ad.get("CRAB_JobReleaseTimeout", 0))
+
+        currentTime = time.time()
+
+        # Check retry delay from resubmit_info
+        # Inside SPOOL_DIR we have resubmit_info folder with text files job.{self.job_id}.txt for each job id
+        # Each file is a dictionary of the format example {0:{'maxmemory':2000, ...}, 1:{}, 2:{}, ...}
+        # where 0,1,2,... are crab_retry numbers. A lot of vital info like site_whitelist, retry_delay_until,
+        # use_resubmit_info, etc is stored and read from this file for each retry across resubmissions.
+        # ToDo: Convert this file to json format
+        retry_info_file = f"resubmit_info/job.{self.job_id}.txt"
+        if os.path.exists(retry_info_file):
+            try:
+                with open(retry_info_file, "r", encoding="utf-8") as fd:
+                    retry_info = literal_eval(fd.read())
+                key = str(self.dag_retry)
+                if key in retry_info:
+                    retry_delay_until = retry_info[key].get("retry_delay_until")
+                    if retry_delay_until and currentTime < retry_delay_until:
+                        wait = int(retry_delay_until - currentTime)
+                        self.logger.info(f"Retry delay not elapsed yet. Deferring for {wait} seconds.")
+                        return True
+            except Exception:
+                self.logger.exception("Error checking retry delay in resubmit_info")
         if deferTime:
             self.logger.info('Release timeout specified in extraJDL:')
             totalDefer = deferTime * int(self.job_id)
             submitTime = int(self.task_ad["CRAB_TaskSubmitTime"])
-            currentTime = time.time()
             if currentTime < (submitTime + totalDefer):
                 msg = f"  Defer time of this job ({totalDefer} seconds since initial task submission)"
                 msg += f" not elapsed yet, deferring for {totalDefer} seconds"
                 self.logger.info(msg)
                 return True
-            self.logger.info('  Continuing normally since current time is greater than requested starttime of the job')
+            self.logger.info('Continuing normally since current time is greater than requested starttime of the job')
         return False
 
     def execute(self, *args):

--- a/src/python/TaskWorker/Actions/PreJob.py
+++ b/src/python/TaskWorker/Actions/PreJob.py
@@ -13,7 +13,7 @@ import errno
 import logging
 from ast import literal_eval
 
-from ServerUtilities import getWebdirForDb, insertJobIdSid, pythonListToClassAdExprTree
+from ServerUtilities import getWebdirForDb, insertJobIdSid, pythonListToClassAdExprTree, getLock
 from TaskWorker.Actions.RetryJob import JOB_RETURN_CODES
 
 import htcondor2 as htcondor
@@ -38,6 +38,7 @@ class PreJob:
         self.resubmit_info = {}
         self.prejob_exit_code = None
         self.logger = logging.getLogger()
+        self.rrn           = None
 
 
     def calculate_crab_retry(self):
@@ -182,6 +183,31 @@ class PreJob:
             with open(file_name, 'r', encoding='utf-8') as fd:
                 self.resubmit_info = literal_eval(fd.read())
 
+    def get_rrn(self):
+        rrn_file = os.path.join("rrn_info", f"job.{self.job_id}.txt")
+        lock_file = rrn_file + ".lock"
+
+        with getLock(lock_file):
+            data = {}
+            if os.path.exists(rrn_file):
+                try:
+                    with open(rrn_file, 'r', encoding='utf-8') as fd:
+                        data = json.load(fd)
+                except Exception:
+                    self.logger.warning("Could not read %s, starting fresh", rrn_file)
+                    data = {}
+
+            rrn = data.get('rrn', 0)
+            rrn += 1
+            data['rrn'] = rrn
+            # Preserve epoch field if present; PreJob does not modify it
+            tmp = rrn_file + ".tmp"
+            with open(tmp, 'w', encoding='utf-8') as fd:
+                json.dump(data, fd)
+            os.rename(tmp, rrn_file)
+
+        self.logger.info("RRN for job %s incremented to %d", self.job_id, rrn)
+        return rrn
 
     def save_resubmit_info(self):
         """
@@ -521,7 +547,9 @@ class PreJob:
 
         ## Load the task ad.
         self.get_task_ad()
-
+        # increment and record RRN for this submission
+        self.rrn = self.get_rrn()
+        self.logger.info("RRN=%d", self.rrn)
         try:
             with open('webdir', 'r', encoding='utf-8') as fd:
                 self.userWebDirPrx = fd.read()

--- a/src/python/TaskWorker/Actions/RetryJob.py
+++ b/src/python/TaskWorker/Actions/RetryJob.py
@@ -5,8 +5,9 @@ import json
 import shutil
 import subprocess
 import socket
+import time
 from collections import namedtuple
-
+from ast import literal_eval
 from ServerUtilities import executeCommand, getLock
 from ServerUtilities import MAX_DISK_SPACE, MAX_WALLTIME, MAX_MEMORY
 
@@ -14,6 +15,41 @@ import classad2 as classad
 
 
 JOB_RETURN_CODES = namedtuple('JobReturnCodes', 'OK RECOVERABLE_ERROR FATAL_ERROR')(0, 1, 2)
+
+# ----------------------------------------------------------------------
+# Exit-code dependent retry policy
+# ----------------------------------------------------------------------
+# ToDo: Reduce Redundance across short and long exit codes
+
+EXIT_RETRY_POLICY = {
+    1: {"type": "recoverable", "delay": 900, "msg": "Job failed to bootstrap CMSSW; likely a worker node issue."},
+    50513: {"type": "recoverable", "delay": 900, "msg": "Job did not find functioning CMSSW on worker node."},
+    81: {"type": "recoverable", "delay": 900, "msg": "Job did not find functioning CMSSW on worker node."},
+    50115: {"type": "recoverable", "delay": 900, "msg": "Job did not produce a FJR; will retry.", "increase_memory": True, "memory_factor": 1.3},
+    195: {"type": "recoverable", "delay": 900, "msg": "Job did not produce a FJR; will retry.", "increase_memory": True, "memory_factor": 1.3},
+    137: {"type": "recoverable", "delay": 900, "msg": "SIGKILL; likely an unrelated batch system kill."},
+    10034: {"type": "recoverable", "delay": 900, "msg": "Required application version not found at the site."},
+    50: {"type": "recoverable", "delay": 900, "msg": "Required application version not found at the site."},
+    10040: {"type": "recoverable", "delay": 900, "msg": "Site Error: failed to generate cmsRun cfg file at runtime."},
+    60403: {"type": "recoverable", "delay": 900, "msg": "Timeout during attempted file stageout.", "increase_runtime": True, "runtime_factor": 1.3},
+    243: {"type": "recoverable", "delay": 900, "msg": "Timeout during attempted file stageout.", "increase_runtime": True, "runtime_factor": 1.3},
+    60307: {"type": "recoverable", "delay": 900, "msg": "Error during attempted file stageout."},
+    147: {"type": "recoverable", "delay": 900, "msg": "Error during attempted file stageout."},
+    60311: {"type": "recoverable", "delay": 900, "msg": "Error during attempted file stageout."},
+    151: {"type": "recoverable", "delay": 900, "msg": "Error during attempted file stageout."},
+    8028: {"type": "recoverable", "delay": 900, "msg": "Job failed to open local and fallback files.", "handler": "handle_file_open_or_root_error"},
+    8021: {"type": "recoverable", "delay": 900, "msg": "FileReadError (May be a site error).", "change_site": True, "handler": "handle_file_open_or_root_error"},
+    8020: {"type": "recoverable", "delay": 900, "msg": "FileOpenError (Likely a site error).", "change_site": True, "handler": "handle_file_open_or_root_error"},
+    8022: {"type": "recoverable", "delay": 900, "msg": "FatalRootError.", "handler": "handle_file_open_or_root_error"},
+    84: {"type": "recoverable", "delay": 900, "msg": "Some required file not found; check logs for name of missing file.", "handler": "handle_file_open_or_root_error"},
+    85: {"type": "recoverable", "delay": 900, "msg": "Job failed to open local and fallback files.", "handler": "handle_file_open_or_root_error"},
+    86: {"type": "recoverable", "delay": 900, "msg": "Job failed to open local and fallback files.", "handler": "handle_file_open_or_root_error"},
+    92: {"type": "recoverable", "delay": 900, "msg": "Job failed to open local and fallback files.", "handler": "handle_file_open_or_root_error"},
+    134: {"type": "recoverable", "delay": 900, "msg": "Abort (ANSI) or IOT trap (4.2 BSD) (most likely user application crashed).", "handler": "handle_sigabrt"},
+    8001: {"type": "recoverable", "delay": 900, "msg": "Other CMS Exception.", "handler": "handle_cvmfs_or_cms_exception"},
+    65: {"type": "recoverable", "delay": 900, "msg": "End of job from user application (CMSSW).", "handler": "handle_cvmfs_or_cms_exception"},
+    "default": {"type": "neutral", "delay": 900, "msg": "Taking default exit code retry policy route."}
+}
 
 # strings in fatal root exception text which indicate code problem, not corrupted file
 # a small "knowledge data base"
@@ -96,6 +132,127 @@ class RetryJob():
                 self.ads.append(ad)
         self.ad = self.ads[-1]
 
+    # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+    def store_retry_actions(self, policy, exitCode):
+        retry_info_file = f"resubmit_info/job.{self.job_id}.txt"
+        retry_info = {}
+
+        if os.path.exists(retry_info_file):
+            try:
+                with open(retry_info_file, "r", encoding="utf-8") as fd:
+                    retry_info = literal_eval(fd.read())
+            except FileNotFoundError:
+                retry_info = {}
+
+        key = str(self.crab_retry)
+        if key not in retry_info:
+            retry_info[key] = {}
+
+        delay = policy.get("delay", 900)
+        retry_info[key]["retry_delay_until"] = time.time() + delay
+        retry_info[key]["exitCode"] = exitCode
+        retry_info[key]["increase_memory"] = policy.get("increase_memory", False)
+        retry_info[key]["increase_runtime"] = policy.get("increase_runtime", False)
+        retry_info[key]["change_site"] = policy.get("change_site", False)
+        retry_info[key]["memory_factor"] = policy.get("memory_factor", 1.0)
+        retry_info[key]["runtime_factor"] = policy.get("runtime_factor", 1.0)
+        retry_info[key]["site"] = getattr(self, "site", None)
+
+        with open(retry_info_file + ".tmp", "w", encoding="utf-8") as fd:
+            fd.write(str(retry_info))
+        os.rename(retry_info_file + ".tmp", retry_info_file)
+
+    # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+    def handle_file_open_or_root_error(self, exitCode):
+        """
+        Handle exit codes related to file open/read/root failures (8020, 8021, 8022, 8028, 84, 85, 86, 92).
+        Checks for corrupted input files; if found, creates a fake FJR with code 8022. 
+        Raises RecoverableError with the policy message.
+        """
+        try:
+            corruptedInputFile = self.check_corrupted_file(exitCode)
+        except Exception as e:  # pylint: disable=broad-except
+            self.logger.error(f"check_corrupted_file raised an exception:\n{e}\nIgnore and go on")
+            corruptedInputFile = False
+        if corruptedInputFile:
+            exitMsg = "Fatal Root Error: possible corrupted input file. Reporting and retrying."
+            self.create_fake_fjr(exitMsg, 8022, 8022, fatalError=False)
+        self.logger.info(f"Handler function ran successfully for exit Code {exitCode}")
+        raise RecoverableError(EXIT_RETRY_POLICY[exitCode]["msg"])
+
+    # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+    def handle_sigabrt(self, exitCode):
+        """
+        Handle exit code 134 (SIGABRT / IOT trap).
+        Checks job stdout for a SIGILL pattern; if found, promotes to a recoverable
+        SIGILL error. Otherwise raises the default RecoverableError.
+        """
+        recoverable_signal = False
+        try:
+            fname = os.path.realpath("WEB_DIR/job_out.%s.%d.txt" % (self.job_id, self.crab_retry))
+            with open(fname, encoding='utf-8') as fd:
+                for line in fd:
+                    if line.startswith("== CMSSW:  A fatal system signal has occurred: illegal instruction"):
+                        recoverable_signal = True
+                        break
+        except Exception:  # pylint: disable=broad-except
+            msg = "Error analyzing abort signal.\nDetails follow:"
+            self.logger.exception(msg)
+        self.logger.info(f"Handler function ran successfully for exit Code {exitCode}")
+        if recoverable_signal:
+            raise RecoverableError("SIGILL; may indicate a worker node issue.")
+
+    # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+    def handle_cvmfs_or_cms_exception(self, exitCode):
+        """
+        Handle exit codes 8001 and 65 (CMS exceptions / end-of-job).
+        Scans job stdout for a truncated CVMFS file pattern; if found raises a
+        specific RecoverableError, otherwise raises the default one.
+        """
+        cvmfs_issue = False
+        try:
+            fname = os.path.relpath("WEB_DIR/job_out.%s.%d.txt" % (self.job_id, self.crab_retry))
+            cvmfs_issue_re = re.compile(r"== CMSSW:  unable to load /cvmfs/.*file too short")
+            with open(fname, encoding='utf-8') as fd:
+                for line in fd:
+                    if cvmfs_issue_re.match(line):
+                        cvmfs_issue = True
+                        break
+        except Exception:  # pylint: disable=broad-except
+            msg = "Error analyzing output for CVMFS issues.\nDetails follow:"
+            self.logger.exception(msg)
+        self.logger.info(f"Handler function ran successfully for exit Code {exitCode}")
+        if cvmfs_issue:
+            raise RecoverableError("CVMFS issue detected.")
+
+    # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+    def apply_retry_policy(self, exitCode):
+        """
+        Enforce exit-code dependent retry limits and delay.
+        Raises FatalError if retry limit exceeded.
+        """
+        policy = EXIT_RETRY_POLICY.get(exitCode, EXIT_RETRY_POLICY["default"])
+        self.logger.info(f"Applying retry policy for exit code {exitCode}")
+        self.store_retry_actions(policy, exitCode)
+        if policy["type"] == "recoverable":
+            # Dispatch to a handler if one is registered for this exit code.
+            handler_name = policy.get("handler")
+            if handler_name:
+                handler = getattr(self, handler_name, None)
+                if handler is None:
+                    self.logger.error(f"Handler '{handler_name}' not found on RetryJob.")
+                else:
+                    handler(exitCode)  
+            raise RecoverableError(policy["msg"])
+
+        if policy["type"] == "neutral":
+            return
+            
     # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
     def get_job_ad_from_file(self):
@@ -307,6 +464,8 @@ class RetryJob():
             return 1
         try:
             exitCode = int(self.report['exitCode'])
+            # Apply retry policy
+            self.apply_retry_policy(exitCode)
         except ValueError:
             msg = "Unable to extract job's wrapper exit code from job report."
             self.logger.warning(msg)
@@ -317,93 +476,11 @@ class RetryJob():
             msg = "Job and stageout wrappers finished successfully (exit code %d)." % (exitCode)
             self.logger.info(msg)
             return 0
-
-        msg = "Job or stageout wrapper finished with exit code %d." % (exitCode)
-        msg += " Trying to determine the meaning of the exit code and if it is a recoverable or fatal error."
-        self.logger.info(msg)
-
-        # Wrapper script sometimes returns the posix return code (8 bits).
-        if exitCode in [8020, 8021, 8022, 8028] or exitCode in [84, 85, 86, 92]:
-            try:  # the following is still a bit experimental, make sure it never crashes the PJ
-                corruptedInputFile = self.check_corrupted_file(exitCode)
-            except Exception as e:  # pylint: disable=broad-except
-                msg = f"check_corrupted_file raised an exception:\n{e}\nIgnore and go on"
-                self.logger.error(msg)
-                corruptedInputFile = False
-            if corruptedInputFile:
-                exitMsg = "Fatal Root Error maybe a corrupted input file. This error is being reported"
-                self.create_fake_fjr(exitMsg, 8022, 8022, fatalError=False)  # retry the job
-            raise RecoverableError("Job failed to open local and fallback files.")
-
-        if exitCode == 1:
-            raise RecoverableError("Job failed to bootstrap CMSSW; likely a worker node issue.")
-
-        if exitCode == 50513 or exitCode == 81:
-            raise RecoverableError("Job did not find functioning CMSSW on worker node.")
-
-        # This is a difficult one -- right now CMSRunAnalysis.py will turn things like
-        # segfaults into an invalid FJR.  Will revisit this decision later.
-        if exitCode == 50115 or exitCode == 195:
-            raise RecoverableError("Job did not produce a FJR; will retry.")
-
-        if exitCode == 134:
-            recoverable_signal = False
-            try:
-                fname = os.path.realpath("WEB_DIR/job_out.%s.%d.txt" % (self.job_id, self.crab_retry))
-                with open(fname, encoding='utf-8') as fd:
-                    for line in fd:
-                        if line.startswith("== CMSSW:  A fatal system signal has occurred: illegal instruction"):
-                            recoverable_signal = True
-                            break
-            except Exception:  # pylint: disable=broad-except
-                msg = "Error analyzing abort signal."
-                msg += "\nDetails follow:"
-                self.logger.exception(msg)
-            if recoverable_signal:
-                raise RecoverableError("SIGILL; may indicate a worker node issue.")
-
-        if exitCode == 8001 or exitCode == 65:
-            cvmfs_issue = False
-            try:
-                fname = os.path.relpath("WEB_DIR/job_out.%s.%d.txt" % (self.job_id, self.crab_retry))
-                cvmfs_issue_re = re.compile("== CMSSW:  unable to load /cvmfs/.*file too short")
-                with open(fname, encoding='utf-8') as fd:
-                    for line in fd:
-                        if cvmfs_issue_re.match(line):
-                            cvmfs_issue = True
-                            break
-            except Exception:  # pylint: disable=broad-except
-                msg = "Error analyzing output for CVMFS issues."
-                msg += "\nDetails follow:"
-                self.logger.exception(msg)
-            if cvmfs_issue:
-                raise RecoverableError("CVMFS issue detected.")
-
-        # Another difficult case -- so far, SIGKILL has mostly been observed at T2_CH_CERN, and it has nothing to do
-        # with an issue of the job itself. Typically, this isn't the user code's fault
-        # it was often a site or pilot misconfiguration that led to the pilot exhausting its allocated runtime.
-        # We should revisit this issue if we see SIGKILL happening for other cases that are the users' fault.
-        if exitCode == 137:
-            raise RecoverableError("SIGKILL; likely an unrelated batch system kill.")
-
-        if exitCode == 10034 or exitCode == 50:
-            raise RecoverableError("Required application version not found at the site.")
-
-        if exitCode == 10040:
-            raise RecoverableError("Site Error: failed to generate cmsRun cfg file at runtime.")
-
-        if exitCode == 60403 or exitCode == 243:
-            raise RecoverableError("Timeout during attempted file stageout.")
-
-        if exitCode == 60307 or exitCode == 147:
-            raise RecoverableError("Error during attempted file stageout.")
-
-        if exitCode == 60311 or exitCode == 151:
-            raise RecoverableError("Error during attempted file stageout.")
-
-        if exitCode:
+        else:
             raise FatalError("Job wrapper finished with exit code %d.\nExit message:\n  %s" % (exitCode, exitMsg.replace('\n', '\n  ')))
 
+        msg = "Job or stageout wrapper finished with exit code %d." % (exitCode)
+        self.logger.info(msg)      
         return 0
 
     # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =


### PR DESCRIPTION
Fix #9318 
For larger discussion on how we reached here, see #9264 and (few last comments in) #9276 

---

## Design Write-Up: CRABServer Resubmission Policy Refactor

---

This PR introduces three interlocking concepts:

1. **RRN (Resubmission Retry Number)** : a new, independent, per-job counter that counts genuine job execution attempts across all resubmission epochs.
2. **EXIT_RETRY_POLICY** : a declarative dictionary in `RetryJob.py` that maps exit codes to retry actions (delay, memory boost, runtime boost, site change).
3. **`resubmit_record.json` and epoch tracking** : a mechanism to allow user-triggered resubmissions to reset RRN counters for targeted jobs, enabling a clean slate while preserving history. Note that epoch is a counter, not time.

---

### The Three Counters: `dag_retry`, `crab_retry`, and `rrn`

Understanding the difference between these is essential.

| Counter | Owned By | What It Counts | Resets? | Stored In |
|---|---|---|---|---|
| `dag_retry` (`$RETRY`) | DAGMan | DAGMan node submission attempts (pre+job+post cycle) within current DAG run | **Never** | DAGMan internal state |
| `crab_retry` | CRAB PostJob | Number of times PostJob has completed (job ran + postjob ran) | **Never** | `retry_info/job.<id>.txt` |
| `rrn` | CRAB PreJob/AdjustSites | True number of execution attempts (auto + user-triggered) | Only on user resubmit | `rrn_info/job.<id>.txt` |

`crab_retry` is used as a key/index into `resubmit_info/job.<id>.txt` to store per-attempt parameters (memory, runtime, site lists, exit code info). It is strictly increasing and never resets, it serves as a stable record key.

`rrn` is used exclusively to answer: "Has this job been tried enough times overall?" It resets to 0 when the user explicitly resubmits, giving the job a fresh budget of `CRAB_NumAutomJobRetries` (now **10**, up from 2) attempts. PreJob stamps `CRAB_RRN` into the job's classAd so PostJob can read it without touching the filesystem.

`dag_retry` still controls the DAGMan machinery, but PostJob no longer uses it as the gate for "too many retries" , it uses `rrn` instead.

---

### The Lifecycle of a Single Job Attempt

**Step 1 — PreJob runs:**
- Calls `get_rrn()`: reads `rrn_info/job.<id>.txt`, increments the `rrn` field, writes it back (atomic rename, file-locked).
- Stamps `My.CRAB_RRN = <rrn>` into the job submit classAd.
- Reads `resubmit_info/job.<id>.txt` at key `crab_retry - 1` (the previous attempt's data).
  - If `increase_memory` is set, multiplies current memory by `memory_factor` (capped at 7500 MB).
  - If `increase_runtime` is set, multiplies current walltime by `runtime_factor` (capped at 47 h).
- Reads `change_site` from the previous attempt. If set, and there is more than one available site, removes the previous failing site from the candidate set.
- Checks `retry_delay_until` from `resubmit_info` for the current `dag_retry` key. If now < that timestamp, returns True from `needsDefer()` and the job is deferred (held and re-released after the delay).
- Writes the chosen parameters into `resubmit_info/job.<id>.txt` at key `str(crab_retry)`.

**Step 2 — Job runs on the worker node.**

**Step 3 — RetryJob runs (if the job finished with non-zero exit code):**
- Calls `apply_retry_policy(exitCode)`.
- Looks up `exitCode` in `EXIT_RETRY_POLICY`. Falls back to `"default"` (neutral, no adjustments) if not found.
- Calls `store_retry_actions(policy, exitCode)`: writes into `resubmit_info/job.<id>.txt` at key `str(crab_retry)`:
  - `retry_delay_until = time.time() + policy["delay"]` (typically 900 s)
  - `increase_memory`, `increase_runtime`, `change_site` booleans and their factors
  - `site` = the site where this attempt ran (so PreJob can discard it next time if needed)
  - `exitCode`
- If the policy type is `"recoverable"`, dispatches to a handler (if registered), then raises `RecoverableError`.
- If the policy type is `"neutral"`, returns without raising, falls through to the existing `FatalError` raise at the bottom of `check_exit_code`.

**Step 4 — PostJob runs:**
- Calls `get_rrn()`: reads `CRAB_RRN` from the job classAd (stamped by PreJob). Falls back to `rrn_info/job.<id>.txt` if classAd unavailable (e.g., PreJob itself crashed before the job ran).
- Calls `get_max_retry()`: reads `CRAB_NumAutomJobRetries` from the task classAd (default 10).
- If `retryjob_retval == RECOVERABLE_ERROR`: checks `rrn >= max_retry`. If yes → fatal. Otherwise → recoverable (DAGMan will retry).

---

### The EXIT_RETRY_POLICY Dictionary

The old `RetryJob.py` had a linear `if/elif` chain. The new code replaces it with a data-driven dictionary:

```python
EXIT_RETRY_POLICY = {
    1:     {"type": "recoverable", "delay": 900, "msg": "...bootstrap failure..."},
    50115: {"type": "recoverable", "delay": 900, "msg": "..no FJR..", "increase_memory": True, "memory_factor": 1.3},
    195:   {"type": "recoverable", "delay": 900, "msg": "..no FJR..", "increase_memory": True, "memory_factor": 1.3},
    60403: {"type": "recoverable", "delay": 900, "msg": "..stageout timeout..", "increase_runtime": True, "runtime_factor": 1.3},
    243:   {"type": "recoverable", "delay": 900, "msg": "..stageout timeout..", "increase_runtime": True, "runtime_factor": 1.3},
    8020:  {"type": "recoverable", "delay": 900, "msg": "..FileOpenError..", "change_site": True, "handler": "handle_file_open_or_root_error"},
    8021:  {"type": "recoverable", "delay": 900, "msg": "..FileReadError..", "change_site": True, "handler": "handle_file_open_or_root_error"},
    ...
    "default": {"type": "neutral", "delay": 900, "msg": "..."}
}
```

Key additions:
- `increase_memory` / `memory_factor`: triggers a 1.3× memory increase on the *next* attempt.
- `increase_runtime` / `runtime_factor`: triggers a 1.3× walltime increase on the *next* attempt.
- `change_site`: triggers removal of the failing site from the candidate set on the *next* attempt.
- `handler`: name of a method on `RetryJob` to call before raising `RecoverableError` (for exit-code-specific logic like checking corrupted files or CVMFS issues).
- `"neutral"` type: the exit code is not recognized as explicitly recoverable; falls through to the existing fatal-error path rather than either retrying blindly or failing definitively.

The three handler methods (`handle_file_open_or_root_error`, `handle_sigabrt`, `handle_cvmfs_or_cms_exception`) contain the same logic as the old inline `if` blocks, they are just extracted into named methods and dispatched via the policy table.

---

### User-Triggered Resubmission and RRN Reset

When a user calls `crab resubmit`, `DagmanResubmitter.py` runs. The new code adds:

```python
newEpoch = currentEpoch + 1
resubmitRecord = json.dumps({
    'epoch': newEpoch,
    'job_ids': task['resubmit_jobids']  
})
schedd.edit(rootConst, "CRAB_ResubmitEpoch", str(newEpoch))
schedd.edit(rootConst, "CRAB_ResubmitRecord", classad.quote(resubmitRecord))
```

Both `epoch` and `job_ids` are written atomically as a single JSON classAd value (`CRAB_ResubmitRecord`). This prevents AdjustSites from ever seeing a mismatched (new epoch, old job list) pair.

When DAGMan restarts and `AdjustSites.py` runs:
1. `writeResubmitRecord(ad)` reads `CRAB_ResubmitRecord` from the task classAd and writes it to `rrn_info/resubmit_record.json`. Idempotent: skips if the on-disk epoch already matches.
2. `resetRRN()` reads `rrn_info/resubmit_record.json`. For each targeted job (or all jobs if `job_ids` is null), opens `rrn_info/job.<id>.txt`, checks `last_reset_epoch`. If `last_reset_epoch < current_epoch`, sets `rrn = 0`. If `last_reset_epoch >= current_epoch`, we skip with continue. This idempotency in == means DAGMan can restart AdjustSites multiple times safely. The > case should not happen until things have gone very wrong.

After this reset, when PreJob runs for a resubmitted job, `get_rrn()` finds `rrn = 0` and increments it to 1, effectively giving the job a new budget of `max_retry` attempts.

### `reuse_rrn`: Handling Interrupted PreJob

There is a subtle race condition: PreJob can crash or be killed after incrementing RRN but before the job actually runs. This also happens when a resubmission of a different job id happens while another is running. When DAGMan retries the node, PreJob runs again. At this point:
- `retry_info` shows `pre > post` (PreJob ran more times than PostJob)
- `job_out.<id>.<retry>` does not exist (job never ran)

Originally, this case set `prejob_exit_code = 1` (error) only if a job_out existed, implying the job had run. In the new code an `else` branch is added: when `pre > post` and no `job_out`, it sets `self.reuse_rrn = True`. Then `get_rrn()`, instead of incrementing, just returns the current `rrn` value unchanged. This prevents RRN from being double-incremented for a single logical job attempt where PreJob happened to restart.

---

### Summary of Key Changes

| Aspect | Existing | New |
|---|---|---|
| Retry gate counter | `dag_retry` (DAGMan internal) | `rrn` (CRAB-owned, per job) |
| Default max retries | 2 | 10 |
| Max retries storage | `$MAX_RETRIES` baked into DAG | `CRAB_NumAutomJobRetries` in task classAd |
| Exit-code handling | `if/elif` chain in `RetryJob` | Declarative `EXIT_RETRY_POLICY` dict |
| Memory auto-boost | Not present | 1.3× on exit 50115/195, capped 7500 MB |
| Runtime auto-boost | Not present | 1.3× on exit 60403/243, capped 47 h |
| Site change on failure | Not present | Discard failing site on exit 8020/8021 |
| Retry delay enforcement | Not present | `retry_delay_until` checked in PreJob |
| User resubmit resets budget | `adjustMaxRetries` increased max_retries by 1 + numAutomJobRetries  | Explicitly via RRN reset + epoch mechanism |
| Idempotent resubmit record | N/A | Yes, `last_reset_epoch` per job |
| Interrupted PreJob | Exit code 1 if job_out exists | `reuse_rrn=True` — no double-increment |
