### PR TITLE
correct handling of too much wall clock. Fix #9345

### DIFF
--- a/src/python/TaskWorker/Actions/RetryJob.py
+++ b/src/python/TaskWorker/Actions/RetryJob.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import socket
 import time
+import datetime
 from collections import namedtuple
 from ast import literal_eval
 from ServerUtilities import executeCommand, getLock
@@ -370,33 +371,20 @@ class RetryJob():
         Need a doc string here.
         """
         # If job was killed on the worker node, we probably don't have a FJR.
+        wallSeconds = self.ad.get("LastRemoteWallClockTime")
+        cpuSeconds =  self.ad.get("RemoteUserCpu") + self.ad.get("RemoteSysCpu")
+        maxSeconds = self.ad.get("MaxWallTimeMinsRun") * 60
         if self.ad.get("RemoveReason", "").startswith("Removed due to wall clock limit"):
+            wallTime = datetime.timedelta(seconds=wallSeconds)  # from seconds to human format days HH:MM:SS
+            wallMax = datetime.timedelta(seconds=maxSeconds) 
             exitMsg = "Not retrying job due to wall clock limit (job automatically killed on the worker node)"
+            exitMsg += f"\nJobs lasted {wallSeconds} seconds ({wallTime}) vs. {maxSeconds} ({wallMax}) MAX"
             self.create_fake_fjr(exitMsg, 50664, 50664)  # this raises FatalError
         if "CPU usage over limit" in self.ad.get("RemoveReason", ""):
-            exitMsg = "Not retrying job due CPU limit (using more CPU than Wall Clock)"
+            # NOTE: currently PeriodicRemoval does not enforce this !!!
+            exitMsg = "Not retrying job due to CPU limit (using more CPU than Wall Clock)"
+            exitMsg += f"\nJob used {cpuSeconds} CPU seconds in {wallSeconds} seconds of wall time"
             self.create_fake_fjr(exitMsg, 50663, 50663)  # this raises FatalError
-        subreport = self.report
-        for attr in ['steps', 'cmsRun', 'performance', 'cpu', 'TotalJobTime']:
-            subreport = subreport.get(attr, None)
-            if subreport is None:
-                return
-        total_job_time = self.report['steps']['cmsRun']['performance']['cpu']['TotalJobTime']
-        try:
-            total_job_time = float(total_job_time)
-        except ValueError:
-            return
-        integrated_job_time = 0
-        for ad in self.ads:
-            if 'RemoteWallClockTime' in ad:
-                integrated_job_time += ad['RemoteWallClockTime']
-        self.integrated_job_time = integrated_job_time
-        if total_job_time > self.MAX_WALLTIME:
-            exitMsg = "Not retrying a long running job (job ran for %d hours)" % (total_job_time / 3600)
-            self.create_fake_fjr(exitMsg, 50664)  # this raises FatalError
-        if integrated_job_time > (1.5 * self.MAX_WALLTIME):
-            exitMsg = "Not retrying a job because the integrated time (across all retries) is %d hours." % (integrated_job_time / 3600)
-            self.create_fake_fjr(exitMsg, 50664)  # this raises FatalError
 
     # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 

--- a/src/python/TaskWorker/Actions/RetryJob.py
+++ b/src/python/TaskWorker/Actions/RetryJob.py
@@ -45,19 +45,19 @@ EXIT_RETRY_POLICY = {
 # sometimes we only get a short exit code from the 8 rightmost bits (like when bash filters it)
 # so let's add them
 newERP = {}  # new temp dict. to avoid changing dict. while iterating
-for code, policy in EXIT_RETRY_POLICY.items():
-    newERP[code] = policy
-    if code == "default":
+for exCode, retryPolicy in EXIT_RETRY_POLICY.items():
+    newERP[exCode] = retryPolicy
+    if exCode == "default":
         continue
-    shortCode = int(code) & 0xff
-    if shortCode == int(code):
+    shortCode = int(exCode) & 0xff
+    if shortCode == int(exCode):
         # the list may intentionally contain short exit codes, e.g. 128+SIG* (bash adds 128 !)
         continue
     if shortCode in newERP:
         # duplicate.. this should never happen other than for the "intentional"
         # exit code 81 (see https://github.com/dmwm/CRABServer/issues/9340 )
         pass
-    newERP[shortCode] = policy
+    newERP[shortCode] = retryPolicy
 EXIT_RETRY_POLICY = newERP
 
 # strings in fatal root exception text which indicate code problem, not corrupted file


### PR DESCRIPTION
also improves message in PostJob. When job hit maximum wall time it will print
```text
Mon, 27 Jul 2026 11:04:56 CEST(+0200):INFO:PostJob        -----> RetryJob log start -----
Mon, 27 Jul 2026 11:04:56 CEST(+0200):DEBUG:RetryJob Job ads already present. Will not use condor_q, but will load previous jobs ads.
Mon, 27 Jul 2026 11:04:56 CEST(+0200):INFO:RetryJob This is job retry number 0. Will not try to search and load previous job ads.
Mon, 27 Jul 2026 11:04:56 CEST(+0200):INFO:RetryJob New job_fjr.1.0.json file content: {"exitMsg": "Not retrying job due to wall clock limit (job automatically killed on the worker node)\nJobs lasted 131.0 seconds (0:02:11) vs. 120 (0:02:00) MAX", "jobExitCode": 50664, "exitCode": 50664}
Mon, 27 Jul 2026 11:04:56 CEST(+0200):ERROR:RetryJob Original error: Job did not produce a usable framework job report.
Mon, 27 Jul 2026 11:04:56 CEST(+0200):ERROR:RetryJob Not retrying job due to wall clock limit (job automatically killed on the worker node)
Jobs lasted 131.0 seconds (0:02:11) vs. 120 (0:02:00) MAX
Mon, 27 Jul 2026 11:04:56 CEST(+0200):INFO:PostJob        <----- RetryJob log finish ----
```
and `crab status --verboseErrors` prints
```text

1 jobs failed with exit code 50664:

	1 jobs failed with following error message: (for example, job 1)

		Not retrying job due to wall clock limit (job automatically killed on the worker node)
		Jobs lasted 131.0 seconds (0:02:11) vs. 120 (0:02:00) MAX

```