### PR TITLE
Make runner more robust

### DIFF
--- a/cicd/gitlab/setupCRABClient.sh
+++ b/cicd/gitlab/setupCRABClient.sh
@@ -19,7 +19,9 @@ set -euo pipefail
 scramv1 project ${CMSSW_release}
 pushd ${CMSSW_release}/src
 eval "$(scramv1 runtime -sh)"
-scram build > /dev/null
+# at times this fails in the gitlab-runner, in that case run again with full output
+scram build > /dev/null || scram build
+
 
 mkdir -p ../venv
 


### PR DESCRIPTION
sometimes our pipeline test fails early in setup client with error like
```
gmake[1]: *** [config/SCRAM/GMake/Makefile.rules:1887: CompilePython] Error 1
gmake: *** [config/SCRAM/GMake/Makefile.rules:1753: src] Error 2
clientValidation.sh ended with exit code: 2
```
triggering a re-run by clicking in the pipeline gitlab UI usually fixes it.
I do not know what could cause it.

So let's try to re-run in the script and see if error goes away, also do w/o redirecting stdout to /dev/null in hope of hints, in case
