### PR TITLE
fix #9336

### DIFF
--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -2427,7 +2427,10 @@ class PostJob():
                 try:
                     Lexicon.lfn(lfn)  # will raise if testLfn is not a valid lfn
                 except AssertionError:
-                    lfn = '/store/user/dummy/DummyLFN'
+                    # need to preserve distinct identities of input files in LFN format
+                    # so that crab report can count correctly the number of processed files
+                    uniqueID = hashlib.sha1(lfn.encode()).hexdigest()
+                    lfn = f'/store/user/dummy/InvalidLFN/{uniqueID}'
 
             lfn = lfn + "_" + str(self.job_id) # jobs can analyze the same input
             configreq = {"taskname"        : self.job_ad['CRAB_ReqName'],


### PR DESCRIPTION
Fixes #9336
when input file name is not a valid LFN, use unique `InvalidLFN` for each unique input file name in InputFMD
