### PR TITLE
avoid races in handling tooManyASOErrors fix #9408 fix #9403

### DIFF
--- a/src/python/TaskWorker/Actions/PostJob.py
+++ b/src/python/TaskWorker/Actions/PostJob.py
@@ -2194,52 +2194,54 @@ class PostJob():
                     #if we need to defer the postjob execution stop here!
                     return ret_code, "", ASOExitCode
             except PermanentStageoutError as pse:
-                retmsg = "Got fatal stageout exception:\n%s" % (str(pse))
-                self.logger.error(retmsg)
-                ASOExitCode = mostCommon(self.stageout_exit_codes, 60324)
+                self.logger.info("====== Finished to check for ASO transfers.")
                 msg = "There was at least one permanent stageout error; user will need to resubmit."
                 self.logger.error(msg)
+                retMsg = "Got fatal stageout exception:\n%s" % (str(pse))
+                self.logger.error(retMsg)
+                ASOExitCode = mostCommon(self.stageout_exit_codes, 60324)
                 self.set_dashboard_state('FAILED', exitCode=ASOExitCode)
                 self.recordPermanentStageoutError(exitCode=ASOExitCode)
-                self.logger.info("====== Finished to check for ASO transfers.")
+                retCode = JOB_RETURN_CODES.FATAL_ERROR
                 if self.tooManyPermanentStageoutErrors():
-                    if self.maxFatalAsoDryRun:
-                        self.logger.error("**** Too Many Fatal ASO errors. ****")
-                        self.logger.error("**** If dry run were False, I would abort DAG and kill task ****")
-                        # send msg to operators (only once per task) and go on normally
-                        if self.maxFatalAsoNotificationMail and not self.maxFatalAsoMailAlreadySent():
-                            self.sendMaxFatalAsoMailToOperators()
-                        self.logger.info("Tag Jobs as ForcefullyTerminated")
-                        self.tagAllJobsInTask(ad='CRAB_ForcefullyTerminated', value='DryASO')
-                        self.set_state_ClassAds('FAILED', exitCode=ASOExitCode)
-                        return JOB_RETURN_CODES.FATAL_ERROR, retmsg, ASOExitCode
-                    # abort DAG, kill task and tag jobs
-                    self.logger.error("**** Too Many Fatal ASO errors. Abort DAG and kill task ****")
-                    killMsg = "Killed by CRAB because output can't be placed at destination site."
-                    killMsg += "\nMake sure that your destination site is healthy and"
-                    killMsg += "\nthat you have enough free disk space there"
-                    killMsg += " before submitting again"
-                    self.killThisTask(killMsg)
-                    self.logger.info("Tag Jobs as ForcefullyTerminated")
-                    self.tagAllJobsInTask(ad='CRAB_ForcefullyTerminated', value='ASO')
-                    retmsg += '\ntoo Many Fatal ASO errors. Abort task DAG'
-                    if self.maxFatalAsoNotificationMail:
-                        self.sendMaxFatalAsoMailToOperators()
-                    self.set_state_ClassAds('FAILED', exitCode=ASOExitCode)
-                    return JOB_RETURN_CODES.DAG_ABORT, retmsg, ASOExitCode
+                    self.logger.error("**** Too Many Fatal ASO errors. ****")
+                    with getLock('actOnTooManyASOErrors'):
+                        if self.maxFatalAsoDryRun:
+                            self.logger.error("**** If dry run were False, I would abort DAG and kill task ****")
+                            # send msg to operators (only once per task) and go on normally
+                            if self.maxFatalAsoNotificationMail and not self.maxFatalAsoMailAlreadySent():
+                                self.sendMaxFatalAsoMailToOperators()
+                            self.logger.info("Tag Jobs as ForcefullyTerminated")
+                            self.tagAllJobsInTask(ad='CRAB_ForcefullyTerminated', value='DryASO')
+                        else:
+                            # abort DAG, kill task and tag jobs
+                            self.logger.error("**** Abort DAG and kill task ****")
+                            retMsg += '\ntoo Many Fatal ASO errors. Abort task DAG'
+                            retCode = JOB_RETURN_CODES.DAG_ABORT
+                            self.logger.info("Tag Jobs as ForcefullyTerminated")
+                            self.tagAllJobsInTask(ad='CRAB_ForcefullyTerminated', value='ASO')
+                            killMsg = "Killed by CRAB because output can't be placed at destination site."
+                            killMsg += "\nMake sure that your destination site is healthy and"
+                            killMsg += "\nthat you have enough free disk space there"
+                            killMsg += " before submitting again"
+                            self.killThisTask(killMsg)
+                            if self.maxFatalAsoNotificationMail:
+                                self.sendMaxFatalAsoMailToOperators()
+                # next line also sets classAd LeaveJobInQueue to False. No more classAd editing after that
                 self.set_state_ClassAds('FAILED', exitCode=ASOExitCode)
-                return JOB_RETURN_CODES.FATAL_ERROR, retmsg, ASOExitCode
+                return retCode, retMsg, ASOExitCode
             except RecoverableStageoutError as rse:
-                retmsg = "Got recoverable stageout exception:\n%s" % (str(rse))
-                self.logger.error(retmsg)
+                retMsg = "Got recoverable stageout exception:\n%s" % (str(rse))
+                self.logger.error(retMsg)
                 msg = "These are all recoverable stageout errors; automatic resubmit is possible."
                 exitCode = mostCommon(self.stageout_exit_codes, 60324)
+                ASOExitCode = mostCommon(self.stageout_exit_codes, 60324)
                 self.logger.error(msg)
                 self.logger.info("====== Finished to check for ASO transfers.")
-                return self.check_retry_count(exitCode=exitCode), retmsg, ASOExitCode
+                return self.check_retry_count(exitCode=exitCode), retMsg, ASOExitCode
             except Exception as ex:
-                retmsg = "Fatal PostJob error during ASO checking: %s" % (str(ex))
-                self.logger.exception(retmsg)
+                retMsg = "Fatal PostJob error during ASO checking: %s" % (str(ex))
+                self.logger.exception(retMsg)
                 raise
             finally:
                 # update job exit code to represent ASO error
@@ -2640,9 +2642,9 @@ class PostJob():
                 try:
                     self.crabserver.post(api="filetransfers", data=encodeRequest(newDoc))
                 except Exception as ex:  # pylint: disable=broad-except
-                    retmsg = "Fatal error updating publication flags of transfered files: %s" % (str(ex))
-                    self.logger.exception(retmsg)
-                    raise Exception(retmsg) from ex  # pylint: disable=broad-exception-raised
+                    retMsg = "Fatal error updating publication flags of transfered files: %s" % (str(ex))
+                    self.logger.exception(retMsg)
+                    raise Exception(retMsg) from ex  # pylint: disable=broad-exception-raised
         self.logger.info("====== Finished to update publication flags of transfered files.")
 
     # = = = = = PostJob = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =


### PR DESCRIPTION
this will hopefully close the "too many ASO error" saga.

Code to deal with those should hopefully be a template for the implementation of #9402 hopefully leading to a common, cleaner, leaner solution.

I tried to be general already e.g. CRAB_ForcefullyTerminated allows for more reasons besides "ASO", same for `tagAllJobsInTask()` and `killThisTask()`.

There may be some un-needed lock files now as well.
