### PR TITLE
Split fatal Application segfaults out of 50115 as 50117.

### DIFF
--- a/src/python/TaskWorker/Actions/RetryJob.py
+++ b/src/python/TaskWorker/Actions/RetryJob.py
@@ -205,7 +205,7 @@ class RetryJob():
             exitMsg = ("Application terminated by itself with a segmentation violation"
                        f" after {cpuSeconds}s of CPU time."
                        " This points at the application code or the input data, not at the site."
-                       " Not retrying; please debug and resubmit.")
+                       " Not retrying; please debug and submit a new task.")
             self.create_fake_fjr(exitMsg, 50117, 50117)
 
     # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =

--- a/src/python/TaskWorker/Actions/RetryJob.py
+++ b/src/python/TaskWorker/Actions/RetryJob.py
@@ -17,6 +17,13 @@ import classad2 as classad
 
 JOB_RETURN_CODES = namedtuple('JobReturnCodes', 'OK RECOVERABLE_ERROR FATAL_ERROR DAG_ABORT DEFER')(0, 1, 2, 3, 4)
 
+# below this much CPU a segfault is more likely environment than user code
+SEGFAULT_CPU_THRESHOLD = 300 # Seconds
+SEGFAULT_RES = [
+    re.compile(r"== CMSSW:\s+A fatal system signal has occurred: segmentation violation"),
+    re.compile(r"== CMSSW:\s+\*\*\* Break \*\*\* segmentation violation"),
+]
+
 # ----------------------------------------------------------------------
 # Exit-code dependent retry policy
 # ----------------------------------------------------------------------
@@ -26,7 +33,7 @@ EXIT_RETRY_POLICY = {
     # if a new string is added as key, code which uses this muzt be changed or will raise ValueError
     1: {"type": "recoverable", "delay": 900, "msg": "Job failed w/o messages; likely a worker node issue."},
     50513: {"type": "recoverable", "delay": 900, "msg": "Job did not find functioning CMSSW on worker node."},
-    50115: {"type": "recoverable", "delay": 900, "msg": "Job did not produce a FJR; will retry.", "increase_memory": True, "memory_factor": 1.3},
+    50115: {"type": "recoverable", "delay": 900, "msg": "Job did not produce a FJR; will retry.", "increase_memory": True, "memory_factor": 1.3, "handler": "handle_missing_fjr"},
     137: {"type": "recoverable", "delay": 900, "msg": "SIGKILL; likely an unrelated batch system kill."},
     10034: {"type": "recoverable", "delay": 900, "msg": "Required application version not found at the site."},
     10040: {"type": "recoverable", "delay": 900, "msg": "Site Error: failed to generate cmsRun cfg file at runtime."},
@@ -171,6 +178,35 @@ class RetryJob():
         with open(retry_info_file + ".tmp", "w", encoding="utf-8") as fd:
             fd.write(str(retry_info))
         os.rename(retry_info_file + ".tmp", retry_info_file)
+
+    # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+    def handle_missing_fjr(self, exitCode):
+        """
+        50115: no FJR was produced. If the job segfaulted after doing real work,
+        relabel as 50117 (fatal, application) instead of retrying.
+        Anything else falls through to the normal recoverable route.
+        """
+        segfault = False
+        try:
+            fname = os.path.realpath("WEB_DIR/job_out.%s.%d.txt" % (self.job_id, self.crab_retry))
+            with open(fname, encoding='utf-8') as fd:
+                for line in fd:
+                    if any(r.search(line) for r in SEGFAULT_RES):
+                        segfault = True
+                        break
+        except Exception:  # pylint: disable=broad-except
+            self.logger.error("Error scanning job stdout for segfault")
+
+        cpuSeconds = int(self.ad.get("RemoteUserCpu", 0)) + int(self.ad.get("RemoteSysCpu", 0))
+        self.logger.info(f"ec {exitCode}: segfault={segfault} cpu={cpuSeconds}s")
+
+        if segfault and cpuSeconds > SEGFAULT_CPU_THRESHOLD:
+            exitMsg = ("Application terminated by itself with a segmentation violation"
+                       f" after {cpuSeconds}s of CPU time."
+                       " This points at the application code or the input data, not at the site."
+                       " Not retrying; please debug and resubmit.")
+            self.create_fake_fjr(exitMsg, 50117, 50117)
 
     # = = = = = RetryJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 


### PR DESCRIPTION
(partially) resolves #9357

## Background

50115 currently means "cmsRun did not produce a valid job report" and is retried three times with a 1.3× memory bump. A survey of 1000 tasks that hit 50115 between 2026-08-04 and 2026-08-30 shows the code covers two populations:
 | tasks | behaviour
-- | -- | --
never succeeded after retries | 262 (26.2%) | retries are pure waste
≥80% of failures were 50115, all eventually succeeded | 565 (56.5%) | retries work as intended

TWiki JobExitCode also already confirm/admits the ambiguity that 50115 "often means cmsRun segfaulted". 

## This PR includes
It resolves the subset we can identify with confidence: 

A segmentation violation that happened **after the event loop started** which may due to user code error or misconfigurations. 
> These are relabelled as 50117 fail-fast and not retried. Everything else remains the current 50115 behaviour.

Users get a faster feedback loop on their own crashes, and the grid stops running three copies of a job that cannot succeed.

## Twiki JobExitCodes

50115 — cmsRun did not produce a valid job report at runtime (cause undetermined; retried)
**50117 — cmsRun terminated with a segmentation violation after processing began (not retried)**

## Why CPU seconds, not wall clock
*Claude opus raised, well recommended us to use Cpu time*
A job stalled on sick CVMFS or a hung xrootd read accumulates wall time while burning almost no CPU — a wall-clock gate would misclassify exactly the transient population this PR is trying to protect. Since 50115 means there is no FJR, the classad (RemoteUserCpu + RemoteSysCpu) is the only available source.

The **SEGFAULT_CPU_THRESHOLD** should be safe threshold and derived from the **survey data of 262 workflows**

## Things will follow up on another PR

New codes for the 565-task transient population. Their behaviour is already correct; new codes there buy monitoring granularity only, and every published code is a permanent commitment in user-facing docs. Revisit once the log patterns are proven.