### PR TITLE
Fix heavy query

### DIFF
--- a/src/python/CRABInterface/RESTTask.py
+++ b/src/python/CRABInterface/RESTTask.py
@@ -67,12 +67,6 @@ class RESTTask(RESTEntity):
         rows = self.api.query(None, None, self.Task.IDAll_sql, taskname=kwargs['workflow'])
         return rows
 
-	#INSERTED BY ERIC SUMMER STUDENT
-    def summary(self, **kwargs):
-        """ Retrieves the data for list all users"""
-        rows = self.api.query(None, None, self.Task.TASKSUMMARY_sql)
-        return rows
-
     # short status summary for the UI MAIN tab
     def status(self, **kwargs):
         """
@@ -315,8 +309,7 @@ class RESTTask(RESTEntity):
         workflow = kwargs['workflow']
         authz_owner_match(self.api, [workflow], self.Task) #check that I am modifying my own workflow
 
-#        rows = self.api.query(None, None, "SELECT tm_task_warnings FROM tasks WHERE tm_taskname = :workflow", workflow=workflow)#self.Task.TASKSUMMARY_sql)
-        rows = self.api.query(None, None, self.Task.ID_sql, taskname=workflow)#self.Task.TASKSUMMARY_sql)
+        rows = self.api.query(None, None, self.Task.ID_sql, taskname=workflow)
         rows = list(rows) #from generator to list
         if len(rows)==0:
             raise InvalidParameter("Task %s not found in the task database" % workflow)
@@ -347,8 +340,7 @@ class RESTTask(RESTEntity):
         workflow = kwargs['workflow']
         authz_owner_match(self.api, [workflow], self.Task) #check that I am modifying my own workflow
 
-#        rows = self.api.query(None, None, "SELECT tm_task_warnings FROM tasks WHERE tm_taskname = :workflow", workflow=workflow)#self.Task.TASKSUMMARY_sql)
-        rows = self.api.query(None, None, self.Task.ID_sql, taskname=workflow)#self.Task.TASKSUMMARY_sql)
+        rows = self.api.query(None, None, self.Task.ID_sql, taskname=workflow)
         rows = list(rows) #from generator to list
         if len(rows)==0:
             raise InvalidParameter("Task %s not found in the task database" % workflow)

--- a/src/python/CRABInterface/RESTWorkerWorkflow.py
+++ b/src/python/CRABInterface/RESTWorkerWorkflow.py
@@ -53,6 +53,7 @@ class RESTWorkerWorkflow(RESTEntity):
             validate_str("workername", param, safe, RX_WORKER_NAME, optional=True)
             validate_str("getstatus", param, safe, RX_STATUS, optional=True)
             validate_num("limit", param, safe, optional=True)
+            validate_num("months", param, safe, optional=True)
             # possible combinations to check
             # 1) workername + getstatus + limit
             # 2) subresource + subjobdef + subuser
@@ -83,12 +84,12 @@ class RESTWorkerWorkflow(RESTEntity):
         return []
 
     @restcall
-    def get(self, workername, getstatus, limit):
+    def get(self, workername, getstatus, limit, months=1):
         """ Retrieve all columns for a specified task or
             tasks which are in a particular status with
             particular conditions """
 
-        binds = {"limit": limit, "tw_name": workername, "get_status": getstatus}
+        binds = {"limit": limit, "tw_name": workername, "get_status": getstatus, "months": months} 
         rows = self.api.query(None, None, self.Task.GetReadyTasks_sql, **binds)
         for row in rows:
             # get index of tm_user_config to load data from clob and load json string

--- a/src/python/CRABInterface/RESTWorkerWorkflow.py
+++ b/src/python/CRABInterface/RESTWorkerWorkflow.py
@@ -89,6 +89,7 @@ class RESTWorkerWorkflow(RESTEntity):
             tasks which are in a particular status with
             particular conditions """
 
+        months = 1 if months is None else int(months)
         binds = {"limit": limit, "tw_name": workername, "get_status": getstatus, "months": months} 
         rows = self.api.query(None, None, self.Task.GetReadyTasks_sql, **binds)
         for row in rows:

--- a/src/python/CRABInterface/Regexps.py
+++ b/src/python/CRABInterface/Regexps.py
@@ -88,7 +88,7 @@ RX_SUBRESTAT = re.compile(r"^(errors|report2|logs|data|logs2|data2|resubmit|resu
 
 #subresources of the ServerInfo (/info) and Task (/task) resources
 RX_SUBRES_SI = re.compile(r"^(delegatedn|version|bannedoutdest|scheddaddress|ignlocalityblacklist)$")
-RX_SUBRES_TASK = re.compile(r"^(allinfo|allusers|summary|search|status|taskbystatus|taskbyddmreqid|getpublishurl|addwarning|deletewarnings|addwebdir|addoutputdatasets|addddmreqid|webdir|webdirprx|counttasksbystatus|counttasksbyuserandstatus|lastfailures|lastrefused|updateschedd|updatepublicationtime|addrucioasoinfo|edit)$")
+RX_SUBRES_TASK = re.compile(r"^(allinfo|allusers|search|status|taskbystatus|taskbyddmreqid|getpublishurl|addwarning|deletewarnings|addwebdir|addoutputdatasets|addddmreqid|webdir|webdirprx|counttasksbystatus|counttasksbyuserandstatus|lastfailures|lastrefused|updateschedd|updatepublicationtime|addrucioasoinfo|edit)$")
 RX_TASK_COLUMN = re.compile(r"^[a-z_]{1,50}$")  # ideally could like all table columns.... but how do we maintain it ?
 
 #subresources of Cache resource

--- a/src/python/Databases/TaskDB/Oracle/Task/Task.py
+++ b/src/python/Databases/TaskDB/Oracle/Task/Task.py
@@ -97,7 +97,7 @@ class Task(object):
                        tm_user_files, tm_transfer_outputs, tm_output_lfn, tm_ignore_locality, tm_fail_limit, tm_one_event_mode, \
                        tm_publish_groupname, tm_nonvalid_input_dataset, tm_secondary_input_dataset, tm_primary_dataset, \
                        tm_submitter_ip_addr, tm_ignore_global_blacklist, tm_user_config \
-                       FROM tasks WHERE tm_task_status = :get_status AND ROWNUM <= :limit AND tw_name LIKE :tw_name
+                       FROM tasks WHERE tm_task_status = :get_status AND ROWNUM <= :limit AND tw_name LIKE :tw_name and tm_start_time > SYSDATE - INTERVAL '1' MONTH \
                        ORDER BY tm_start_time ASC"""
 
     #GetUserFromID

--- a/src/python/Databases/TaskDB/Oracle/Task/Task.py
+++ b/src/python/Databases/TaskDB/Oracle/Task/Task.py
@@ -26,8 +26,6 @@ class Task(object):
 
     #INSERTED BY ERIC SUMMER STUDENT
     ALLUSER_sql = "SELECT DISTINCT(tm_username) FROM tasks"
-    #TODO: remove some of the following unused queries
-    TASKSUMMARY_sql = "select tm_username, tm_task_status, count(*) from tasks group by tm_username, tm_task_status order by tm_username"
     #get taskname by user and status
     GetByUserAndStatus_sql = "select tm_taskname from tasks where tm_username=:username and tm_task_status=:status"
     #quick search

--- a/src/python/Databases/TaskDB/Oracle/Task/Task.py
+++ b/src/python/Databases/TaskDB/Oracle/Task/Task.py
@@ -95,7 +95,7 @@ class Task(object):
                        tm_user_files, tm_transfer_outputs, tm_output_lfn, tm_ignore_locality, tm_fail_limit, tm_one_event_mode, \
                        tm_publish_groupname, tm_nonvalid_input_dataset, tm_secondary_input_dataset, tm_primary_dataset, \
                        tm_submitter_ip_addr, tm_ignore_global_blacklist, tm_user_config \
-                       FROM tasks WHERE tm_task_status = :get_status AND ROWNUM <= :limit AND tw_name LIKE :tw_name and tm_start_time > SYSDATE - INTERVAL '1' MONTH \
+                       FROM tasks WHERE tm_task_status = :get_status AND ROWNUM <= :limit AND tw_name LIKE :tw_name and tm_start_time > SYSDATE - INTERVAL ':months' MONTH \
                        ORDER BY tm_start_time ASC"""
 
     #GetUserFromID

--- a/src/python/Databases/TaskDB/Oracle/Task/Task.py
+++ b/src/python/Databases/TaskDB/Oracle/Task/Task.py
@@ -95,7 +95,7 @@ class Task(object):
                        tm_user_files, tm_transfer_outputs, tm_output_lfn, tm_ignore_locality, tm_fail_limit, tm_one_event_mode, \
                        tm_publish_groupname, tm_nonvalid_input_dataset, tm_secondary_input_dataset, tm_primary_dataset, \
                        tm_submitter_ip_addr, tm_ignore_global_blacklist, tm_user_config \
-                       FROM tasks WHERE tm_task_status = :get_status AND ROWNUM <= :limit AND tw_name LIKE :tw_name and tm_start_time > SYSDATE - INTERVAL ':months' MONTH \
+                       FROM tasks WHERE tm_task_status = :get_status AND ROWNUM <= :limit AND tw_name LIKE :tw_name and tm_start_time > ADD_MONTHS(SYSDATE, -:months) \
                        ORDER BY tm_start_time ASC"""
 
     #GetUserFromID


### PR DESCRIPTION
Resolve #9320 

I have tested the extended sql queries and it looks good with roughly 2 orders of magnitude speed up [1].

[1]
```sql
SQL> SELECT COUNT(*) FROM tasks WHERE tm_task_status = 'SUBMITTED' and ROWNUM <= 1000 AND tw_name LIKE 'crab-prod-tw01' ORDER BY tm_start_time ASC;

  COUNT(*)
----------
      1000

Elapsed: 00:00:02.21
SQL> SELECT COUNT(*) FROM tasks WHERE tm_task_status = 'SUBMITTED' and ROWNUM <= 1000 AND tw_name LIKE 'crab-prod-tw01' and tm_start_time > SYSDATE - INTERVAL '1' MONTH ORDER BY tm_start_time ASC;

  COUNT(*)
----------
      1000

Elapsed: 00:00:00.01
```